### PR TITLE
Remove .tools-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-elixir 1.14.1-otp-24
-erlang 24.3.4


### PR DESCRIPTION
This file isn't really necessary and it gets in the way when trying out different versions of Elixir/OTP