### PR TITLE
Prefix layout meta tag fns with "layout_"

### DIFF
--- a/lib/beacon_web/components/layouts.ex
+++ b/lib/beacon_web/components/layouts.ex
@@ -114,16 +114,14 @@ defmodule BeaconWeb.Layouts do
     |> Beacon.Loader.call_function_with_retry(:page_assigns, [page_id])
   end
 
-  # layout-level meta tags -- rename?
-
-  def meta_tags(%{__dynamic_layout_id__: _, __dynamic_page_id__: _, __site__: _} = assigns) do
-    {:safe, meta_tags_unsafe(assigns)}
+  def layout_meta_tags(%{__dynamic_layout_id__: _, __dynamic_page_id__: _, __site__: _} = assigns) do
+    {:safe, layout_meta_tags_unsafe(assigns)}
   end
 
-  def meta_tags(_), do: ""
+  def layout_meta_tags(_), do: ""
 
-  def meta_tags_unsafe(assigns) do
-    meta_tags = get_meta_tags(assigns)
+  def layout_meta_tags_unsafe(assigns) do
+    meta_tags = layout_get_meta_tags(assigns)
 
     if meta_tags do
       Enum.map_join(meta_tags, "\n", fn {key, value} ->
@@ -134,17 +132,17 @@ defmodule BeaconWeb.Layouts do
     end
   end
 
-  def get_meta_tags(%{layout_assigns: %{meta_tags: meta_tags}} = assigns) do
+  def layout_get_meta_tags(%{layout_assigns: %{meta_tags: meta_tags}} = assigns) do
     assigns
-    |> compiled_meta_tags()
+    |> compiled_layout_meta_tags()
     |> Map.merge(meta_tags)
   end
 
-  def get_meta_tags(assigns) do
-    compiled_meta_tags(assigns)
+  def layout_get_meta_tags(assigns) do
+    compiled_layout_meta_tags(assigns)
   end
 
-  defp compiled_meta_tags(%{__dynamic_layout_id__: layout_id, __site__: site}) do
+  defp compiled_layout_meta_tags(%{__dynamic_layout_id__: layout_id, __site__: site}) do
     %{meta_tags: compiled_meta_tags} = compiled_layout_assigns(site, layout_id)
     compiled_meta_tags
   end

--- a/lib/beacon_web/components/layouts/runtime.html.heex
+++ b/lib/beacon_web/components/layouts/runtime.html.heex
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="csrf-token" content={get_csrf_token()} />
-    <%= meta_tags(assigns) %>
+    <%= layout_meta_tags(assigns) %>
     <%= page_meta_tags(assigns) %>
     <title><%= page_title(assigns) %></title>
     <%= linked_stylesheets(assigns) %>

--- a/lib/beacon_web/live/page_live.ex
+++ b/lib/beacon_web/live/page_live.ex
@@ -36,7 +36,7 @@ defmodule BeaconWeb.PageLive do
 
     socket =
       socket
-      |> push_event("meta", %{meta: BeaconWeb.Layouts.meta_tags_unsafe(socket.assigns)})
+      |> push_event("meta", %{meta: BeaconWeb.Layouts.layout_meta_tags_unsafe(socket.assigns)})
       |> push_event("lang", %{lang: "en"})
 
     Beacon.PubSub.subscribe_page_update(site, path)


### PR DESCRIPTION
Following on from adding page meta tags, I renamed the layout meta tags functions from e.g. `meta_tags` to `layout_meta_tags`. Think I got everything, let me know if I missed something.