### PR TITLE
Import app css

### DIFF
--- a/lib/beacon/loader/stylesheet_module_loader.ex
+++ b/lib/beacon/loader/stylesheet_module_loader.ex
@@ -16,6 +16,7 @@ defmodule Beacon.Loader.StylesheetModuleLoader do
     {:ok, code_string}
   end
 
+  # TODO: check if we'll be using this module to render stylesheets or if we'll rely on RuntimeCSS
   defp render_module(stylesheet_module, stylesheets) do
     """
     defmodule #{stylesheet_module} do

--- a/lib/beacon_web/components/layouts.ex
+++ b/lib/beacon_web/components/layouts.ex
@@ -50,8 +50,9 @@ defmodule BeaconWeb.Layouts do
   end
 
   def render_dynamic_layout(%{__dynamic_layout_id__: layout_id, __site__: site} = assigns) do
-    module = Beacon.Loader.layout_module_for_site(site)
-    Beacon.Loader.call_function_with_retry(module, :render, [layout_id, assigns])
+    site
+    |> Beacon.Loader.layout_module_for_site()
+    |> Beacon.Loader.call_function_with_retry(:render, [layout_id, assigns])
   end
 
   def live_socket_path(%{__site__: site}) do
@@ -146,9 +147,11 @@ defmodule BeaconWeb.Layouts do
   def dynamic_layout?(_), do: false
 
   def stylesheet_tag(%{__dynamic_layout_id__: _, __site__: site}) do
-    module = Beacon.Loader.stylesheet_module_for_site(site)
+    stylesheet_tag =
+      site
+      |> Beacon.Loader.stylesheet_module_for_site()
+      |> Beacon.Loader.call_function_with_retry(:render, [])
 
-    stylesheet_tag = Beacon.Loader.call_function_with_retry(module, :render, [])
     {:safe, stylesheet_tag}
   end
 

--- a/lib/beacon_web/components/layouts/runtime.html.heex
+++ b/lib/beacon_web/components/layouts/runtime.html.heex
@@ -4,7 +4,6 @@
     <%= meta_tags(assigns) %>
     <title><%= page_title(assigns) %></title>
     <%= linked_stylesheets(assigns) %>
-    <%= stylesheet_tag(assigns) %>
     <style>
       <%= raw(render("app.css", assigns)) %>
     </style>

--- a/priv/beacon_tailwind.css
+++ b/priv/beacon_tailwind.css
@@ -1,10 +1,9 @@
+/* tailwind */
 @import "tailwindcss/base";
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 
-/* This file is for your main application CSS */
-
-/* Alerts and form errors used by phx.new */
+/* phoenix */
 .alert {
   padding: 15px;
   margin-bottom: 20px;

--- a/test/beacon_web/live/page_live_test.exs
+++ b/test/beacon_web/live/page_live_test.exs
@@ -102,7 +102,6 @@ defmodule BeaconWeb.Live.PageLiveTest do
     test "a given path", %{conn: conn} do
       {:ok, _view, html} = live(conn, "/home")
 
-      assert html =~ "body {cursor: zoom-in;}"
       assert html =~ "<header>Page header</header>"
       assert html =~ ~s"<main><h2>Some Values:</h2>"
       assert html =~ "<footer>Page footer</footer>"


### PR DESCRIPTION
We need to import the app css into the input source to evaluate tailwind functions and directives https://tailwindcss.com/docs/functions-and-directives.

Another option would be using PostCSS on the host application but I don't think asking users to do it is good UX if we can provide basic import out of the box.