### PR TITLE
Handle malformed or missing asset requests

### DIFF
--- a/lib/beacon/media_library.ex
+++ b/lib/beacon/media_library.ex
@@ -7,7 +7,7 @@ defmodule Beacon.MediaLibrary do
 
   alias Beacon.MediaLibrary.Asset
 
-  def get_asset!(site, name) do
-    Repo.get_by!(Asset, site: site, file_name: name)
+  def get_asset(site, name) do
+    Repo.get_by(Asset, site: site, file_name: name)
   end
 end

--- a/lib/beacon_web/controllers/media_library_controller.ex
+++ b/lib/beacon_web/controllers/media_library_controller.ex
@@ -5,12 +5,13 @@ defmodule BeaconWeb.MediaLibraryController do
   alias Beacon.MediaLibrary.Asset
 
   def show(conn, %{"asset" => asset}) do
-    %{params: %{"site" => site}} = fetch_query_params(conn)
-
-    %Asset{file_body: file_body, file_type: file_type} = MediaLibrary.get_asset!(site, asset)
-
-    conn
-    |> put_resp_header("content-type", "#{file_type}; charset=utf-8")
-    |> send_resp(200, file_body)
+    with %{params: %{"site" => site}} <- fetch_query_params(conn),
+         %Asset{file_body: file_body, file_type: file_type} <- MediaLibrary.get_asset(site, asset) do
+      conn
+      |> put_resp_header("content-type", "#{file_type}; charset=utf-8")
+      |> send_resp(200, file_body)
+    else
+      _ -> raise BeaconWeb.NotFoundError, "asset #{inspect(asset)} not found"
+    end
   end
 end


### PR DESCRIPTION
If the asset request is missing the site, or the asset is not found, raise a `BeaconWeb.NotFoundError`.