### PR TITLE
allow beacon_admin to accept opts to configure live_session.

### DIFF
--- a/lib/beacon/router.ex
+++ b/lib/beacon/router.ex
@@ -120,9 +120,26 @@ defmodule Beacon.Router do
   end
 
   @doc """
-  Admin routes.
+  Admin routes for a beacon site.
+
+  ## Examples
+
+      defmodule MyAppWeb.Router do
+        use Phoenix.Router
+        use Beacon.Router
+
+        scope "/", MyAppWeb do
+          pipe_through :browser
+          beacon_admin "/admin", on_mount: [SomeHook]
+        end
+      end
+
+  ## Options
+
+    * `:on_mount` (optional) , an optional list of `on_mount` hooks passed to `live_session`.
+    This will allow for authenticated routes, among other uses.
   """
-  defmacro beacon_admin(path) do
+  defmacro beacon_admin(path, opts \\ []) do
     quote bind_quoted: binding(), location: :keep do
       # check before scope so it can raise with the proper message
       if existing = Module.get_attribute(__MODULE__, :beacon_admin_prefix) do
@@ -138,7 +155,9 @@ defmodule Beacon.Router do
       scope path, alias: false, as: false do
         import Phoenix.LiveView.Router, only: [live: 3, live_session: 3]
 
-        live_session :beacon_admin, root_layout: {BeaconWeb.Layouts, :admin} do
+        session_opts = Beacon.Router.__admin_session_opts__(opts)
+
+        live_session :beacon_admin, session_opts do
           get "/beacon_static/css-:md5", BeaconWeb.BeaconStaticController, :css, as: :beacon_admin_static_asset
           get "/beacon_static/js:md5", BeaconWeb.BeaconStaticController, :js, as: :beacon_admin_static_asset
 
@@ -151,6 +170,22 @@ defmodule Beacon.Router do
         end
       end
     end
+  end
+
+  @doc false
+  def __admin_session_opts__(opts) do
+    if Keyword.has_key?(opts, :root_layout) do
+      raise ArgumentError, """
+      You cannot assign a different root_layout.
+
+      Beacon Admin depends on {BeaconWeb.Layouts, :admin}
+      """
+    end
+
+    [
+      on_mount: Keyword.get(opts, :on_mount, []),
+      root_layout: {BeaconWeb.Layouts, :admin}
+    ]
   end
 
   @doc """

--- a/lib/beacon/router.ex
+++ b/lib/beacon/router.ex
@@ -18,7 +18,7 @@ defmodule Beacon.Router do
     quote do
       Module.register_attribute(__MODULE__, :beacon_sites, accumulate: true)
       Module.register_attribute(__MODULE__, :beacon_admin_prefix, accumulate: false)
-      import Beacon.Router, only: [beacon_site: 2, beacon_admin: 1, beacon_api: 1]
+      import Beacon.Router, only: [beacon_site: 2, beacon_admin: 1, beacon_admin: 2, beacon_api: 1]
       @before_compile unquote(__MODULE__)
     end
   end
@@ -177,6 +177,14 @@ defmodule Beacon.Router do
     if Keyword.has_key?(opts, :root_layout) do
       raise ArgumentError, """
       You cannot assign a different root_layout.
+
+      Beacon Admin depends on {BeaconWeb.Layouts, :admin}
+      """
+    end
+
+    if Keyword.has_key?(opts, :layout) do
+      raise ArgumentError, """
+      You cannot assign a layout.
 
       Beacon Admin depends on {BeaconWeb.Layouts, :admin}
       """

--- a/test/beacon/router_test.exs
+++ b/test/beacon/router_test.exs
@@ -39,6 +39,10 @@ defmodule Beacon.RouterTest do
     test "dose not assign root_layout" do
       assert_raise ArgumentError, fn -> Router.__admin_session_opts__(root_layout: {BeaconWeb.Layouts, :runtime}) end
     end
+
+    test "dose not assign layout" do
+      assert_raise ArgumentError, fn -> Router.__admin_session_opts__(layout: {BeaconWeb.Layouts, :runtime}) end
+    end
   end
 
   defmodule RouterSimple do

--- a/test/beacon/router_test.exs
+++ b/test/beacon/router_test.exs
@@ -21,6 +21,26 @@ defmodule Beacon.RouterTest do
     end
   end
 
+  describe "admin options" do
+    test "options are optional" do
+      assert [
+               {:on_mount, []},
+               {:root_layout, {BeaconWeb.Layouts, :admin}}
+             ] = Router.__admin_session_opts__([])
+    end
+
+    test "assigns on_mount" do
+      assert [
+               {:on_mount, [SomeHook]},
+               {:root_layout, {BeaconWeb.Layouts, :admin}}
+             ] = Router.__admin_session_opts__(on_mount: [SomeHook])
+    end
+
+    test "dose not assign root_layout" do
+      assert_raise ArgumentError, fn -> Router.__admin_session_opts__(root_layout: {BeaconWeb.Layouts, :runtime}) end
+    end
+  end
+
   defmodule RouterSimple do
     use Beacon.BeaconTest, :router
     use Beacon.Router


### PR DESCRIPTION
Admin routes for a beacon site.

  ## Examples

      defmodule MyAppWeb.Router do
        use Phoenix.Router
        use Beacon.Router

        scope "/", MyAppWeb do
          pipe_through :browser
          beacon_admin "/admin", on_mount: [SomeHook]
        end
      end

  ## Options

    * `:on_mount` (optional) , an optional list of `on_mount` hooks passed to `live_session`.
    This will allow for authenticated routes, among other uses.