### PR TITLE
Add events to pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,21 +118,26 @@ Steps to build a Phoenix umbrella project that uses Beacon:
         """
       })
 
-    Pages.create_page!(%{
-      path: "home",
-      site: "my_site",
-      layout_id: layout_id,
-      template: """
-      <main>
-        <h2>Some Values:</h2>
-        <ul>
-          <%= for val <- @beacon_live_data[:vals] do %>
-            <%= my_component("sample_component", val: val) %>
-          <% end %>
-        </ul>
-      </main>
-      """
-    })
+    %{id: page_id} =
+      Pages.create_page!(%{
+        path: "home",
+        site: "my_site",
+        layout_id: layout_id,
+        template: """
+        <main>
+          <h2>Some Values:</h2>
+          <ul>
+            <%= for val <- @beacon_live_data[:vals] do %>
+              <%= my_component("sample_component", val: val) %>
+            <% end %>
+          </ul>
+          <.form let={f} for={:greeting} phx-submit="hello">
+            Name: <%= text_input f, :name %> <%= submit "Hello" %>
+          </.form>
+          <%= if assigns[:message], do: assigns.message %>
+        </main>
+        """
+      })
 
     Pages.create_page!(%{
       path: "blog/:blog_slug",
@@ -148,6 +153,15 @@ Steps to build a Phoenix umbrella project that uses Beacon:
       </main>
       """
     })
