### PR TITLE
Introduce Extra Page Fields

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -94,6 +94,34 @@ defmodule BeaconDataSource do
   def meta_tags(:dev, %{meta_tags: meta_tags}), do: meta_tags
 end
 
+defmodule BeaconTagsField do
+  use Phoenix.Component
+  import BeaconWeb.CoreComponents
+  import Ecto.Changeset
+
+  @behaviour Beacon.PageField
+
+  @impl true
+  def name, do: :tags
+
+  @impl true
+  def type, do: :string
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <.input type="text" label="Tags" field={@field} />
+    """
+  end
+
+  @impl true
+  def changeset(data, attrs) do
+    data
+    |> cast(attrs, [:tags])
+    |> validate_required([:tags])
+  end
+end
+
 seeds = fn ->
   Beacon.Stylesheets.create_stylesheet!(%{
     site: "dev",
@@ -291,7 +319,7 @@ end
 Task.start(fn ->
   children = [
     {Phoenix.PubSub, [name: SamplePhoenix.PubSub]},
-    {Beacon, sites: [[site: :dev, data_source: BeaconDataSource], [site: :other]]},
+    {Beacon, sites: [[site: :dev, data_source: BeaconDataSource, extra_page_fields: [BeaconTagsField]], [site: :other]]},
     SamplePhoenix.Endpoint
   ]
 

--- a/dev.exs
+++ b/dev.exs
@@ -108,6 +108,9 @@ defmodule BeaconTagsField do
   def type, do: :string
 
   @impl true
+  def default, do: "beacon,dev"
+
+  @impl true
   def render(assigns) do
     ~H"""
     <.input type="text" label="Tags" field={@field} />
@@ -115,10 +118,11 @@ defmodule BeaconTagsField do
   end
 
   @impl true
-  def changeset(data, attrs) do
+  def changeset(data, attrs, _metadata) do
     data
     |> cast(attrs, [:tags])
     |> validate_required([:tags])
+    |> validate_format(:tags, ~r/,/, message: "invalid format, expected ,")
   end
 end
 

--- a/lib/beacon/config.ex
+++ b/lib/beacon/config.ex
@@ -79,6 +79,7 @@ defmodule Beacon.Config do
              ]}
           | {:publish_page, [{identifier :: atom(), fun :: (Beacon.Pages.Page.t() -> {:cont, Beacon.Pages.Page.t()} | {:halt, Exception.t()})}]}
           | {:create_page, [{identifier :: atom(), fun :: (Beacon.Pages.Page.t() -> {:cont, Beacon.Pages.Page.t()} | {:halt, Exception.t()})}]}
