### PR TITLE
Fix seeds.exs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@ Steps to build a Phoenix umbrella project that uses Beacon:
     alias Beacon.Layouts
     alias Beacon.Stylesheets
 
+    Stylesheets.create_stylesheet!(%{
+      site: "my_site",
+      name: "sample_stylesheet",
+      content: "body {cursor: zoom-in;}"
+    })
+
+    Components.create_component!(%{
+      site: "my_site",
+      name: "sample_component",
+      body: """
+      <li>
+        <%= @val %>
+      </li>
+      """
+    })
+
     %{id: layout_id} =
       Layouts.create_layout!(%{
         site: "my_site",
@@ -131,22 +147,6 @@ Steps to build a Phoenix umbrella project that uses Beacon:
         </ul>
       </main>
       """
-    })
-
-    Components.create_component!(%{
-      site: "my_site",
-      name: "sample_component",
-      body: """
-      <li>
-        <%= @val %>
-      </li>
-      """
-    })
-
-    Stylesheets.create_stylesheet!(%{
-      site: "my_site",
-      name: "sample_stylesheet",
-      content: "body {cursor: zoom-in;}"
     })
     ```
 


### PR DESCRIPTION
The project readme step "Add some seeds to your seeds.exs" causes an error when running `mix ecto.reset` as suggested:

```
** (CompileError) nofile:4: module BeaconWeb.LiveRenderer.Component6A217F0F7032720EB50A1A2FBF258463 is not loaded and could not be found
    (elixir 1.13.4) lib/code.ex:1392: Code.compile_string/2
    (beacon 0.1.0) lib/beacon/loader/module_loader.ex:6: Beacon.Loader.ModuleLoader.load/2
    (beacon 0.1.0) lib/beacon/loader/layout_module_loader.ex:18: Beacon.Loader.LayoutModuleLoader.load_layouts/2
    (beacon 0.1.0) lib/beacon/loader/db_loader.ex:32: anonymous fn/1 in Beacon.Loader.DBLoader.load_layouts/0
    (elixir 1.13.4) lib/enum.ex:942: anonymous fn/3 in Enum.each/2
    (stdlib 4.0) maps.erl:411: :maps.fold_1/3
    (elixir 1.13.4) lib/enum.ex:2408: Enum.each/2
    (beacon 0.1.0) lib/beacon/loader/db_loader.ex:31: Beacon.Loader.DBLoader.load_layouts/0
```

This is because `sample_component`, which is referenced by the example page, hasn't yet been created when `Beacon.Pages.create_page!/1` is called in this code sample. Reordering the function calls in `seeds.exs` allows the seed data to be created as expected.