### PR TITLE
Fix runtime warnings from my_component

### DIFF
--- a/lib/beacon/loader/layout_module_loader.ex
+++ b/lib/beacon/loader/layout_module_loader.ex
@@ -7,12 +7,7 @@ defmodule Beacon.Loader.LayoutModuleLoader do
   def load_layouts(site, layouts) do
     component_module = Beacon.Loader.component_module_for_site(site)
     module = Beacon.Loader.layout_module_for_site(site)
-
-    render_functions =
-      Enum.map(layouts, fn layout ->
-        render_layout(layout)
-      end)
-
+    render_functions = Enum.map(layouts, &render_layout/1)
     code_string = render(module, render_functions, component_module)
     Logger.debug("Loading layout: \n#{code_string}")
     :ok = ModuleLoader.load(module, code_string)
@@ -24,7 +19,7 @@ defmodule Beacon.Loader.LayoutModuleLoader do
     defmodule #{module_name} do
       use Phoenix.HTML
       import Phoenix.LiveView.Helpers
-      import #{component_module}, only: [my_component: 2]
+      #{ModuleLoader.import_my_component(component_module, render_functions)}
 
     #{Enum.join(render_functions, "\n")}
     end

--- a/lib/beacon/loader/module_loader.ex
+++ b/lib/beacon/loader/module_loader.ex
@@ -7,4 +7,12 @@ defmodule Beacon.Loader.ModuleLoader do
     {:module, ^module} = Code.ensure_loaded(module)
     :ok
   end
+
+  def import_my_component(component_module, functions) do
+    if Enum.any?(functions, &String.match?(&1, ~r/my_component/)) do
+      "import #{component_module}, only: [my_component: 2]"
+    else
+      ""
+    end
+  end
 end

--- a/lib/beacon/loader/page_module_loader.ex
+++ b/lib/beacon/loader/page_module_loader.ex
@@ -25,7 +25,7 @@ defmodule Beacon.Loader.PageModuleLoader do
     """
     defmodule #{module_name} do
       import Phoenix.LiveView.Helpers
-      import #{component_module}, only: [my_component: 2]
+      #{ModuleLoader.import_my_component(component_module, functions)}
       use Phoenix.HTML
 
       #{Enum.join(functions, "\n")}


### PR DESCRIPTION
This will first check if my_component is used before importing in order
to avoid runtime warnings.