### PR TITLE
Add cancel links to page manager forms

### DIFF
--- a/lib/beacon_web/live/page_management/page_live/form_component.html.heex
+++ b/lib/beacon_web/live/page_management/page_live/form_component.html.heex
@@ -27,7 +27,7 @@
 
     <div>
       <%= submit "Save", phx_disable_with: "Saving..." %>
-      <%= live_patch "Cancel", to: "../pages" %>
+      <%= live_redirect "Cancel", to: "../pages" %>
     </div>
   </.form>
 </div>

--- a/lib/beacon_web/live/page_management/page_live/form_component.html.heex
+++ b/lib/beacon_web/live/page_management/page_live/form_component.html.heex
@@ -27,6 +27,7 @@
 
     <div>
       <%= submit "Save", phx_disable_with: "Saving..." %>
+      <%= live_patch "Cancel", to: "../pages" %>
     </div>
   </.form>
 </div>

--- a/lib/beacon_web/live/page_management/page_live/index.html.heex
+++ b/lib/beacon_web/live/page_management/page_live/index.html.heex
@@ -31,7 +31,7 @@ Last reload time: <%= @last_reload_time %>ms
         <td><%= page.template %></td>
 
         <td>
-          <span><%= live_patch "Edit", to: "page_editor/#{page.id}" %></span>
+          <span><%= live_redirect "Edit", to: "page_editor/#{page.id}" %></span>
           <span><%= link "Delete", to: "#", phx_click: "delete", phx_value_id: page.id, data: [confirm: "Are you sure?"] %></span>
         </td>
       </tr>

--- a/lib/beacon_web/live/page_management/page_live/page_editor_live.html.heex
+++ b/lib/beacon_web/live/page_management/page_live/page_editor_live.html.heex
@@ -31,7 +31,7 @@
           <%= checkbox :opts, :publish, value: false %> Publish on Save
           <div>
             <%= submit "Save", phx_disable_with: "Saving..." %>
-            <%= live_patch "Cancel", to: "../pages" %>
+            <%= live_redirect "Cancel", to: "../pages" %>
           </div>
         </.form>
       </td>

--- a/lib/beacon_web/live/page_management/page_live/page_editor_live.html.heex
+++ b/lib/beacon_web/live/page_management/page_live/page_editor_live.html.heex
@@ -31,6 +31,7 @@
           <%= checkbox :opts, :publish, value: false %> Publish on Save
           <div>
             <%= submit "Save", phx_disable_with: "Saving..." %>
+            <%= live_patch "Cancel", to: "../pages" %>
           </div>
         </.form>
       </td>


### PR DESCRIPTION
Shouldn't need to use "back" buttons