+          | {:update_page, [{identifier :: atom(), fun :: (Beacon.Pages.Page.t() -> {:cont, Beacon.Pages.Page.t()} | {:halt, Exception.t()})}]}
 
   @typedoc """
   Add extra fields to pages.
@@ -139,7 +140,8 @@ defmodule Beacon.Config do
               load_template: @default_load_template,
               render_template: @default_render_template,
               publish_page: [],
-              create_page: []
+              create_page: [],
+              update_page: []
             ],
             extra_page_fields: []
 
@@ -266,6 +268,7 @@ defmodule Beacon.Config do
             ]
           ],
           create_page: [],
+          update_page: [],
           publish_page: [
             notify_admin: #Function<42.3316493/1 in :erl_eval.expr/6>
           ]
@@ -291,6 +294,7 @@ defmodule Beacon.Config do
       load_template: Keyword.merge(@default_load_template, get_in(opts, [:lifecycle, :load_template]) || []),
       render_template: Keyword.merge(@default_render_template, get_in(opts, [:lifecycle, :render_template]) || []),
       create_page: get_in(opts, [:lifecycle, :create_page]) || [],
+      update_page: get_in(opts, [:lifecycle, :update_page]) || [],
       publish_page: get_in(opts, [:lifecycle, :publish_page]) || []
     ]
 

--- a/lib/beacon/config.ex
+++ b/lib/beacon/config.ex
@@ -42,19 +42,19 @@ defmodule Beacon.Config do
   Register formats to handle templates, eg: `[{:heex, "HEEx (HTML)"}]`.
 
   Beacon provides two formats built-in, HEEx and Markdown, but you can register your own
-  as long as you also implement the lifecyce stages `:load_template` and `:render_template`.
+  as long as you also implement the life-cycle stages `:load_template` and `:render_template`.
 
   The description is used on user interfaces as Beacon Admin.
   """
   @type template_formats :: [{format :: atom(), description :: String.t()}]
 
   @typedoc """
-  Attach steps into Beacon's internal lifecycle stages to inject custom functionality.
+  Attach steps into Beacon's internal life-cycle stages to inject custom functionality.
   """
   @type lifecycle :: [lifecycle_stage()]
 
   @typedoc """
-  Lifecycle stages.
+  Life-cycle stages.
   """
   @type lifecycle_stage ::
           {:load_template,
@@ -80,6 +80,11 @@ defmodule Beacon.Config do
           | {:publish_page, [{identifier :: atom(), fun :: (Beacon.Pages.Page.t() -> {:cont, Beacon.Pages.Page.t()} | {:halt, Exception.t()})}]}
           | {:create_page, [{identifier :: atom(), fun :: (Beacon.Pages.Page.t() -> {:cont, Beacon.Pages.Page.t()} | {:halt, Exception.t()})}]}
 
+  @typedoc """
+  Add extra fields to pages.
+  """
+  @type extra_page_fields :: [module()]
+
   @type t :: %__MODULE__{
           site: Beacon.Types.Site.t(),
           data_source: data_source(),
@@ -89,7 +94,8 @@ defmodule Beacon.Config do
           live_socket_path: live_socket_path(),
           safe_code_check: safe_code_check(),
           template_formats: template_formats(),
-          lifecycle: lifecycle()
+          lifecycle: lifecycle(),
+          extra_page_fields: extra_page_fields()
         }
 
   @default_load_template [
@@ -134,7 +140,8 @@ defmodule Beacon.Config do
               render_template: @default_render_template,
               publish_page: [],
               create_page: []
-            ]
+            ],
+            extra_page_fields: []
 
   @type option ::
           {:site, Beacon.Types.Site.t()}
@@ -146,6 +153,7 @@ defmodule Beacon.Config do
           | {:safe_code_check, safe_code_check()}
           | {:template_formats, template_formats()}
           | {:lifecycle, lifecycle()}
+          | {:extra_page_fields, extra_page_fields()}
 
   @doc """
   Build a new `%Beacon.Config{}` instance to hold the entire configuration for each site.
@@ -183,6 +191,8 @@ defmodule Beacon.Config do
 
     * `lifecycle` - `t:lifecycle/0` (optional).
     Note that the default config is merged with your config.
+
+    * `:extra_page_fields` - `t:extra_page_fields/0` (optional)
 
   ## Example
 
@@ -259,7 +269,8 @@ defmodule Beacon.Config do
           publish_page: [
             notify_admin: #Function<42.3316493/1 in :erl_eval.expr/6>
           ]
-        ]
+        ],
+        extra_page_fields: []
       }
 
   """

--- a/lib/beacon/lifecycle.ex
+++ b/lib/beacon/lifecycle.ex
@@ -112,6 +112,24 @@ defmodule Beacon.Lifecycle do
   end
 
   @doc """
+  Execute all steps for stage `:update_page`.
+
+  It's executed in the same repo transaction, after the `page` record is saved into the database.
+  """
+  @spec update_page(Beacon.Pages.Page.t()) :: Beacon.Pages.Page.t()
+  def update_page(page) do
+    config = Beacon.Config.fetch!(page.site)
+    do_update_page(page, Keyword.fetch!(config.lifecycle, :update_page))
+  end
+
+  @doc false
+  def do_update_page(page, [] = _steps), do: page
+
+  def do_update_page(page, steps) do
+    execute_steps(:update_page, steps, page, nil)
+  end
+
+  @doc """
   Execute all steps for stage `:publish_page`.
 
   It's executed before the `page` is reloaded.

--- a/lib/beacon/page_field.ex
+++ b/lib/beacon/page_field.ex
@@ -34,6 +34,8 @@ defmodule Beacon.PageField do
 
   """
 
