### PR TITLE
Add PathParser

### DIFF
--- a/lib/beacon/path_parser.ex
+++ b/lib/beacon/path_parser.ex
@@ -1,0 +1,11 @@
+defmodule Beacon.PathParser do
+  @behaviour Beacon.PathParser.Behaviour
+
+  def parse(site, path, params) do
+    get_path_parser().parse(site, path, params)
+  end
+
+  def get_path_parser do
+    Application.get_env(:beacon, :path_parser, Beacon.PathParser.Impl)
+  end
+end

--- a/lib/beacon/path_parser/behaviour.ex
+++ b/lib/beacon/path_parser/behaviour.ex
@@ -1,0 +1,3 @@
+defmodule Beacon.PathParser.Behaviour do
+  @callback parse(site :: String.t(), path :: String.t(), params :: map()) :: {String.t(), map()}
+end

--- a/lib/beacon/path_parser/impl.ex
+++ b/lib/beacon/path_parser/impl.ex
@@ -1,0 +1,5 @@
+defmodule Beacon.PathParser.Impl do
+  @behaviour Beacon.PathParser.Behaviour
+
+  def parse(_site, path, _params), do: {path, %{}}
+end

--- a/lib/beacon_web/live/page_live.ex
+++ b/lib/beacon_web/live/page_live.ex
@@ -4,7 +4,9 @@ defmodule BeaconWeb.PageLive do
   require Logger
 
   def mount(%{"path" => path} = params, %{"beacon_site" => site}, socket) do
-    live_data = Beacon.DataSource.live_data(site, path, Map.drop(params, ["path"]))
+    new_params = Map.drop(params, ["path"])
+    {path, path_params} = Beacon.PathParser.parse(site, path, new_params)
+    live_data = Beacon.DataSource.live_data(site, path, Map.put(new_params, "path_params", path_params))
 
     layout_id =
       site


### PR DESCRIPTION
This PR adds one of the options I came up to support dynamic segments in paths.

## How does this work (user land)?

The user defines a PathParser. It receives the same arguments as `DataSource.live_data/3` but it returns `{path, %{"segment_name" => value}}`. The second element of the tuple, is merged into params under `"path_params"`. Example:

```ex
defmodule MyApp.PathParser do
  def parse(_site, "blog", _params), do: {"blog", %{}}
  def parse(_site, "blog/authors", _params), do: {"blog/authors", %{}}
  def parse(_site, "blog/posts", _params), do: {"blog/posts", %{}}
  def parse(_site, "blog/authors/" <> author, _params), do: {"blog/authors", %{author: author}}
  def parse(_site, "blog/posts/" <> post, _params), do: {"blog/authors", %{post: post}}
end

defmodule MyApp.DataSource do
  def live_data(_site, "blog/authors", %{"path_params" => %{author: author}}=params) do
	%{author: Authors.get_by_slug(author)}
  end
  def live_data(_site, "blog/authors", _params) do
    %{authors: Authors.list_all()}
  end
end
```

## Other options

The other design (which I do like more but is not backwards compatible) is for `parse` to return `{String.t(), [String.t()]}`. In that case, the `DataSource` would look like:

```ex
defmodule MyApp.DataSource do
  def live_data(_site, {"blog/authors", [author]}, _params) do
	%{author: Authors.get_by_slug(author)}
  end

  def live_data(_site, {"blog/authors", _}, _params) do
    %{authors: Authors.list_all()}
  end
end
```

Which I think it looks better because it keeps the variable segments together with the page (which is actually a path).