### PR TITLE
Inject beacon seeds into ecto.setup alias

### DIFF
--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -269,6 +269,12 @@ For more details please check out the docs: `mix help beacon.install`
     })
     ```
 
+6. Include new seeds in the `ecto.setup` alias in `mix.exs`:
+
+    ```elixir
+    "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs", "run priv/repo/beacon_seeds.exs"],
+    ```
+
 ## Setup database, seeds, and assets:
 
 Feel free to edit `priv/repo/beacon_seeds.exs` as you wish and run:


### PR DESCRIPTION
Updates the installation mix task so that beacon's seeds are run on `mix setup`.