### PR TITLE
remove authorization_bootstrap

### DIFF
--- a/lib/beacon_web/admin/hooks/assign_agent.ex
+++ b/lib/beacon_web/admin/hooks/assign_agent.ex
@@ -2,10 +2,6 @@ defmodule BeaconWeb.Admin.Hooks.AssignAgent do
   @moduledoc """
   Assigns the agent on the socket to be used by `Beacon.Authorization`.
 
-  To enable Authorization you must set a session key/value `authorization_bootstrap`.
-  Beacon does not in itself depend on the contents of `authorization_bootstrap`.
-  This is to be consumed by your own `Beacon.Authorization` implementation.
-
   It is presumed you will have already authenticated the agent with your own hook.
   See `Beacon.Router.beacon_admin/2` for details on adding hooks.
   """
@@ -15,8 +11,7 @@ defmodule BeaconWeb.Admin.Hooks.AssignAgent do
   def on_mount(:default, _params, session, socket) do
     socket =
       assign_new(socket, :agent, fn ->
-        authorization_bootstrap = Map.get(session, "authorization_bootstrap", nil)
-        Beacon.Authorization.get_agent(authorization_bootstrap)
+        Beacon.Authorization.get_agent(session)
       end)
 
     {:cont, socket}

--- a/test/beacon/authorization_test.exs
+++ b/test/beacon/authorization_test.exs
@@ -5,7 +5,7 @@ defmodule Beacon.AuthorizationTest do
 
   describe "get_agent/1" do
     test "returns agent" do
-      assert %{role: :admin} = Authorization.get_agent(%{session_id: "admin_session_123"})
+      assert %{role: :admin} = Authorization.get_agent(%{"session_id" => "admin_session_123"})
     end
   end
 

--- a/test/beacon_web/hooks/assign_agent_test.exs
+++ b/test/beacon_web/hooks/assign_agent_test.exs
@@ -9,7 +9,8 @@ defmodule BeaconWeb.Admin.Hooks.AssignAgentTest do
     test "works", %{conn: conn} do
       session =
         conn
-        |> Plug.Test.init_test_session(%{authorization_bootstrap: %{session_id: "admin_session_123"}})
+        |> Phoenix.ConnTest.init_test_session(%{})
+        |> Plug.Conn.put_session(:session_id, "admin_session_123")
         |> get_session()
 
       socket = %Phoenix.LiveView.Socket{endpoint: Endpoint, router: Router}

--- a/test/beacon_web/live/admin/page_live/index_test.exs
+++ b/test/beacon_web/live/admin/page_live/index_test.exs
@@ -10,7 +10,7 @@ defmodule BeaconWeb.Live.Admin.PageLive.IndexTest do
       conn =
         conn
         |> Phoenix.ConnTest.init_test_session(%{})
-        |> Plug.Conn.put_session(:authorization_bootstrap, %{session_id: "admin_session_123"})
+        |> Plug.Conn.put_session(:session_id, "admin_session_123")
 
       assert {:ok, _view, html} = live(conn, "/admin/pages")
       assert html =~ "New Page"
@@ -23,7 +23,7 @@ defmodule BeaconWeb.Live.Admin.PageLive.IndexTest do
       conn =
         conn
         |> Phoenix.ConnTest.init_test_session(%{})
-        |> Plug.Conn.put_session(:authorization_bootstrap, %{session_id: "editor_session_123"})
+        |> Plug.Conn.put_session(:session_id, "editor_session_123")
 
       assert {:ok, _view, html} = live(conn, "/admin/pages")
       refute html =~ "New Page"
@@ -34,7 +34,7 @@ defmodule BeaconWeb.Live.Admin.PageLive.IndexTest do
       conn =
         conn
         |> Phoenix.ConnTest.init_test_session(%{})
-        |> Plug.Conn.put_session(:authorization_bootstrap, %{session_id: "other_session_123"})
+        |> Plug.Conn.put_session(:session_id, "other_session_123")
 
       assert {:error, {:redirect, %{flash: %{}, to: "/admin"}}} = live(conn, "/admin/pages")
     end

--- a/test/support/beacon_authorization_source.ex
+++ b/test/support/beacon_authorization_source.ex
@@ -3,15 +3,15 @@ defmodule Beacon.BeaconTest.BeaconAuthorizationSource do
 
   alias Beacon.Pages.Page
 
-  def get_agent(%{session_id: "admin_session_123"}) do
+  def get_agent(%{"session_id" => "admin_session_123"}) do
     %{role: :admin, session_id: "admin_session_123"}
   end
 
-  def get_agent(%{session_id: "editor_session_123"}) do
+  def get_agent(%{"session_id" => "editor_session_123"}) do
     %{role: :editor, session_id: "editor_session_123"}
   end
 
-  def get_agent(%{session_id: "other_session_123"}) do
+  def get_agent(%{"session_id" => "other_session_123"}) do
     %{role: :other, session_id: "other_session_123"}
   end
 


### PR DESCRIPTION
Changes `get_agent` parameter semantics.

AssignAgent originally pulled data from the session under the key, `authorization_bootstrap` and passed that to `get_agent`. This put an unnecessary burden and constraint upon the implementor. We now simply pass in the session blindly to `get_agent` and allow the implementor to do what they want with that data. In the course of refactoring this, I had to change atom key references to string to match session keys.