### PR TITLE
Leverage the process dict to avoid requiring attr beacon_attrs

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -156,7 +156,7 @@ seeds = fn ->
         <%= my_component("sample_component", val: 1) %>
 
         <div>
-          <BeaconWeb.Components.image beacon_attrs={@beacon_attrs} name="dockyard_1.png" width="200px" />
+          <BeaconWeb.Components.image name="dockyard_1.png" width="200px" />
         </div>
 
         <div>

--- a/lib/beacon/beacon_attrs.ex
+++ b/lib/beacon/beacon_attrs.ex
@@ -1,10 +1,8 @@
 defmodule Beacon.BeaconAttrs do
   @moduledoc """
-  The Beacon attributes for pages.
+  The public Beacon's attributes for each page.
 
-  This is injected into every page as an assign `@beacon_attrs`,
-  and is usually passed to component functions so they can
-  resolve paths or fetch the site configuration.
+  It's injected into the Live View process and also as an assign `@beacon_attrs`.
   """
 
   defstruct site: nil, prefix: nil

--- a/lib/beacon_web/components/components.ex
+++ b/lib/beacon_web/components/components.ex
@@ -5,21 +5,21 @@ defmodule BeaconWeb.Components do
 
   use Phoenix.Component
   import Beacon.Router, only: [beacon_asset_path: 2]
-  alias Beacon.BeaconAttrs
 
   @doc """
   Renders a image previously uploaded in Admin Media Library.
 
   ## Examples
 
-      <BeaconWeb.Components.image beacon_attrs={@beacon_attrs} name="logo.jpg" width="200px" />
+      <BeaconWeb.Components.image name="logo.jpg" width="200px" />
   """
-  attr :beacon_attrs, BeaconAttrs, required: true
   attr :name, :string, required: true
   attr :class, :string, default: nil
   attr :rest, :global
 
   def image(assigns) do
+    assigns = Map.put(assigns, :beacon_attrs, Process.get(:__beacon_attrs__))
+
     ~H"""
     <img src={beacon_asset_path(@beacon_attrs, @name)} class={@class} {@rest} />
     """

--- a/lib/beacon_web/live/page_live.ex
+++ b/lib/beacon_web/live/page_live.ex
@@ -3,7 +3,6 @@ defmodule BeaconWeb.PageLive do
   use Phoenix.HTML
   require Logger
   import Phoenix.Component
-  alias Beacon.BeaconAttrs
 
   def mount(:not_mounted_at_router, _params, socket) do
     {:ok, socket}
@@ -102,11 +101,14 @@ defmodule BeaconWeb.PageLive do
     live_data = Beacon.DataSource.live_data(site, path, Map.drop(params, ["path"]))
     {{_site, _path}, {page_id, layout_id, _templat_ast, page_module, component_module}} = lookup_route!(site, path)
 
+    beacon_attrs = %Beacon.BeaconAttrs{site: site, prefix: socket.router.__beacon_site_prefix__(site)}
+    Process.put(:__beacon_attrs__, beacon_attrs)
+
     socket =
       socket
       |> assign(:beacon, %{site: site})
       |> assign(:beacon_live_data, live_data)
-      |> assign(:beacon_attrs, %BeaconAttrs{site: site, prefix: socket.router.__beacon_site_prefix__(site)})
+      |> assign(:beacon_attrs, beacon_attrs)
       |> assign(:__live_path__, path)
       |> assign(:__page_updated_at, DateTime.utc_now())
       |> assign(:__dynamic_layout_id__, layout_id)


### PR DESCRIPTION
It adds a bit of complexity on our side because the proc dict isn't so explicit but on the other hand improves the UX for the final user who shouldn't be aware of `@beacon_attrs` to call built-in components.