### PR TITLE
Introduce `live_admin_path` to generate router paths on Admin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ First clone this repository:
 git clone git@github.com:BeaconCMS/beacon.git
 ```
 
-And call setup to install deps:
+Call setup to install deps:
 
 ```sh
 mix setup
@@ -63,3 +63,11 @@ mix setup
 ```sh
 mix test
 ```
+
+## Running a local app
+
+```sh
+mix dev
+```
+
+Visit http://localhost:4000/dev/home or http://localhost:4000/admin/pages

--- a/README.md
+++ b/README.md
@@ -224,13 +224,13 @@ Beacon supports both.
     ```elixir
     import Beacon.Router
 
-    scope "/" do
+    scope "/beacon" do
       pipe_through :browser
-      beacon_admin "/beacon/page_management"
+      beacon_admin "/admin"
     end
     ```
 
-2. Visit <http://localhost:4000/beacon/page_management/pages>
+2. Visit <http://localhost:4000/beacon/admin>
 
 3. Edit the existing page or create a new page then click edit to go to the Page Editor (including version management)
 
@@ -243,7 +243,7 @@ Beacon supports both.
 
     scope "/api"
       pipe_through :api
-      beacon_api "/beacon/page_management"
+      beacon_api "/beacon"
     end
     ```
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,6 @@ Beacon supports both.
 `dev.exs` provides a phoenix app running beacon with with code reload enabled:
 
 ```shell
