### PR TITLE
Add ability to render nested components.

### DIFF
--- a/lib/beacon/loader/component_module_loader.ex
+++ b/lib/beacon/loader/component_module_loader.ex
@@ -23,6 +23,7 @@ defmodule Beacon.Loader.ComponentModuleLoader do
       alias BeaconWeb.Router.Helpers, as: Routes
 
     #{Enum.join(render_functions, "\n")}
+      def my_component(name, assigns), do: Components.render(name, Enum.into(assigns, %{}))
     end
     """
   end


### PR DESCRIPTION
Currently, we cannot render nested components because there is no `my_component` helper in Components