### PR TITLE
Fix query error: comparison with nil is forbidden - /admin/pages/new

### DIFF
--- a/lib/beacon/layouts.ex
+++ b/lib/beacon/layouts.ex
@@ -21,7 +21,7 @@ defmodule Beacon.Layouts do
     Repo.all(Layout)
   end
 
-  def list_layouts_for_site(site) when not is_nil(site) do
+  def list_layouts_for_site(site) do
     Repo.all(from l in Layout, where: l.site == ^site)
   end
 

--- a/lib/beacon/layouts.ex
+++ b/lib/beacon/layouts.ex
@@ -21,6 +21,8 @@ defmodule Beacon.Layouts do
     Repo.all(Layout)
   end
 
+  def list_layouts_for_site(nil), do: []
+
   def list_layouts_for_site(site) do
     Repo.all(from l in Layout, where: l.site == ^site)
   end

--- a/lib/beacon/layouts.ex
+++ b/lib/beacon/layouts.ex
@@ -21,10 +21,22 @@ defmodule Beacon.Layouts do
     Repo.all(Layout)
   end
 
-  def list_layouts_for_site(nil), do: []
-
-  def list_layouts_for_site(site) do
+  def list_layouts_for_site(site) when not is_nil(site) do
     Repo.all(from l in Layout, where: l.site == ^site)
+  end
+
+  @doc """
+  Returns a distinct list of sites associated with layouts.
+
+  ## Examples
+
+      iex> list_distinct_sites_from_layouts()
+      [:site_01, ...]
+
+  """
+  @spec list_distinct_sites_from_layouts :: list(Beacon.Type.Site.t())
+  def list_distinct_sites_from_layouts do
+    Repo.all(from l in Layout, distinct: true, select: l.site)
   end
 
   @doc """

--- a/lib/beacon_web/live/admin/page_live/form_component.ex
+++ b/lib/beacon_web/live/admin/page_live/form_component.ex
@@ -28,7 +28,7 @@ defmodule BeaconWeb.Admin.PageLive.FormComponent do
     socket =
       socket
       |> assign(:changeset, changeset)
-      |> assign_layouts()
+      |> assign_layouts(page_params)
 
     {:noreply, socket}
   end
@@ -70,9 +70,20 @@ defmodule BeaconWeb.Admin.PageLive.FormComponent do
 
   defp assign_layouts(%{assigns: %{changeset: changeset}} = socket) do
     layouts =
-      changeset
-      |> Ecto.Changeset.get_field(:site)
-      |> Layouts.list_layouts_for_site()
+      case Ecto.Changeset.get_field(changeset, :site) do
+        nil -> []
+        site -> Layouts.list_layouts_for_site(site)
+      end
+
+    assign(socket, :site_layouts, layouts)
+  end
+
+  defp assign_layouts(socket, %{"site" => ""}) do
+    assign(socket, :site_layouts, [])
+  end
+
+  defp assign_layouts(socket, %{"site" => site}) do
+    layouts = Layouts.list_layouts_for_site(site)
 
     assign(socket, :site_layouts, layouts)
   end
@@ -82,4 +93,6 @@ defmodule BeaconWeb.Admin.PageLive.FormComponent do
       {title, id}
     end)
   end
+
+  defp list_sites, do: Layouts.list_distinct_sites_from_layouts()
 end

--- a/lib/beacon_web/live/admin/page_live/form_component.html.heex
+++ b/lib/beacon_web/live/admin/page_live/form_component.html.heex
@@ -4,10 +4,10 @@
   </.header>
 
   <.simple_form :let={f} for={@changeset} id="page-form" phx-target={@myself} phx-change="validate" phx-submit="save">
-    <.input field={{f, :site}} type="text" label="Site" />
+    <.input field={{f, :site}} type="select" label="Site" prompt="..." options={list_sites()}/>
     <.input field={{f, :path}} type="text" label="Path" />
     <.input field={{f, :template}} type="textarea" label="Template" />
-    <.input field={{f, :layout_id}} type="select" label="Template" options={layouts_to_options(@site_layouts)} />
+    <.input field={{f, :layout_id}} type="select" label="Template" prompt="..." options={layouts_to_options(@site_layouts)} />
 
     <:actions>
       <.button phx-disable-with="Saving...">Save</.button>

--- a/test/beacon/layouts_test.exs
+++ b/test/beacon/layouts_test.exs
@@ -1,0 +1,20 @@
+defmodule Beacon.LayoutsTest do
+  use Beacon.DataCase
+
+  import Beacon.Fixtures
+  alias Beacon.Layouts
+
+  describe "list_distinct_sites_from_layouts/0" do
+    test "list distinct sites" do
+      for site <- ["site_01", "site_02", "site_01"] do
+        create_layout(%{site: site})
+      end
+
+      assert [:site_01, :site_02] = Layouts.list_distinct_sites_from_layouts()
+    end
+  end
+
+  defp create_layout(attrs) do
+    layout_fixture(attrs)
+  end
+end


### PR DESCRIPTION
I get the following error after going to the `http://localhost:4000/admin/pages/new` route (after running the project for the first time)
```elixir
** (ArgumentError) comparison with nil is forbidden as it is unsafe. If you want to check if a value is nil, use is_nil/1 instead
    (ecto 3.9.4) lib/ecto/query/builder.ex:1045: Ecto.Query.Builder.not_nil!/1
    (beacon 0.1.0-dev) lib/beacon/layouts.ex:27: Beacon.Layouts.list_layouts_for_site/1
    (beacon 0.1.0-dev) lib/beacon_web/live/admin/page_live/form_component.ex:75: BeaconWeb.Admin.PageLive.FormComponent.assign_layouts/1
```

This problem is happening because we tried to load a list of **Layouts** based on a **site**, but at this moment we still don't know which **site** to use, so we call `Layouts.list_layouts_for_site(nil)` and the error above happens.

So before trying to load the `list_layouts_for_site` without a site, we need to load the existing sites and display them on the form. 

![ezgif com-gif-maker](https://user-images.githubusercontent.com/21342004/221590292-59e71cfd-e31c-4f45-9bd1-5e62ecba3a45.gif)

**Changes:**
- Change the form text input field to type "select" and display the existing sites in the form
- Create a function to load existing sites - `list_distinct_sites_from_layouts/0`
- Add `assign_layouts/2` to assign the available **Layouts** according to the selected **site**