-mix deps.get
+mix setup
 mix dev
 ```

--- a/config/config.exs
+++ b/config/config.exs
@@ -9,29 +9,31 @@ config :phoenix, :json_library, Jason
 config :esbuild,
   version: "0.16.13",
   default: [
-    args: ~w(js/app.js --bundle --target=es2020 --outdir=../dist/js),
+    args: ~w(js/app.js --bundle --target=es2020 --outdir=../../dist/js),
     cd: Path.expand("../priv/assets", __DIR__),
     env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
   ]
 
+# Beacon Admin running in dev.exs
 config :tailwind,
   version: "3.2.4",
   admin_dev: [
     args: ~w(
       --config=tailwind.config.js
       --input=css/admin.css
-      --output=../dev/static/assets/admin.css
+      --output=../../dev/static/assets/admin.css
     ),
     cd: Path.expand("../priv/assets", __DIR__)
   ]
 
+# Beacon Admin running in host apps
 config :tailwind,
   version: "3.2.4",
   admin: [
     args: ~w(
       --config=tailwind.config.js
       --input=css/admin.css
-      --output=../dist/css/admin.css
+      --output=../../dist/css/admin.css
     ),
     cd: Path.expand("../priv/assets", __DIR__)
   ]

--- a/dev.exs
+++ b/dev.exs
@@ -59,14 +59,10 @@ defmodule SamplePhoenixWeb.Router do
     plug :put_secure_browser_headers
   end
 
-  scope "/admin" do
+  scope "/" do
     pipe_through :browser
-    beacon_admin "/"
-  end
-
-  scope "/dev" do
-    pipe_through :browser
-    beacon_site "/", name: "dev", data_source: BeaconDataSource
+    beacon_admin "/admin"
+    beacon_site "/dev", name: "dev", data_source: BeaconDataSource
   end
 end
 

--- a/lib/beacon/router.ex
+++ b/lib/beacon/router.ex
@@ -119,4 +119,17 @@ defmodule Beacon.Router do
       end
     end
   end
+
+  @doc """
+  Router helper to generate admin paths.
+
+  Prefix is added automatically based on the current router scope.
+  """
+  def beacon_admin_path(socket, path, params \\ %{}) do
+    prefix = socket.router.__beacon_admin_prefix__()
+    path = String.replace("#{prefix}/#{path}", "//", "/")
+    params = for {key, val} <- params, do: {key, val}
+
+    Phoenix.VerifiedRoutes.unverified_path(socket, socket.router, path, params)
+  end
 end

--- a/lib/beacon/router.ex
+++ b/lib/beacon/router.ex
@@ -94,6 +94,9 @@ defmodule Beacon.Router do
           live "/page_editor/:id", PageEditorLive, :edit
         end
       end
+
+      @beacon_admin_prefix Phoenix.Router.scoped_path(__MODULE__, path)
+      def __beacon_admin_prefix__, do: @beacon_admin_prefix
     end
   end
 

--- a/lib/beacon_web/beacon_web.ex
+++ b/lib/beacon_web/beacon_web.ex
@@ -34,6 +34,8 @@ defmodule BeaconWeb do
       use Phoenix.LiveView,
         layout: {BeaconWeb.Layouts, :app}
 
+      import BeaconWeb.Layouts, only: [live_admin_path: 2, live_admin_path: 3]
+
       unquote(html_helpers())
     end
   end

--- a/lib/beacon_web/beacon_web.ex
+++ b/lib/beacon_web/beacon_web.ex
@@ -34,7 +34,7 @@ defmodule BeaconWeb do
       use Phoenix.LiveView,
         layout: {BeaconWeb.Layouts, :app}
 
-      import BeaconWeb.Layouts, only: [live_admin_path: 2, live_admin_path: 3]
+      import Beacon.Router, only: [beacon_admin_path: 2, beacon_admin_path: 3]
 
       unquote(html_helpers())
     end

--- a/lib/beacon_web/beacon_web.ex
+++ b/lib/beacon_web/beacon_web.ex
@@ -34,8 +34,6 @@ defmodule BeaconWeb do
       use Phoenix.LiveView,
         layout: {BeaconWeb.Layouts, :app}
 
-      import Beacon.Router, only: [beacon_admin_path: 2, beacon_admin_path: 3]
-
       unquote(html_helpers())
     end
   end
@@ -74,6 +72,9 @@ defmodule BeaconWeb do
 
       # Router helpers
       alias BeaconWeb.Router.Helpers, as: Routes
+
+      # Admin Router helper
+      import Beacon.Router, only: [beacon_admin_path: 2, beacon_admin_path: 3]
     end
   end
 

--- a/lib/beacon_web/components/layouts.ex
+++ b/lib/beacon_web/components/layouts.ex
@@ -158,17 +158,4 @@ defmodule BeaconWeb.Layouts do
     %{stylesheet_urls: compiled_linked_stylesheets} = compiled_layout_assigns(site, layout_id)
     compiled_linked_stylesheets
   end
-
-  @doc """
-  Router helper to generate admin paths.
-
-  Prefix is added automatically based on the current router scope.
-  """
-  def live_admin_path(socket, path, params \\ %{}) do
-    prefix = socket.router.__beacon_admin_prefix__()
-    path = String.replace("#{prefix}/#{path}", "//", "/")
-    params = for {key, val} <- params, do: {key, val}
-
-    Phoenix.VerifiedRoutes.unverified_path(socket, socket.router, path, params)
-  end
 end

--- a/lib/beacon_web/components/layouts.ex
+++ b/lib/beacon_web/components/layouts.ex
@@ -158,4 +158,17 @@ defmodule BeaconWeb.Layouts do
     %{stylesheet_urls: compiled_linked_stylesheets} = compiled_layout_assigns(site, layout_id)
     compiled_linked_stylesheets
   end
+
+  @doc """
+  Router helper to generate admin paths.
+
+  Prefix is added automatically based on the current router scope.
+  """
+  def live_admin_path(socket, path, params \\ %{}) do
+    prefix = socket.router.__beacon_admin_prefix__()
+    path = String.replace("#{prefix}/#{path}", "//", "/")
+    params = for {key, val} <- params, do: {key, val}
+
+    Phoenix.VerifiedRoutes.unverified_path(socket, socket.router, path, params)
+  end
 end

--- a/lib/beacon_web/live/page_management/page_live/index.html.heex
+++ b/lib/beacon_web/live/page_management/page_live/index.html.heex
@@ -2,7 +2,7 @@
   Listing Pages
   <:actions>
     <.button phx-click="reload_pages" class="ml-2">Reload Pages</.button>
-    <.link patch="pages/new">
+    <.link patch={live_admin_path(@socket, "/pages/new")}>
       <.button>New Page</.button>
     </.link>
   </:actions>
@@ -20,11 +20,11 @@
   <:col :let={page} label="Template"><pre><%= page.template %></pre></:col>
 
   <:action :let={page}>
-    <.link navigate={"/beacon/page_management/page_editor/#{page.id}"}>Edit</.link>
+    <.link navigate={live_admin_path(@socket, "/page_editor/#{page.id}")}>Edit</.link>
   </:action>
 </.table>
 
-<.modal :if={@live_action in [:new, :edit]} id="page-modal" show on_cancel={JS.navigate("/beacon/page_management/pages")}>
+<.modal :if={@live_action in [:new, :edit]} id="page-modal" show on_cancel={JS.navigate(live_admin_path(@socket, "/pages"))}>
   <.live_component
     module={BeaconWeb.PageManagement.PageLive.FormComponent}
     ,
@@ -32,6 +32,6 @@
     title={@page_title}
     action={@live_action}
     page={@page}
-    navigate="/beacon/page_management/pages"
+    navigate={live_admin_path(@socket, "/pages")}
   />
 </.modal>

--- a/lib/beacon_web/live/page_management/page_live/index.html.heex
+++ b/lib/beacon_web/live/page_management/page_live/index.html.heex
@@ -2,7 +2,7 @@
   Listing Pages
   <:actions>
     <.button phx-click="reload_pages" class="ml-2">Reload Pages</.button>
-    <.link patch={live_admin_path(@socket, "/pages/new")}>
+    <.link patch={beacon_admin_path(@socket, "/pages/new")}>
       <.button>New Page</.button>
     </.link>
   </:actions>
@@ -20,11 +20,11 @@
   <:col :let={page} label="Template"><pre><%= page.template %></pre></:col>
 
   <:action :let={page}>
-    <.link navigate={live_admin_path(@socket, "/page_editor/#{page.id}")}>Edit</.link>
+    <.link navigate={beacon_admin_path(@socket, "/page_editor/#{page.id}")}>Edit</.link>
   </:action>
 </.table>
 
-<.modal :if={@live_action in [:new, :edit]} id="page-modal" show on_cancel={JS.navigate(live_admin_path(@socket, "/pages"))}>
+<.modal :if={@live_action in [:new, :edit]} id="page-modal" show on_cancel={JS.navigate(beacon_admin_path(@socket, "/pages"))}>
   <.live_component
     module={BeaconWeb.PageManagement.PageLive.FormComponent}
     ,
@@ -32,6 +32,6 @@
     title={@page_title}
     action={@live_action}
     page={@page}
-    navigate={live_admin_path(@socket, "/pages")}
+    navigate={beacon_admin_path(@socket, "/pages")}
   />
 </.modal>

--- a/lib/beacon_web/live/page_management/page_live/page_editor_live.html.heex
+++ b/lib/beacon_web/live/page_management/page_live/page_editor_live.html.heex
@@ -2,7 +2,7 @@
   <.header>
     Edit Page
     <:actions>
-      <.link navigate={live_admin_path(@socket, "/pages")}>
+      <.link navigate={beacon_admin_path(@socket, "/pages")}>
         <.button>Pages</.button>
       </.link>
     </:actions>

--- a/lib/beacon_web/live/page_management/page_live/page_editor_live.html.heex
+++ b/lib/beacon_web/live/page_management/page_live/page_editor_live.html.heex
@@ -2,7 +2,7 @@
   <.header>
     Edit Page
     <:actions>
-      <.link navigate="/beacon/page_management/pages">
+      <.link navigate={live_admin_path(@socket, "/pages")}>
         <.button>Pages</.button>
       </.link>
     </:actions>

--- a/mix.exs
+++ b/mix.exs
@@ -70,11 +70,12 @@ defmodule Beacon.MixProject do
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
     [
-      setup: ["deps.get", "ecto.setup", "tailwind.install"],
+      setup: ["deps.get", "assets.setup", "assets.build", "ecto.setup"],
       "ecto.setup": ["ecto.create", "ecto.migrate"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       dev: "run --no-halt dev.exs",
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
+      "assets.setup": ["tailwind.install --if-missing", "esbuild.install --if-missing"],
       "assets.build": ["esbuild default --minify", "tailwind admin --minify"]
     ]
   end

--- a/priv/assets/tailwind.config.js
+++ b/priv/assets/tailwind.config.js
@@ -8,8 +8,8 @@ let plugin = require('tailwindcss/plugin')
 module.exports = {
   content: [
     './js/**/*.js',
-    '../lib/*_web.ex',
-    '../lib/*_web/**/*.*ex'
+    '../../lib/*_web.ex',
+    '../../lib/*_web/**/*.*ex'
   ],
   theme: {
     extend: {},

--- a/priv/assets/tailwind.config.js.eex
+++ b/priv/assets/tailwind.config.js.eex
@@ -1,3 +1,5 @@
+// Tailwind config for Beacon Sites
+//
 // See the Tailwind configuration guide for advanced usage
 // https://tailwindcss.com/docs/configuration
 

--- a/test/beacon/router_test.exs
+++ b/test/beacon/router_test.exs
@@ -54,20 +54,20 @@ defmodule Beacon.RouterTest do
     use Phoenix.Endpoint, otp_app: :beacon
   end
 
-  test "live_admin_path" do
+  test "beacon_admin_path" do
     socket = %Phoenix.LiveView.Socket{endpoint: Endpoint, router: RouterSimple}
-    import BeaconWeb.Layouts, only: [live_admin_path: 2, live_admin_path: 3]
+    import Beacon.Router, only: [beacon_admin_path: 2, beacon_admin_path: 3]
     start_supervised!(Endpoint)
 
-    assert live_admin_path(socket, "/pages") == "/admin/pages"
-    assert live_admin_path(socket, :pages, %{foo: :bar}) == "/admin/pages?foo=bar"
+    assert beacon_admin_path(socket, "/pages") == "/admin/pages"
+    assert beacon_admin_path(socket, :pages, %{foo: :bar}) == "/admin/pages?foo=bar"
   end
 
-  test "live_admin_path nested" do
+  test "beacon_admin_path nested" do
     socket = %Phoenix.LiveView.Socket{endpoint: Endpoint, router: RouterNested}
-    import BeaconWeb.Layouts, only: [live_admin_path: 2]
+    import Beacon.Router, only: [beacon_admin_path: 2]
     start_supervised!(Endpoint)
 
-    assert live_admin_path(socket, "/pages") == "/outer/nested/admin/pages"
+    assert beacon_admin_path(socket, "/pages") == "/outer/nested/admin/pages"
   end
 end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -12,7 +12,7 @@ defmodule Beacon.BeaconTest.Router do
 
   scope "/" do
     pipe_through :browser
-    beacon_admin "/page_management"
+    beacon_admin "/admin"
     beacon_site "/", name: "my_site", data_source: Beacon.BeaconTest.BeaconDataSource
   end
 end


### PR DESCRIPTION
Allow users to run admin on custom path and close https://github.com/BeaconCMS/beacon/pull/33. This one is extracted from https://github.com/BeaconCMS/beacon/pull/86 to keep the Asset Manager PR smaller.

Also close #105 which is related.