### PR TITLE
Prevent tailwind-cli parser fail

### DIFF
--- a/lib/beacon/loader/component_module_loader.ex
+++ b/lib/beacon/loader/component_module_loader.ex
@@ -10,7 +10,6 @@ defmodule Beacon.Loader.ComponentModuleLoader do
     render_functions = Enum.map(components, &render_component/1)
 
     code_string = render(component_module, render_functions)
-    Logger.debug("Loading components: \n#{code_string}")
     :ok = ModuleLoader.load(component_module, code_string)
     {:ok, code_string}
   end

--- a/lib/beacon/loader/layout_module_loader.ex
+++ b/lib/beacon/loader/layout_module_loader.ex
@@ -10,7 +10,6 @@ defmodule Beacon.Loader.LayoutModuleLoader do
     module = Beacon.Loader.layout_module_for_site(site)
     render_functions = Enum.map(layouts, &render_layout/1)
     code_string = render(module, render_functions, component_module)
-    Logger.debug("Loading layout: \n#{code_string}")
     :ok = ModuleLoader.load(module, code_string)
     {:ok, code_string}
   end

--- a/lib/beacon/loader/page_module_loader.ex
+++ b/lib/beacon/loader/page_module_loader.ex
@@ -1,6 +1,4 @@
 defmodule Beacon.Loader.PageModuleLoader do
-  require Logger
-
   alias Beacon.Loader.ModuleLoader
   alias Beacon.Pages.Page
   alias Beacon.Pages.PageEvent
@@ -26,7 +24,6 @@ defmodule Beacon.Loader.PageModuleLoader do
 
     code_string = render(page_module, component_module, functions)
 
-    Logger.debug("Loading template: \n#{code_string}")
     :ok = ModuleLoader.load(page_module, code_string)
     {:ok, code_string}
   end

--- a/lib/beacon/loader/stylesheet_module_loader.ex
+++ b/lib/beacon/loader/stylesheet_module_loader.ex
@@ -8,7 +8,6 @@ defmodule Beacon.Loader.StylesheetModuleLoader do
     stylesheet_module = Beacon.Loader.stylesheet_module_for_site(site)
 
     code_string = render_module(stylesheet_module, stylesheets)
-    Logger.debug("Loading stylesheets: \n#{code_string}")
     :ok = ModuleLoader.load(stylesheet_module, code_string)
     {:ok, code_string}
   end

--- a/lib/beacon/pub_sub.ex
+++ b/lib/beacon/pub_sub.ex
@@ -12,7 +12,6 @@ defmodule Beacon.PubSub do
   end
 
   defp broadcast(channel, message) when is_binary(channel) do
-    Logger.debug("broadcast #{inspect(channel)} #{inspect(message)}")
     Phoenix.PubSub.broadcast(@pubsub, channel, message)
   end
 
@@ -21,7 +20,6 @@ defmodule Beacon.PubSub do
   # end
 
   defp subscribe(channel) when is_binary(channel) do
-    Logger.debug("subscribe #{inspect(channel)}")
     Phoenix.PubSub.subscribe(@pubsub, channel)
   end
 end

--- a/lib/beacon/runtime_css.ex
+++ b/lib/beacon/runtime_css.ex
@@ -23,7 +23,6 @@ defmodule Beacon.RuntimeCSS do
   """
   @spec compile!(Layout.t(), keyword()) :: String.t()
   def compile!(%Layout{} = layout, opts \\ []) do
-    Logger.debug("[Beacon.RuntimeCSS] compiling CSS...")
     get_compiler().compile!(layout, opts)
   end
 


### PR DESCRIPTION
The tailwind-cli fails to parse some special chars in the raw content and escaping doesn't work either. Just removing them for now to get it working.

```
** (Mix) Could not start application beacon: Beacon.Application.start(:normal, []) returned an error: shutdown: failed to start child: Beacon.Loader.Server
    ** (EXIT) an exception was raised:
        ** (RuntimeError) Error running tailwind with exit code 1
            (beacon 0.1.0-dev) lib/beacon/css_compiler.ex:41: Beacon.CSSCompiler.compile!/2
            (beacon 0.1.0-dev) lib/beacon/loader/layout_module_loader.ex:32: Beacon.Loader.LayoutModuleLoader.render_layout/1
            (elixir 1.14.2) lib/enum.ex:1658: Enum."-map/2-lists^map/1-0-"/2
            (beacon 0.1.0-dev) lib/beacon/loader/layout_module_loader.ex:11: Beacon.Loader.LayoutModuleLoader.load_layouts/2
            (beacon 0.1.0-dev) lib/beacon/loader/db_loader.ex:32: anonymous fn/1 in Beacon.Loader.DBLoader.load_layouts/0
            (elixir 1.14.2) lib/enum.ex:980: anonymous fn/3 in Enum.each/2
            (stdlib 3.17) maps.erl:410: :maps.fold_1/3
            (elixir 1.14.2) lib/enum.ex:2480: Enum.each/2
            (beacon 0.1.0-dev) lib/beacon/loader/db_loader.ex:31: Beacon.Loader.DBLoader.load_layouts/0
            (beacon 0.1.0-dev) lib/beacon/loader/db_loader.ex:13: Beacon.Loader.DBLoader.load_from_db/0
            (beacon 0.1.0-dev) lib/beacon/loader/server.ex:15: Beacon.Loader.Server.init/1
            (stdlib 3.17) gen_server.erl:423: :gen_server.init_it/2
            (stdlib 3.17) gen_server.erl:390: :gen_server.init_it/6
            (stdlib 3.17) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```