+  @optional_callbacks default: 0
+
   @doc """
   Field identifier. Must be unique per site.
   """
@@ -45,6 +47,11 @@ defmodule Beacon.PageField do
   @callback type :: any()
 
   @doc """
+  Default value for field. Defaults to `nil`.
+  """
+  @callback default :: any()
+
+  @doc """
   Template to render the field on Admin.
   """
   @callback render(assigns :: Phoenix.LiveView.Socket.assigns()) :: Phoenix.LiveView.Rendered.t()
@@ -52,23 +59,27 @@ defmodule Beacon.PageField do
   @doc """
   Changeset used to validate and save data.
   """
-  @callback changeset(data :: {Ecto.Changeset.data(), Ecto.Changeset.types()}, attrs :: %{String.t() => any()}) :: Ecto.Changeset.t()
+  @callback changeset(
+              data :: {Ecto.Changeset.data(), Ecto.Changeset.types()},
+              attrs :: %{String.t() => any()},
+              metadata :: %{page_changeset: Ecto.Changeset.t()}
+            ) :: Ecto.Changeset.t()
 
   @doc false
-  def extra_fields(site, form, extra, errors) do
+  def extra_fields(site, %Phoenix.HTML.Form{} = form, params, errors) when is_map(params) and is_list(errors) do
     mods = Beacon.Config.fetch!(site).extra_page_fields
