### PR TITLE
Rename __live_data__

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.13.2-otp-24
+erlang 24.3.4

--- a/lib/beacon_web/live/page_live.ex
+++ b/lib/beacon_web/live/page_live.ex
@@ -13,8 +13,8 @@ defmodule BeaconWeb.PageLive do
 
     socket =
       socket
+      |> assign(:beacon_live_data, live_data)
       |> assign(:__live_path__, path)
-      |> assign(:__live_data__, live_data)
       |> assign(:__page_update_available__, false)
       |> assign(:__dynamic_layout_id__, layout_id)
       |> assign(:__site__, site)
@@ -30,11 +30,11 @@ defmodule BeaconWeb.PageLive do
   end
 
   def render(assigns) do
-    {%{__live_path__: live_path, __live_data__: live_data}, render_assigns} = Map.split(assigns, [:__live_path__, :__live_data__])
+    {%{__live_path__: live_path}, render_assigns} = Map.split(assigns, [:__live_path__])
 
     module = Beacon.Loader.page_module_for_site(assigns.__site__)
 
-    Beacon.Loader.call_function_with_retry(module, :render, [live_path, live_data, render_assigns])
+    Beacon.Loader.call_function_with_retry(module, :render, [live_path, render_assigns])
   end
 
   def handle_info(:page_updated, socket) do


### PR DESCRIPTION
- Add `.tool-versions` for the fellow asdf nerds
- Rename `__live_data__` assign to `beacon_live_data` so that it is consistent for layout templates to access
- Group generated function heads together to heed off compiler warnings