### PR TITLE
Feature/custom liveview socket path

### DIFF
--- a/lib/beacon_web/components/layouts.ex
+++ b/lib/beacon_web/components/layouts.ex
@@ -26,6 +26,10 @@ defmodule BeaconWeb.Layouts do
   #{File.read!(phoenix_live_view_path) |> String.replace("//# sourceMappingURL=", "// ")}
   #{File.read!(beacon_js_path)}
   """
+  def render("app.js", %{conn: %{private: %{beacon: %{live_socket_path: live_socket_path}}}}) do
+    String.replace(@app_js, "/live", live_socket_path)
+  end
+
   def render("app.js", _assigns) do
     @app_js
   end

--- a/lib/beacon_web/components/layouts.ex
+++ b/lib/beacon_web/components/layouts.ex
@@ -26,8 +26,8 @@ defmodule BeaconWeb.Layouts do
   #{File.read!(phoenix_live_view_path) |> String.replace("//# sourceMappingURL=", "// ")}
   #{File.read!(beacon_js_path)}
   """
-  def render("app.js", %{conn: %{private: %{beacon: %{live_socket_path: live_socket_path}}}}) do
-    String.replace(@app_js, "/live", live_socket_path)
+  def live_socket_path(conn) do
+    conn.private.beacon.live_socket_path
   end
 
   def render("app.js", _assigns) do

--- a/lib/beacon_web/components/layouts/runtime.html.heex
+++ b/lib/beacon_web/components/layouts/runtime.html.heex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" phx-socket={live_socket_path(@conn)}>
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/test/beacon_web/live/page_live_test.exs
+++ b/test/beacon_web/live/page_live_test.exs
@@ -111,7 +111,7 @@ defmodule BeaconWeb.Live.PageLiveTest do
     test "routes to custom live path", %{conn: conn} do
       {:ok, _view, html} = live(conn, "/home")
 
-      assert html =~ "||\"/custom_live\""
+      assert html =~ ~s(phx-socket="/custom_live")
     end
   end
 end

--- a/test/beacon_web/live/page_live_test.exs
+++ b/test/beacon_web/live/page_live_test.exs
@@ -107,5 +107,11 @@ defmodule BeaconWeb.Live.PageLiveTest do
         {:ok, _view, _html} = live(conn, "/no_page_match")
       end
     end
+
+    test "routes to custom live path", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/home")
+
+      assert html =~ "||\"/custom_live\""
+    end
   end
 end

--- a/test/support/endpoint.ex
+++ b/test/support/endpoint.ex
@@ -8,6 +8,8 @@ defmodule Beacon.BeaconTest.Endpoint do
 
   socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]
 
+  socket "/custom_live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]
+
   plug Plug.Session, store: :cookie, key: "_beacon_app_key", signing_salt: "5Ude+fet"
 
   plug Beacon.BeaconTest.Router

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -13,6 +13,6 @@ defmodule Beacon.BeaconTest.Router do
   scope "/" do
     pipe_through :browser
     beacon_admin "/admin"
-    beacon_site "/", name: "my_site", data_source: Beacon.BeaconTest.BeaconDataSource
+    beacon_site "/", name: "my_site", data_source: Beacon.BeaconTest.BeaconDataSource, live_socket_path: "/custom_live"
   end
 end


### PR DESCRIPTION
Resolves https://github.com/BeaconCMS/beacon/issues/106

It replaces the default "/live" path using the option `live_socket_path` from `beacon_site` macro.