+    do_extra_fields(mods, form, params, errors)
+  end
+
+  @doc false
+  def do_extra_fields(mods, form, params, errors) do
+    errors = traverse_errors(errors)
 
     Enum.reduce(mods, %{}, fn mod, acc ->
       name = mod.name()
-      value = Map.get(extra, "#{name}")
-
-      errors =
-        case errors do
-          {_, fields} -> fields
-          _ -> []
-        end
-        |> Keyword.get(name, [])
-        |> List.wrap()
+      default = if function_exported?(mod, :default, 0), do: mod.default(), else: nil
+      value = Map.get(params, "#{name}", default)
+      errors = Map.get(errors, name, [])
 
       Map.put(acc, name, %Phoenix.HTML.FormField{
         id: "page_extra_#{name}",
@@ -82,9 +93,29 @@ defmodule Beacon.PageField do
   end
 
   @doc false
-  def apply_changesets(page_changeset, site, params) do
-    mods = Beacon.Config.fetch!(site).extra_page_fields
+  def traverse_errors(errors) when is_list(errors) do
+    merge_fields = fn fields ->
+      Enum.reduce(fields, %{}, fn {field, error}, acc ->
+        Map.update(acc, field, [error], fn e ->
+          [error | e]
+        end)
+      end)
+    end
 
+    Enum.reduce(errors, %{}, fn {:extra, {_msg, fields}}, acc ->
+      field = fields |> merge_fields.() |> Map.new(fn {k, v} -> {k, Enum.reverse(v)} end)
+      Map.merge(acc, field)
+    end)
+  end
+
+  @doc false
+  def apply_changesets(%Ecto.Changeset{} = page_changeset, site, params) when is_atom(site) and is_map(params) do
+    mods = Beacon.Config.fetch!(site).extra_page_fields
+    do_apply_changesets(mods, page_changeset, params)
+  end
+
+  @doc false
+  def do_apply_changesets(mods, page_changeset, params) do
     Enum.reduce(mods, page_changeset, fn mod, page_changeset ->
       name = mod.name()
       params = Map.take(params, ["#{name}"])
@@ -93,16 +124,20 @@ defmodule Beacon.PageField do
       types = %{name => type}
       data = {%{}, types}
 
-      field_changeset = mod.changeset(data, params)
+      field_changeset = mod.changeset(data, params, %{page_changeset: page_changeset})
 
       case Ecto.Changeset.apply_action(field_changeset, :update) do
         {:ok, field} ->
-          extra = Ecto.Changeset.get_field(page_changeset, :extra) || %{}
           value = Map.get(field, name)
+          extra = Ecto.Changeset.get_field(page_changeset, :extra) || %{}
           extra = Map.put(extra, "#{name}", value)
           Ecto.Changeset.put_change(page_changeset, :extra, extra)
 
         {:error, field_changeset} ->
+          value = Ecto.Changeset.apply_changes(field_changeset) |> Map.get(name)
+          extra = Ecto.Changeset.get_field(page_changeset, :extra) || %{}
+          extra = Map.put(extra, "#{name}", value)
+          page_changeset = Ecto.Changeset.put_change(page_changeset, :extra, extra)
           Ecto.Changeset.add_error(page_changeset, :extra, "invalid", field_changeset.errors)
       end
     end)

--- a/lib/beacon/page_field.ex
+++ b/lib/beacon/page_field.ex
@@ -1,0 +1,110 @@
+defmodule Beacon.PageField do
+  @moduledoc ~S"""
+  Add extra fields to pages.
+
+  ## Example
+
+      defmodule MyApp.TagsField do
+        use Phoenix.Component
+        import BeaconWeb.CoreComponents
+        import Ecto.Changeset
+
+        @behaviour Beacon.PageField
+
+        @impl true
+        def name, do: :tags
+
+        @impl true
+        def type, do: :string
+
+        @impl true
+        def render(assigns) do
+          ~H\"""
+          <.input type="text" label="Tags" field={@field} />
+          \"""
+        end
+
+        @impl true
+        def changeset(data, attrs) do
+          data
+          |> cast(attrs, [:tags])
+          |> validate_required([:tags])
+        end
+      end
+
+  """
+
+  @doc """
+  Field identifier. Must be unique per site.
+  """
+  @callback name :: atom()
+
+  @doc """
+  Field type. Can be any value supported by Ecto Schema.
+  """
+  @callback type :: any()
+
+  @doc """
+  Template to render the field on Admin.
+  """
+  @callback render(assigns :: Phoenix.LiveView.Socket.assigns()) :: Phoenix.LiveView.Rendered.t()
+
+  @doc """
+  Changeset used to validate and save data.
+  """
+  @callback changeset(data :: {Ecto.Changeset.data(), Ecto.Changeset.types()}, attrs :: %{String.t() => any()}) :: Ecto.Changeset.t()
+
+  @doc false
+  def extra_fields(site, form, extra, errors) do
+    mods = Beacon.Config.fetch!(site).extra_page_fields
+
+    Enum.reduce(mods, %{}, fn mod, acc ->
+      name = mod.name()
+      value = Map.get(extra, "#{name}")
+
+      errors =
+        case errors do
+          {_, fields} -> fields
+          _ -> []
+        end
+        |> Keyword.get(name, [])
+        |> List.wrap()
+
+      Map.put(acc, name, %Phoenix.HTML.FormField{
+        id: "page_extra_#{name}",
+        name: "page[extra][#{name}]",
+        errors: errors,
+        field: name,
+        value: value,
+        form: form
+      })
+    end)
+  end
+
+  @doc false
+  def apply_changesets(page_changeset, site, params) do
+    mods = Beacon.Config.fetch!(site).extra_page_fields
+
+    Enum.reduce(mods, page_changeset, fn mod, page_changeset ->
+      name = mod.name()
+      params = Map.take(params, ["#{name}"])
+
+      type = mod.type()
+      types = %{name => type}
+      data = {%{}, types}
+
+      field_changeset = mod.changeset(data, params)
+
+      case Ecto.Changeset.apply_action(field_changeset, :update) do
+        {:ok, field} ->
+          extra = Ecto.Changeset.get_field(page_changeset, :extra) || %{}
+          value = Map.get(field, name)
+          extra = Map.put(extra, "#{name}", value)
+          Ecto.Changeset.put_change(page_changeset, :extra, extra)
+
+        {:error, field_changeset} ->
+          Ecto.Changeset.add_error(page_changeset, :extra, "invalid", field_changeset.errors)
+      end
+    end)
+  end
+end

--- a/lib/beacon/pages.ex
+++ b/lib/beacon/pages.ex
@@ -162,6 +162,12 @@ defmodule Beacon.Pages do
     |> Repo.update()
   end
 
+  def update_page(%Page{} = page, params) do
+    page
+    |> Page.update_page_changeset(params)
+    |> Repo.update()
+  end
+
   @doc """
   Deletes a page.
 
@@ -185,15 +191,7 @@ defmodule Beacon.Pages do
     end)
   end
 
-  @doc """
-  Returns an `%Ecto.Changeset{}` for tracking page changes.
-
-  ## Examples
-
-      iex> change_page(page)
-      %Ecto.Changeset{data: %Page{}}
-
-  """
+  @doc false
   def change_page(%Page{} = page, attrs \\ %{}) do
     Page.changeset(page, attrs)
   end

--- a/lib/beacon/pages.ex
+++ b/lib/beacon/pages.ex
@@ -4,11 +4,11 @@ defmodule Beacon.Pages do
   """
 
   import Ecto.Query, warn: false
-  alias Beacon.Repo
   alias Beacon.Pages.Page
   alias Beacon.Pages.PageEvent
   alias Beacon.Pages.PageHelper
   alias Beacon.Pages.PageVersion
+  alias Beacon.Repo
 
   @doc """
   Returns the list of pages.

--- a/lib/beacon/pages.ex
+++ b/lib/beacon/pages.ex
@@ -150,6 +150,7 @@ defmodule Beacon.Pages do
     end
   end
 
+  # TODO: remove update_page_pending
   def update_page_pending(%Page{} = page, template, layout_id, extra \\ %{}) do
     params =
       Map.merge(extra, %{

--- a/lib/beacon/pages/page.ex
+++ b/lib/beacon/pages/page.ex
@@ -27,7 +27,7 @@ defmodule Beacon.Pages.Page do
     field :order, :integer, default: 1
     field :status, Ecto.Enum, values: [:draft, :published], default: :draft
     field :format, Beacon.Types.Atom, default: :heex
-    field :extra, :map
+    field :extra, :map, default: %{}
 
     belongs_to :layout, Layout
     belongs_to :pending_layout, Layout
@@ -52,7 +52,8 @@ defmodule Beacon.Pages.Page do
       :order,
       :layout_id,
       :status,
-      :format
+      :format,
+      :extra
     ])
     |> cast(attrs, [:path], empty_values: [])
     |> put_pending()

--- a/lib/beacon/pages/page.ex
+++ b/lib/beacon/pages/page.ex
@@ -27,6 +27,7 @@ defmodule Beacon.Pages.Page do
     field :order, :integer, default: 1
     field :status, Ecto.Enum, values: [:draft, :published], default: :draft
     field :format, Beacon.Types.Atom, default: :heex
+    field :extra, :map
 
     belongs_to :layout, Layout
     belongs_to :pending_layout, Layout
@@ -85,6 +86,30 @@ defmodule Beacon.Pages.Page do
     |> trim([:pending_template])
     |> remove_all_newlines([:description])
     |> remove_empty_meta_attributes(:meta_tags)
+  end
+
+  # TODO: The inclusion of the fields [:title, :description, :meta_tags] here requires some more consideration, but we
+  # need them to get going on the admin interface for now
+  # TODO: only allow path if status = draft
+  @doc false
+  def update_page_changeset(page, attrs) do
+    {extra_attrs, attrs} = Map.pop(attrs, "extra")
+
+    page
+    |> cast(attrs, [
+      :pending_template,
+      :pending_layout_id,
+      :title,
+      :description,
+      :meta_tags,
+      :path,
+      :format
+    ])
+    |> validate_required([:pending_template, :pending_layout_id])
+    |> trim([:pending_template])
+    |> remove_all_newlines([:description])
+    |> remove_empty_meta_attributes(:meta_tags)
+    |> Beacon.PageField.apply_changesets(page.site, extra_attrs)
   end
 
   def put_pending(%Changeset{} = changeset) do

--- a/lib/beacon_web/live/admin/page_live/page_editor_live.ex
+++ b/lib/beacon_web/live/admin/page_live/page_editor_live.ex
@@ -140,6 +140,7 @@ defmodule BeaconWeb.Admin.PageEditorLive do
     change = Ecto.Changeset.get_change(changeset, :extra)
     field = Ecto.Changeset.get_field(changeset, :extra)
 
+    # account for validate_required to display empty fields instead of the field value
     extra =
       if errors && is_nil(change) do
         Map.new(field, fn {k, _v} -> {k, nil} end)

--- a/lib/beacon_web/live/admin/page_live/page_editor_live.ex
+++ b/lib/beacon_web/live/admin/page_live/page_editor_live.ex
@@ -136,19 +136,8 @@ defmodule BeaconWeb.Admin.PageEditorLive do
   end
 
   defp assign_extra_fields(socket, changeset) do
-    errors = changeset.errors[:extra]
-    change = Ecto.Changeset.get_change(changeset, :extra)
-    field = Ecto.Changeset.get_field(changeset, :extra)
-
-    # account for validate_required to display empty fields instead of the field value
-    extra =
-      if errors && is_nil(change) do
-        Map.new(field, fn {k, _v} -> {k, nil} end)
-      else
-        field
-      end
-
-    extra_fields = Beacon.PageField.extra_fields(socket.assigns.page.site, socket.assigns.form, extra, errors)
+    params = Ecto.Changeset.get_field(changeset, :extra)
+    extra_fields = Beacon.PageField.extra_fields(socket.assigns.page.site, socket.assigns.form, params, changeset.errors)
     assign(socket, :extra_fields, extra_fields)
   end
 

--- a/lib/beacon_web/live/admin/page_live/page_editor_live.html.heex
+++ b/lib/beacon_web/live/admin/page_live/page_editor_live.html.heex
@@ -34,6 +34,10 @@
     <.input field={@form[:format]} type="select" label="Format" options={template_format_options(@form)} />
     <.input field={@form[:pending_template]} type="textarea" label="Template" phx-debounce="500" rows="20" class="block mb-2 font-mono text-sm" />
 
+    <%= for mod <- Beacon.Config.fetch!(@page.site).extra_page_fields do %>
+      <%= extra_page_field(mod, @extra_fields[mod.name()], __ENV__) %>
+    <% end %>
+
     <.header>Meta Tags</.header>
     <.live_component module={MetaTagsInputs} id="meta-tags" field={@form[:meta_tags]} extra_attributes={@extra_meta_attributes} />
 

--- a/priv/repo/migrations/20230418141354_add_extra_to_pages.exs
+++ b/priv/repo/migrations/20230418141354_add_extra_to_pages.exs
@@ -1,0 +1,9 @@
+defmodule Beacon.Repo.Migrations.AddExtraToPages do
+  use Ecto.Migration
+
+  def change do
+    alter table(:beacon_pages) do
+      add :extra, :map, default: %{}
+    end
+  end
+end

--- a/test/beacon/config_test.exs
+++ b/test/beacon/config_test.exs
@@ -40,6 +40,7 @@ defmodule Beacon.ConfigTest do
                  load_template: [{:heex, _}, {:markdown, _}],
                  render_template: [{:heex, _}, {:markdown, _}],
                  create_page: [],
+                 update_page: [],
                  publish_page: []
                ]
              } = Config.new(lifecycle: [load_template: []])

--- a/test/beacon/page_field_test.exs
+++ b/test/beacon/page_field_test.exs
@@ -1,0 +1,127 @@
+defmodule Beacon.PageFieldTest do
+  use Beacon.DataCase, async: true
+
+  import Beacon.Fixtures
+  alias Beacon.PageField
+
+  @form %Phoenix.HTML.Form{}
+
+  defmodule BeaconTest.PageFieldTags do
+    use Phoenix.Component
+    import BeaconWeb.CoreComponents
+    import Ecto.Changeset
+
+    @behaviour Beacon.PageField
+
+    @impl true
+    def name, do: :tags
+
+    @impl true
+    def type, do: :string
+
+    @impl true
+    def default, do: "beacon,test"
+
+    @impl true
+    def render(assigns) do
+      ~H"""
+      <.input type="text" label="Tags" field={@field} />
+      """
+    end
+
+    @impl true
+    def changeset(data, attrs, _metadata) do
+      data
+      |> cast(attrs, [:tags])
+      |> validate_format(:tags, ~r/,/, message: "invalid format")
+    end
+  end
+
+  describe "apply_changesets" do
+    setup do
+      page = page_fixture()
+      page_changeset = Beacon.Pages.change_page(page)
+      [page_changeset: page_changeset]
+    end
+
+    test "empty params", %{page_changeset: page_changeset} do
+      assert %Ecto.Changeset{
+               valid?: true,
+               changes: %{extra: %{"tags" => nil}},
+               errors: []
+             } = PageField.do_apply_changesets([BeaconTest.PageFieldTags], page_changeset, %{})
+    end
+
+    test "invalid params", %{page_changeset: page_changeset} do
+      assert %Ecto.Changeset{
+               valid?: false,
+               changes: %{extra: %{"tags" => "foo"}},
+               errors: [extra: {"invalid", [tags: {"invalid format", [validation: :format]}]}]
+             } = PageField.do_apply_changesets([BeaconTest.PageFieldTags], page_changeset, %{"tags" => "foo"})
+    end
+
+    test "valid params", %{page_changeset: page_changeset} do
+      assert %Ecto.Changeset{
+               valid?: true,
+               changes: %{extra: %{"tags" => "foo,bar"}},
+               errors: []
+             } = PageField.do_apply_changesets([BeaconTest.PageFieldTags], page_changeset, %{"tags" => "foo,bar"})
+    end
+  end
+
+  describe "extra_fields" do
+    setup do
+      page = page_fixture()
+      page_changeset = Beacon.Pages.change_page(page)
+      [page_changeset: page_changeset]
+    end
+
+    test "build form field" do
+      assert %{
+               tags: %Phoenix.HTML.FormField{
+                 id: "page_extra_tags",
+                 name: "page[extra][tags]",
+                 errors: [],
+                 field: :tags,
+                 value: "foo,bar"
+               }
+             } = PageField.do_extra_fields([BeaconTest.PageFieldTags], @form, %{"tags" => "foo,bar"}, [])
+    end
+
+    test "default value" do
+      assert %{
+               tags: %Phoenix.HTML.FormField{value: "beacon,test"}
+             } = PageField.do_extra_fields([BeaconTest.PageFieldTags], @form, %{}, [])
+    end
+
+    test "errors", %{page_changeset: page_changeset} do
+      page_changeset = PageField.do_apply_changesets([BeaconTest.PageFieldTags], page_changeset, %{"tags" => "foo"})
+
+      assert %{
+               tags: %Phoenix.HTML.FormField{
+                 value: "foo",
+                 errors: [{"invalid format", [validation: :format]}]
+               }
+             } = PageField.do_extra_fields([BeaconTest.PageFieldTags], @form, %{"tags" => "foo"}, page_changeset.errors)
+    end
+  end
+
+  test "traverse_errors" do
+    assert PageField.traverse_errors(
+             extra:
+               {"invalid",
+                [
+                  field_a: {"message_1", [validation: 1]},
+                  field_a: {"message_2", [validation: 2]}
+                ]},
+             extra:
+               {"invalid",
+                [
+                  field_c: {"message_3", [validation: 3]}
+                ]}
+           ) == %{
+             field_a: [{"message_1", [validation: 1]}, {"message_2", [validation: 2]}],
+             field_c: [{"message_3", [validation: 3]}]
+           }
+  end
+end

--- a/test/beacon/pages_test.exs
+++ b/test/beacon/pages_test.exs
@@ -25,4 +25,18 @@ defmodule Beacon.PagesTest do
 
     assert [%{path: ""}, %{path: "blog_a"}, %{path: "blog_b"}] = Pages.list_pages_for_site(:my_site, [:events, :helpers])
   end
+
+  describe "extra" do
+    test "update existing field" do
+      page = page_fixture(extra: %{})
+
+      assert {:ok, %Page{extra: %{"tags" => "foo,bar"}}} = Pages.update_page(page, %{"extra" => %{"tags" => "foo,bar"}})
+    end
+
+    test "skip non-existing field" do
+      page = page_fixture(extra: %{})
+
+      assert {:ok, %Page{extra: %{}}} = Pages.update_page(page, %{"extra" => %{"foo" => "bar"}})
+    end
+  end
 end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -8,6 +8,12 @@ defmodule Beacon.Fixtures do
   def get_lazy(attrs, key, fun) when is_map(attrs), do: Map.get_lazy(attrs, key, fun)
   def get_lazy(attrs, key, fun), do: Keyword.get_lazy(attrs, key, fun)
 
+  def conn_admin(conn) do
+    conn
+    |> Phoenix.ConnTest.init_test_session(%{})
+    |> Plug.Conn.put_session(:session_id, "admin_session_123")
+  end
+
   def stylesheet_fixture(attrs \\ %{}) do
     attrs
     |> Enum.into(%{

--- a/test/support/page_fields.ex
+++ b/test/support/page_fields.ex
@@ -19,7 +19,7 @@ defmodule Beacon.BeaconTest.PageFields.TagsField do
   end
 
   @impl true
-  def changeset(data, attrs) do
+  def changeset(data, attrs, _metadata) do
     data
     |> cast(attrs, [:tags])
   end

--- a/test/support/page_fields.ex
+++ b/test/support/page_fields.ex
@@ -1,0 +1,26 @@
+defmodule Beacon.BeaconTest.PageFields.TagsField do
+  use Phoenix.Component
+  import BeaconWeb.CoreComponents
+  import Ecto.Changeset
+
+  @behaviour Beacon.PageField
+
+  @impl true
+  def name, do: :tags
+
+  @impl true
+  def type, do: :string
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <.input type="text" label="Tags" field={@field} />
+    """
+  end
+
+  @impl true
+  def changeset(data, attrs) do
+    data
+    |> cast(attrs, [:tags])
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -17,7 +17,8 @@ Supervisor.start_link(
          site: :my_site,
          tailwind_config: Path.join([File.cwd!(), "test", "support", "tailwind.config.js.eex"]),
          data_source: Beacon.BeaconTest.BeaconDataSource,
-         live_socket_path: "/custom_live"
+         live_socket_path: "/custom_live",
+         extra_page_fields: [Beacon.BeaconTest.PageFields.TagsField]
        ],
        [
          site: :data_source_test,


### PR DESCRIPTION
`Beacon.Pages.Page` has a limited set of fields, the minimum required for a page to work. Any other field needed by host apps, for eg `tags`, `author`, and so on, are considered "extra, ie: they don't belong to beacon core but users should be able to store and manage such fields on Beacon Admin.

This PR introduces:
- a `jsonb` column to store such fields, which doesn't require migrations
- a behaviour to define the template to be displayed on page editor form (admin) and the changeset to validate those fields

### Example

https://github.com/BeaconCMS/beacon/blob/2a892b749cef379fa503597910ea97764a593ff1/dev.exs#L97-L123