### PR TITLE
Support TagEngine from PhoenixLiveView 0.18.17 and misc improvements

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -46,8 +46,8 @@ end
 
 defmodule SamplePhoenixWeb.Router do
   use Phoenix.Router
+  use Beacon.Router
   import Phoenix.LiveView.Router
-  import Beacon.Router
 
   pipeline :browser do
     plug :accepts, ["html"]
@@ -61,6 +61,7 @@ defmodule SamplePhoenixWeb.Router do
     pipe_through :browser
     beacon_admin "/admin"
     beacon_site "/dev", site: :dev
+    beacon_site "/other", site: :other
   end
 end
 
@@ -245,6 +246,28 @@ seeds = fn ->
     "dockyard_2.jpg",
     "image/jpg"
   )
+
+  %{id: other_layout_id} =
+    Beacon.Layouts.create_layout!(%{
+      site: "other",
+      title: "other",
+      stylesheet_urls: [],
+      body: """
+      <%= @inner_content %>
+      """
+    })
+
+  Beacon.Pages.create_page!(%{
+    path: "home",
+    site: "other",
+    title: "other home",
+    layout_id: other_layout_id,
+    template: """
+    <main>
+      <h1 class="text-violet-900">Other</h1>
+    </main>
+    """
+  })
 end
 
 Task.start(fn ->

--- a/guides/introduction/admin.md
+++ b/guides/introduction/admin.md
@@ -5,7 +5,7 @@ In that interface you'll be able to manage versioned pages and access more featu
 1. Edit the file `router.ex` in your project to look like:
 
 ```elixir
-import Beacon.Router
+use Beacon.Router
 
 scope "/" do
   pipe_through :browser

--- a/guides/introduction/api.md
+++ b/guides/introduction/api.md
@@ -5,7 +5,7 @@ HTTP endpoints to integrate with Beacon layouts, pages, assets, and more.
 1. Edit the file `router.ex` in your project to add:
 
 ```elixir
-import Beacon.Router
+use Beacon.Router
 
 scope "/api"
   pipe_through :api

--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -164,7 +164,7 @@ For more details please check out the docs: `mix help beacon.install`
     end
     ```
 
-4. Edit `lib/my_app_web/router.ex` to import `Beacon.Router`, create a new `scope`, and call `beacon_site` in your app router:
+4. Edit `lib/my_app_web/router.ex` to add  `use Beacon.Router`, create a new `scope`, and call `beacon_site` in your app router:
 
     ```elixir
     use Beacon.Router

--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -167,7 +167,7 @@ For more details please check out the docs: `mix help beacon.install`
 4. Edit `lib/my_app_web/router.ex` to import `Beacon.Router`, create a new `scope`, and call `beacon_site` in your app router:
 
     ```elixir
-    import Beacon.Router
+    use Beacon.Router
 
     scope "/" do
       pipe_through :browser

--- a/lib/beacon/beacon_attrs.ex
+++ b/lib/beacon/beacon_attrs.ex
@@ -7,10 +7,10 @@ defmodule Beacon.BeaconAttrs do
   resolve paths or fetch the site configuration.
   """
 
-  defstruct site: nil, router: nil
+  defstruct site: nil, prefix: nil
 
   @type t :: %__MODULE__{
           site: Beacon.Type.Site.t(),
-          router: module()
+          prefix: String.t()
         }
 end

--- a/lib/beacon/beacon_attrs.ex
+++ b/lib/beacon/beacon_attrs.ex
@@ -7,9 +7,10 @@ defmodule Beacon.BeaconAttrs do
   resolve paths or fetch the site configuration.
   """
 
-  defstruct router: nil
+  defstruct site: nil, router: nil
 
   @type t :: %__MODULE__{
+          site: Beacon.Type.Site.t(),
           router: module()
         }
 end

--- a/lib/beacon/loader/component_module_loader.ex
+++ b/lib/beacon/loader/component_module_loader.ex
@@ -32,17 +32,8 @@ defmodule Beacon.Loader.ComponentModuleLoader do
   end
 
   defp render_component(%Component{site: site, name: name, body: body}) do
-    Beacon.safe_code_heex_check!(site, body)
-
-    ast =
-      EEx.compile_string(body,
-        engine: Phoenix.LiveView.HTMLEngine,
-        line: 1,
-        trim: true,
-        caller: __ENV__,
-        source: body,
-        file: "component-render-#{name}"
-      )
+    file = "site-#{site}-component-#{name}"
+    ast = Beacon.Loader.compile_template!(site, file, body)
 
     quote do
       def render(unquote(name), var!(assigns)) when is_map(var!(assigns)) do

--- a/lib/beacon/loader/layout_module_loader.ex
+++ b/lib/beacon/loader/layout_module_loader.ex
@@ -26,17 +26,8 @@ defmodule Beacon.Loader.LayoutModuleLoader do
   end
 
   defp render_layout(%Layout{} = layout) do
-    Beacon.safe_code_heex_check!(layout.site, layout.body)
-
-    ast =
-      EEx.compile_string(layout.body,
-        engine: Phoenix.LiveView.HTMLEngine,
-        line: 1,
-        trim: true,
-        caller: __ENV__,
-        source: layout.body,
-        file: "layout-render-#{layout.id}"
-      )
+    file = "layout-render-#{layout.title}"
+    ast = Beacon.Loader.compile_template!(layout.site, file, layout.body)
 
     quote do
       def render(unquote(layout.id), var!(assigns)) when is_map(var!(assigns)) do

--- a/lib/beacon/loader/layout_module_loader.ex
+++ b/lib/beacon/loader/layout_module_loader.ex
@@ -26,7 +26,7 @@ defmodule Beacon.Loader.LayoutModuleLoader do
   end
 
   defp render_layout(%Layout{} = layout) do
-    file = "layout-render-#{layout.title}"
+    file = "site-#{layout.site}-layout-#{layout.title}"
     ast = Beacon.Loader.compile_template!(layout.site, file, layout.body)
 
     quote do

--- a/lib/beacon/loader/page_module_loader.ex
+++ b/lib/beacon/loader/page_module_loader.ex
@@ -44,19 +44,8 @@ defmodule Beacon.Loader.PageModuleLoader do
 
   defp store_page(%Page{} = page, page_module, component_module) do
     %{id: page_id, layout_id: layout_id, site: site, path: path, template: template} = page
-
-    Beacon.safe_code_heex_check!(site, template)
-
-    template_ast =
-      EEx.compile_string(template,
-        engine: Phoenix.LiveView.HTMLEngine,
-        line: 1,
-        trim: true,
-        caller: __ENV__,
-        source: template,
-        file: "page-render-#{page_id}"
-      )
-
+    file = "site-#{page.site}-page-#{page.path}"
+    template_ast = Beacon.Loader.compile_template!(site, file, template)
     Beacon.Router.add_page(site, path, {page_id, layout_id, template_ast, page_module, component_module})
   end
 

--- a/lib/beacon/router.ex
+++ b/lib/beacon/router.ex
@@ -5,7 +5,7 @@ defmodule Beacon.Router do
   @moduledoc """
   Provides routing helpers to instantiate sites, admin interface, or api endpoints.
 
-  In your app router, add `import Beacon.Router` and call one the of the available macros.
+  In your app router, add `use Beacon.Router` and call one the of the available macros.
   """
 
   defmacro __using__(_opts) do
@@ -47,7 +47,7 @@ defmodule Beacon.Router do
 
       defmodule MyAppWeb.Router do
         use Phoenix.Router
-        import Beacon.Router
+        use Beacon.Router
 
         scope "/", MyAppWeb do
           pipe_through :browser

--- a/lib/beacon/router.ex
+++ b/lib/beacon/router.ex
@@ -195,7 +195,7 @@ defmodule Beacon.Router do
   @spec beacon_asset_path(Beacon.BeaconAttrs.t(), Path.t()) :: String.t()
   def beacon_asset_path(%Beacon.BeaconAttrs{} = attrs, file_name) do
     %{site: site, prefix: prefix} = attrs
-    sanitize_path("#{prefix}/beacon_assets/#{file_name}?site=#{site}")
+    sanitize_path("/#{prefix}/beacon_assets/#{file_name}?site=#{site}")
   end
 
   @doc """

--- a/lib/beacon/router.ex
+++ b/lib/beacon/router.ex
@@ -52,11 +52,8 @@ defmodule Beacon.Router do
         end
       end
 
-      @beacon_site opts[:site]
-      def __beacon_site__, do: @beacon_site
-
       @beacon_site_prefix Phoenix.Router.scoped_path(__MODULE__, path)
-      def __beacon_site_prefix__, do: @beacon_site_prefix
+      def __beacon_site_prefix__(site), do: @beacon_site_prefix
     end
   end
 
@@ -158,9 +155,9 @@ defmodule Beacon.Router do
   Note that `@beacon_attrs` assign is injected and available in pages automatically.
   """
   @spec beacon_asset_path(Beacon.BeaconAttrs.t(), Path.t()) :: String.t()
-  def beacon_asset_path(beacon_attrs, file_name) do
-    site = beacon_attrs.router.__beacon_site__()
-    sanitize_path(beacon_attrs.router.__beacon_site_prefix__() <> "/beacon_assets/#{file_name}?site=#{site}")
+  def beacon_asset_path(%Beacon.BeaconAttrs{site: site} = attrs, file_name) do
+    prefix = attrs.router.__beacon_site_prefix__(site)
+    sanitize_path("#{prefix}/beacon_assets/#{file_name}?site=#{site}")
   end
 
   @doc """

--- a/lib/beacon_web/components/layouts.ex
+++ b/lib/beacon_web/components/layouts.ex
@@ -12,7 +12,7 @@ defmodule BeaconWeb.Layouts do
   # TODO: style nonce
   def static_asset_path(conn, asset) when asset in [:css, :js] do
     %{assigns: %{__site__: site}} = conn
-    prefix = conn.private.phoenix_router.__beacon_site_prefix__()
+    prefix = conn.private.phoenix_router.__beacon_site_prefix__(site)
 
     hash =
       cond do

--- a/lib/beacon_web/live/page_live.ex
+++ b/lib/beacon_web/live/page_live.ex
@@ -21,7 +21,7 @@ defmodule BeaconWeb.PageLive do
       socket
       |> assign(:beacon, %{site: site})
       |> assign(:beacon_live_data, live_data)
-      |> assign(:beacon_attrs, %BeaconAttrs{site: site, router: socket.router})
+      |> assign(:beacon_attrs, %BeaconAttrs{site: site, prefix: socket.router.__beacon_site_prefix__(site)})
       |> assign(:__live_path__, path)
       |> assign(:__page_update_available__, false)
       |> assign(:__dynamic_layout_id__, layout_id)

--- a/lib/beacon_web/live/page_live.ex
+++ b/lib/beacon_web/live/page_live.ex
@@ -21,7 +21,7 @@ defmodule BeaconWeb.PageLive do
       socket
       |> assign(:beacon, %{site: site})
       |> assign(:beacon_live_data, live_data)
-      |> assign(:beacon_attrs, %BeaconAttrs{router: socket.router})
+      |> assign(:beacon_attrs, %BeaconAttrs{site: site, router: socket.router})
       |> assign(:__live_path__, path)
       |> assign(:__page_update_available__, false)
       |> assign(:__dynamic_layout_id__, layout_id)

--- a/priv/templates/install/beacon_router_scope.ex
+++ b/priv/templates/install/beacon_router_scope.ex
@@ -1,5 +1,5 @@
 
-  import Beacon.Router
+  use Beacon.Router
 
   scope "/" do
     pipe_through :browser

--- a/test/beacon/router_test.exs
+++ b/test/beacon/router_test.exs
@@ -74,15 +74,15 @@ defmodule Beacon.RouterTest do
     import Beacon.Router, only: [beacon_asset_path: 2]
 
     test "plain route" do
-      beacon = %{router: RouterSimple}
+      attrs = %Beacon.BeaconAttrs{site: :site, router: RouterSimple}
 
-      assert beacon_asset_path(beacon, "file.jpg") == "/beacon_assets/file.jpg?site=site"
+      assert beacon_asset_path(attrs, "file.jpg") == "/beacon_assets/file.jpg?site=site"
     end
 
     test "nested route" do
-      beacon = %{router: RouterNested}
+      attrs = %Beacon.BeaconAttrs{site: :site, router: RouterNested}
 
-      assert beacon_asset_path(beacon, "file.jpg") == "/parent/nested/site/beacon_assets/file.jpg?site=site"
+      assert beacon_asset_path(attrs, "file.jpg") == "/parent/nested/site/beacon_assets/file.jpg?site=site"
     end
   end
 

--- a/test/beacon/router_test.exs
+++ b/test/beacon/router_test.exs
@@ -27,7 +27,6 @@ defmodule Beacon.RouterTest do
 
     scope "/" do
       beacon_admin "/admin"
-      beacon_site "/", site: :site
     end
   end
 
@@ -38,7 +37,6 @@ defmodule Beacon.RouterTest do
     scope "/parent" do
       scope "/nested" do
         beacon_admin "/admin"
-        beacon_site "/site", site: :site
       end
     end
   end
@@ -74,15 +72,15 @@ defmodule Beacon.RouterTest do
     import Beacon.Router, only: [beacon_asset_path: 2]
 
     test "plain route" do
-      attrs = %Beacon.BeaconAttrs{site: :site, router: RouterSimple}
+      attrs = %Beacon.BeaconAttrs{site: :site, prefix: ""}
 
       assert beacon_asset_path(attrs, "file.jpg") == "/beacon_assets/file.jpg?site=site"
     end
 
     test "nested route" do
-      attrs = %Beacon.BeaconAttrs{site: :site, router: RouterNested}
+      attrs = %Beacon.BeaconAttrs{site: :site, prefix: "parent/nested"}
 
-      assert beacon_asset_path(attrs, "file.jpg") == "/parent/nested/site/beacon_assets/file.jpg?site=site"
+      assert beacon_asset_path(attrs, "file.jpg") == "/parent/nested/beacon_assets/file.jpg?site=site"
     end
   end
 

--- a/test/beacon/router_test.exs
+++ b/test/beacon/router_test.exs
@@ -23,7 +23,7 @@ defmodule Beacon.RouterTest do
 
   defmodule RouterSimple do
     use Beacon.BeaconTest, :router
-    import Beacon.Router
+    use Beacon.Router
 
     scope "/" do
       beacon_admin "/admin"
@@ -32,7 +32,7 @@ defmodule Beacon.RouterTest do
 
   defmodule RouterNested do
     use Beacon.BeaconTest, :router
-    import Beacon.Router
+    use Beacon.Router
 
     scope "/parent" do
       scope "/nested" do

--- a/test/beacon_web/controllers/media_library_controller_test.exs
+++ b/test/beacon_web/controllers/media_library_controller_test.exs
@@ -1,12 +1,10 @@
 defmodule BeaconWeb.Controllers.MediaLibraryControllerTest do
   use BeaconWeb.ConnCase, async: true
 
-  import Beacon.Router, only: [beacon_asset_path: 2]
-
   test "show", %{conn: conn} do
     Beacon.Fixtures.media_library_asset_fixture()
-    attrs = %Beacon.BeaconAttrs{site: :my_site, router: Beacon.BeaconTest.Router}
-    path = beacon_asset_path(attrs, "image.jpg")
+    attrs = %Beacon.BeaconAttrs{site: :my_site, prefix: ""}
+    path = Beacon.Router.beacon_asset_path(attrs, "image.jpg")
 
     conn = get(conn, path)
 

--- a/test/beacon_web/controllers/media_library_controller_test.exs
+++ b/test/beacon_web/controllers/media_library_controller_test.exs
@@ -5,8 +5,8 @@ defmodule BeaconWeb.Controllers.MediaLibraryControllerTest do
 
   test "show", %{conn: conn} do
     Beacon.Fixtures.media_library_asset_fixture()
-    beacon = %{router: Beacon.BeaconTest.Router}
-    path = beacon_asset_path(beacon, "image.jpg")
+    attrs = %Beacon.BeaconAttrs{site: :my_site, router: Beacon.BeaconTest.Router}
+    path = beacon_asset_path(attrs, "image.jpg")
 
     conn = get(conn, path)
 

--- a/test/mix/tasks/install_test.exs
+++ b/test/mix/tasks/install_test.exs
@@ -108,7 +108,7 @@ defmodule Mix.Tasks.Beacon.InstallTest do
       Install.maybe_inject_beacon_site_routes(bindings)
 
       file_content = File.read!(dest_file)
-      assert file_content =~ ~r/import Beacon\.Router/
+      assert file_content =~ ~r/use Beacon\.Router/
       assert file_content =~ ~r/beacon_site \"\/my_test_blog\", site: :my_test_blog/
     end)
   end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -1,6 +1,6 @@
 defmodule Beacon.BeaconTest.Router do
   use Beacon.BeaconTest, :router
-  import Beacon.Router
+  use Beacon.Router
 
   pipeline :browser do
     plug :accepts, ["html"]


### PR DESCRIPTION
- [x] Compile templates with `Phoenix.LiveView.TagEngine` if available (introduced in LV 0.18.17)
- [x] Name the compiled files with a long description to help identify them in stacktraces.
- [x] `import Beacon.Router` -> `use Beacon.Router` so we have more control over the compilation to generate all required functions and attributes. With such change would be possible to override Phoenix.Router init/call if necessary too.
- [x] Raise if more than one `beacon_admin` is defined. Currently there's no tenant control on admin and thus only one admin is allowed.
- [x] Do not expose `router` on `BeaconAttrs` because that public struct will be the building block for user defined components and we better keep it limited.