+
+    Pages.create_page_event!(%{
+      page_id: page_id,
+      event_name: "hello",
+      code: """
+        {:noreply, Phoenix.LiveView.assign(socket, :message, "Hello \#{event_params["greeting"]["name"]}!")}
+      """
+    })
+
     ```
 
 12. `cd apps/my_app && mix ecto.reset && cd ../..`

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,8 @@ import Config
 
 config :beacon, ecto_repos: [Beacon.Repo]
 
+config :beacon, :generators, binary_id: true
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"

--- a/lib/beacon/loader/component_module_loader.ex
+++ b/lib/beacon/loader/component_module_loader.ex
@@ -29,7 +29,7 @@ defmodule Beacon.Loader.ComponentModuleLoader do
   end
 
   defp render_component(%Component{name: name, body: body}) do
-    if !Application.get_env(:beacon, :disable_safe_code, false) do
+    if !Application.get_env(:beacon, :disable_safe_code, true) do
       SafeCode.Validator.validate_heex!(body, extra_function_validators: Beacon.Loader.SafeCodeImpl)
     end
 

--- a/lib/beacon/loader/db_loader.ex
+++ b/lib/beacon/loader/db_loader.ex
@@ -36,7 +36,7 @@ defmodule Beacon.Loader.DBLoader do
   end
 
   def load_pages do
-    Pages.list_pages()
+    Pages.list_pages([:events])
     |> Enum.group_by(& &1.site, & &1)
     |> Enum.each(fn {site, pages} ->
       {:ok, _} = PageModuleLoader.load_templates(site, pages)

--- a/lib/beacon/loader/layout_module_loader.ex
+++ b/lib/beacon/loader/layout_module_loader.ex
@@ -27,7 +27,7 @@ defmodule Beacon.Loader.LayoutModuleLoader do
   end
 
   defp render_layout(%Layout{} = layout) do
-    if !Application.get_env(:beacon, :disable_safe_code, false) do
+    if !Application.get_env(:beacon, :disable_safe_code, true) do
       SafeCode.Validator.validate_heex!(layout.body, extra_function_validators: Beacon.Loader.SafeCodeImpl)
     end
 

--- a/lib/beacon/loader/page_module_loader.ex
+++ b/lib/beacon/loader/page_module_loader.ex
@@ -64,7 +64,7 @@ defmodule Beacon.Loader.PageModuleLoader do
       end
 
       """
-        def handle_event(#{path_to_args(path, "")}, #{event.event_name}, event_params, socket) do
+        def handle_event(#{path_to_args(path, "")}, "#{event.event_name}", event_params, socket) do
           #{event.code}
         end
       """

--- a/lib/beacon/pages.ex
+++ b/lib/beacon/pages.ex
@@ -295,9 +295,17 @@ defmodule Beacon.Pages do
 
   """
   def create_page_event(attrs \\ %{}) do
-    %PageEvent{}
-    |> PageEvent.changeset(attrs)
+    attrs
+    |> PageEvent.changeset()
     |> Repo.insert()
+    |> case do
+      {:ok, page_event} ->
+        Beacon.Loader.DBLoader.load_from_db()
+        {:ok, page_event}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
   @doc """

--- a/lib/beacon/pages.ex
+++ b/lib/beacon/pages.ex
@@ -300,6 +300,9 @@ defmodule Beacon.Pages do
     |> Repo.insert()
   end
 
+  @doc """
+  Same as create_page_event/1 but raises when there are validation errors.
+  """
   def create_page_event!(attrs \\ %{}) do
     case create_page_event(attrs) do
       {:ok, page_event} -> page_event

--- a/lib/beacon/pages.ex
+++ b/lib/beacon/pages.ex
@@ -7,6 +7,7 @@ defmodule Beacon.Pages do
   alias Beacon.Repo
 
   alias Beacon.Pages.Page
+  alias Beacon.Pages.PageEvent
   alias Beacon.Pages.PageVersion
 
   @doc """
@@ -250,5 +251,106 @@ defmodule Beacon.Pages do
   """
   def change_page_version(%PageVersion{} = page_version, attrs \\ %{}) do
     PageVersion.changeset(page_version, attrs)
+  end
+
+  @doc """
+  Returns the list of beacon_page_events.
+
+  ## Examples
+
+      iex> list_beacon_page_events()
+      [%PageEvent{}, ...]
+
+  """
+  def list_beacon_page_events do
+    Repo.all(PageEvent)
+  end
+
+  @doc """
+  Gets a single page_event.
+
+  Raises `Ecto.NoResultsError` if the Page event does not exist.
+
+  ## Examples
+
+      iex> get_page_event!(123)
+      %PageEvent{}
+
+      iex> get_page_event!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_page_event!(id), do: Repo.get!(PageEvent, id)
+
+  @doc """
+  Creates a page_event.
+
+  ## Examples
+
+      iex> create_page_event(%{field: value})
+      {:ok, %PageEvent{}}
+
+      iex> create_page_event(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_page_event(attrs \\ %{}) do
+    %PageEvent{}
+    |> PageEvent.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def create_page_event!(attrs \\ %{}) do
+    case create_page_event(attrs) do
+      {:ok, page_event} -> page_event
+      {:error, changeset} -> raise "Failed to create page_event #{inspect(changeset.errors)} "
+    end
+  end
+
+  @doc """
+  Updates a page_event.
+
+  ## Examples
+
+      iex> update_page_event(page_event, %{field: new_value})
+      {:ok, %PageEvent{}}
+
+      iex> update_page_event(page_event, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_page_event(%PageEvent{} = page_event, attrs) do
+    page_event
+    |> PageEvent.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a page_event.
+
+  ## Examples
+
+      iex> delete_page_event(page_event)
+      {:ok, %PageEvent{}}
+
+      iex> delete_page_event(page_event)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_page_event(%PageEvent{} = page_event) do
+    Repo.delete(page_event)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking page_event changes.
+
+  ## Examples
+
+      iex> change_page_event(page_event)
+      %Ecto.Changeset{data: %PageEvent{}}
+
+  """
+  def change_page_event(%PageEvent{} = page_event, attrs \\ %{}) do
+    PageEvent.changeset(page_event, attrs)
   end
 end

--- a/lib/beacon/pages/page.ex
+++ b/lib/beacon/pages/page.ex
@@ -4,6 +4,7 @@ defmodule Beacon.Pages.Page do
 
   alias Beacon.Layouts.Layout
   alias Beacon.Pages.Page
+  alias Beacon.Pages.PageEvent
   alias Beacon.Pages.PageVersion
   alias Ecto.Changeset
 
@@ -20,6 +21,7 @@ defmodule Beacon.Pages.Page do
     belongs_to(:layout, Layout)
     belongs_to(:pending_layout, Layout)
 
+    has_many(:events, PageEvent)
     has_many(:versions, PageVersion)
 
     timestamps()

--- a/lib/beacon/pages/page_event.ex
+++ b/lib/beacon/pages/page_event.ex
@@ -2,6 +2,8 @@ defmodule Beacon.Pages.PageEvent do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Beacon.Pages.PageEvent
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "beacon_page_events" do
@@ -14,7 +16,7 @@ defmodule Beacon.Pages.PageEvent do
   end
 
   @doc false
-  def changeset(page_event, attrs) do
+  def changeset(page_event \\ %PageEvent{}, attrs) do
     page_event
     |> cast(attrs, [:code, :order, :event_name, :page_id])
     |> validate_required([:code, :order, :event_name, :page_id])

--- a/lib/beacon/pages/page_event.ex
+++ b/lib/beacon/pages/page_event.ex
@@ -1,0 +1,22 @@
+defmodule Beacon.Pages.PageEvent do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "beacon_page_events" do
+    field :code, :string
+    field :event_name, :string
+    field :order, :integer, default: 1
+    field :page_id, :binary_id
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(page_event, attrs) do
+    page_event
+    |> cast(attrs, [:code, :order, :event_name, :page_id])
+    |> validate_required([:code, :order, :event_name, :page_id])
+  end
+end

--- a/lib/beacon_web/live/page_live.ex
+++ b/lib/beacon_web/live/page_live.ex
@@ -40,4 +40,17 @@ defmodule BeaconWeb.PageLive do
   def handle_info(:page_updated, socket) do
     {:noreply, assign(socket, :__page_update_available__, true)}
   end
+
+  def handle_event(event_name, event_params, socket) do
+    socket.assigns.__site__
+    |> Beacon.Loader.page_module_for_site()
+    |> Beacon.Loader.call_function_with_retry(:handle_event, [socket.assigns.__live_path__, event_name, event_params, socket])
+    |> case do
+      {:noreply, %Phoenix.LiveView.Socket{} = socket} ->
+        {:noreply, socket}
+
+      other ->
+        raise "handle_event for #{socket.assigns.__live_path__} expected return of {:noreply, %Phoenix.LiveView.Socket{}}, but got #{inspect(other)}"
+    end
+  end
 end

--- a/priv/repo/migrations/20220823185841_create_beacon_page_events.exs
+++ b/priv/repo/migrations/20220823185841_create_beacon_page_events.exs
@@ -1,0 +1,17 @@
+defmodule Beacon.Repo.Migrations.CreateBeaconPageEvents do
+  use Ecto.Migration
+
+  def change do
+    create table(:beacon_page_events, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :code, :text
+      add :order, :integer
+      add :event_name, :text
+      add :page_id, references(:beacon_pages, on_delete: :nothing, type: :binary_id)
+
+      timestamps()
+    end
+
+    create index(:beacon_page_events, [:page_id])
+  end
+end

--- a/priv/repo/migrations/20220823185841_create_beacon_page_events.exs
+++ b/priv/repo/migrations/20220823185841_create_beacon_page_events.exs
@@ -4,9 +4,9 @@ defmodule Beacon.Repo.Migrations.CreateBeaconPageEvents do
   def change do
     create table(:beacon_page_events, primary_key: false) do
       add :id, :binary_id, primary_key: true
-      add :code, :text
-      add :order, :integer
-      add :event_name, :text
+      add :code, :text, null: false
+      add :order, :integer, null: false
+      add :event_name, :text, null: false
       add :page_id, references(:beacon_pages, on_delete: :nothing, type: :binary_id)
 
       timestamps()


### PR DESCRIPTION
Fixes #19.

This PR adds the concept of a `PageEvent`. Pages can have events, which for now define an event name and code. The code will have `event_params` and the `socket` in scope, and should return `{:noreply, socket}`.

See the seed in the README file walkthrough for an example.

Additional changes:
Safe Code is now disabled by default. Will re-enable once we have time to work on improving the SafeCode interaction.
Fix edge case with call_function_with_retry error handling.