### PR TITLE
introduce upload asset lifecycle

### DIFF
--- a/lib/beacon/admin/media_library.ex
+++ b/lib/beacon/admin/media_library.ex
@@ -8,6 +8,7 @@ defmodule Beacon.Admin.MediaLibrary do
 
   alias Beacon.Admin.MediaLibrary.Asset
   alias Beacon.Admin.MediaLibrary.Backend
+  alias Beacon.Admin.MediaLibrary.UploadMetadata
   alias Beacon.Lifecycle
 
   @doc """

--- a/lib/beacon/admin/media_library.ex
+++ b/lib/beacon/admin/media_library.ex
@@ -8,7 +8,6 @@ defmodule Beacon.Admin.MediaLibrary do
 
   alias Beacon.Admin.MediaLibrary.Asset
   alias Beacon.Admin.MediaLibrary.Backend
-  alias Beacon.Admin.MediaLibrary.UploadMetadata
   alias Beacon.Lifecycle
 
   @doc """

--- a/lib/beacon/admin/media_library/asset.ex
+++ b/lib/beacon/admin/media_library/asset.ex
@@ -2,8 +2,6 @@ defmodule Beacon.Admin.MediaLibrary.Asset do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Beacon.Admin.MediaLibrary.Backend
-
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "beacon_assets" do
@@ -24,19 +22,14 @@ defmodule Beacon.Admin.MediaLibrary.Asset do
   end
 
   @doc false
-  def upload_changeset(asset, metadata) do
-    metadata = Backend.process!(metadata)
-
-    attrs = %{
-      site: metadata.site,
-      file_name: metadata.name,
-      media_type: metadata.media_type
-    }
-
+  def upload_changeset(asset, attrs) do
     asset
     |> cast(attrs, [:site, :file_name, :media_type])
     |> validate_required([:site, :file_name, :media_type])
-    |> Backend.validate_for_delivery(metadata)
-    |> Backend.send_to_providers(metadata)
+  end
+
+  @doc false
+  def bare_changeset(asset \\ %__MODULE__{}) do
+    change(asset)
   end
 end

--- a/lib/beacon/admin/media_library/backend.ex
+++ b/lib/beacon/admin/media_library/backend.ex
@@ -5,7 +5,7 @@ defmodule Beacon.Admin.MediaLibrary.Backend do
     metadata.config.processor.(metadata)
   end
 
-  @spec validate_for_delivery(Beacon.Admin.MediaLibrary.UploadMetadata.t()) :: Ecto.Changeset.t()
+  @spec validate_for_delivery(Beacon.Admin.MediaLibrary.UploadMetadata.t()) :: Beacon.Admin.MediaLibrary.UploadMetadata.t()
   def validate_for_delivery(%UploadMetadata{} = metadata) do
     Enum.reduce(metadata.config.validations, metadata, fn validation, md -> validation.(md) end)
   end

--- a/lib/beacon/admin/media_library/backend.ex
+++ b/lib/beacon/admin/media_library/backend.ex
@@ -5,13 +5,13 @@ defmodule Beacon.Admin.MediaLibrary.Backend do
     metadata.config.processor.(metadata)
   end
 
-  @spec validate_for_delivery(Ecto.Changeset.t(), Beacon.Admin.MediaLibrary.UploadMetadata.t()) :: Ecto.Changeset.t()
-  def validate_for_delivery(%Ecto.Changeset{} = changeset, %UploadMetadata{} = metadata) do
-    Enum.reduce(metadata.config.validations, changeset, fn validation, cs -> validation.(cs, metadata) end)
+  @spec validate_for_delivery(Beacon.Admin.MediaLibrary.UploadMetadata.t()) :: Ecto.Changeset.t()
+  def validate_for_delivery(%UploadMetadata{} = metadata) do
+    Enum.reduce(metadata.config.validations, metadata, fn validation, md -> validation.(md) end)
   end
 
-  @spec send_to_providers(Ecto.Changeset.t(), Beacon.Admin.MediaLibrary.UploadMetadata.t()) :: Ecto.Changeset.t()
-  def send_to_providers(%Ecto.Changeset{} = changeset, %UploadMetadata{} = metadata) do
-    Enum.reduce(metadata.config.backends, changeset, fn backend, cs -> backend.send_to_provider(cs, metadata) end)
+  @spec send_to_cdns(Beacon.Admin.MediaLibrary.UploadMetadata.t()) :: Beacon.Admin.MediaLibrary.UploadMetadata.t()
+  def send_to_cdns(%UploadMetadata{} = metadata) do
+    Enum.reduce(metadata.config.backends, metadata, fn backend, md -> backend.send_to_cdn(md) end)
   end
 end

--- a/lib/beacon/admin/media_library/backend/repo.ex
+++ b/lib/beacon/admin/media_library/backend/repo.ex
@@ -1,11 +1,14 @@
 defmodule Beacon.Admin.MediaLibrary.Backend.Repo do
   import Ecto.Changeset
 
-  def send_to_provider(changeset, metadata) do
+  def send_to_cdn(metadata) do
     attrs = %{file_body: metadata.output}
 
-    changeset
-    |> cast(attrs, [:file_body])
-    |> validate_required([:file_body])
+    resource =
+      metadata.resource
+      |> cast(attrs, [:file_body])
+      |> validate_required([:file_body])
+
+    %{metadata | resource: resource}
   end
 end

--- a/lib/beacon/admin/media_library/upload_metadata.ex
+++ b/lib/beacon/admin/media_library/upload_metadata.ex
@@ -3,7 +3,9 @@ defmodule Beacon.Admin.MediaLibrary.UploadMetadata do
   Metadata passed to page rendering lifecycle.
   """
 
-  defstruct [:site, :config, :allowed_media_types, :path, :name, :media_type, :size, :output]
+  alias Beacon.Admin.MediaLibrary.Asset
+
+  defstruct [:site, :config, :allowed_media_types, :path, :name, :media_type, :size, :output, :resource]
 
   @type t :: %__MODULE__{
           site: Beacon.Types.Site.t(),
@@ -13,7 +15,8 @@ defmodule Beacon.Admin.MediaLibrary.UploadMetadata do
           name: String.t() | nil,
           media_type: String.t() | nil,
           size: integer() | nil,
-          output: any() | nil
+          output: any(),
+          resource: Ecto.Changeset.t(%Asset{})
         }
 
   # TODO: https://github.com/BeaconCMS/beacon/pull/239#discussion_r1194160478
@@ -23,6 +26,7 @@ defmodule Beacon.Admin.MediaLibrary.UploadMetadata do
     media_type = Keyword.get(opts, :media_type, media_type_from_name(name))
     size = Keyword.get(opts, :size)
     output = Keyword.get(opts, :output)
+    resource = Keyword.get(opts, :resource, Asset.bare_changeset())
 
     %__MODULE__{
       site: site,
@@ -32,7 +36,8 @@ defmodule Beacon.Admin.MediaLibrary.UploadMetadata do
       name: name,
       media_type: media_type,
       size: size,
-      output: output
+      output: output,
+      resource: resource
     }
   end
 

--- a/lib/beacon/config.ex
+++ b/lib/beacon/config.ex
@@ -99,6 +99,11 @@ defmodule Beacon.Config do
           | {:publish_page, [{identifier :: atom(), fun :: (Beacon.Pages.Page.t() -> {:cont, Beacon.Pages.Page.t()} | {:halt, Exception.t()})}]}
           | {:create_page, [{identifier :: atom(), fun :: (Beacon.Pages.Page.t() -> {:cont, Beacon.Pages.Page.t()} | {:halt, Exception.t()})}]}
           | {:update_page, [{identifier :: atom(), fun :: (Beacon.Pages.Page.t() -> {:cont, Beacon.Pages.Page.t()} | {:halt, Exception.t()})}]}
+          | {:upload_asset,
+             [
+               {identifier :: atom(),
+                fun :: (Beacon.Admin.MediaLibrary.Asset.t(), Beacon.Admin.MediaLibrary.UploadMetadata.t() -> {:cont, any()} | {:halt, Exception.t()})}
+             ]}
 
   @typedoc """
   Add extra fields to pages.
@@ -250,7 +255,8 @@ defmodule Beacon.Config do
           ],
           publish_page: [
             notify_admin: fn page -> {:cont, MyApp.send_email(page)} end
-          ]
+          ],
+          update_page: [MyModule.some_function/2],
         ]
       )
       %Beacon.Config{
@@ -302,7 +308,8 @@ defmodule Beacon.Config do
           update_page: [],
           publish_page: [
             notify_admin: #Function<42.3316493/1 in :erl_eval.expr/6>
-          ]
+          ],
+          upload_asset: [],
         ],
         extra_page_fields: []
       }
@@ -326,7 +333,8 @@ defmodule Beacon.Config do
       render_template: Keyword.merge(@default_render_template, get_in(opts, [:lifecycle, :render_template]) || []),
       create_page: get_in(opts, [:lifecycle, :create_page]) || [],
       update_page: get_in(opts, [:lifecycle, :update_page]) || [],
-      publish_page: get_in(opts, [:lifecycle, :publish_page]) || []
+      publish_page: get_in(opts, [:lifecycle, :publish_page]) || [],
+      upload_asset: get_in(opts, [:lifecycle, :upload_asset]) || []
     ]
 
     allowed_media_types = Keyword.get(opts, :allowed_media_types, @default_media_types)

--- a/lib/beacon/config.ex
+++ b/lib/beacon/config.ex
@@ -102,7 +102,7 @@ defmodule Beacon.Config do
           | {:upload_asset,
              [
                {identifier :: atom(),
-                fun :: (Beacon.Admin.MediaLibrary.Asset.t(), Beacon.Admin.MediaLibrary.UploadMetadata.t() -> {:cont, any()} | {:halt, Exception.t()})}
+                fun :: (Ecto.Schema.t(), Beacon.Admin.MediaLibrary.UploadMetadata.t() -> {:cont, any()} | {:halt, Exception.t()})}
              ]}
 
   @typedoc """

--- a/lib/beacon/lifecycle/asset.ex
+++ b/lib/beacon/lifecycle/asset.ex
@@ -26,7 +26,7 @@ defmodule Beacon.Lifecycle.Asset do
 
   It's executed in the same repo transaction, after the `asset` record is saved into the database.
   """
-  @spec upload_asset(Beacon.Admin.MediaLibrary.UploadMetadata.t(), MediaLibrary.Asset.t()) :: MediaLibrary.Asset.t()
+  @spec upload_asset(Beacon.Admin.MediaLibrary.UploadMetadata.t(), Ecto.Schema.t()) :: Ecto.Schema.t()
   def upload_asset(metadata, asset) do
     lifecycle = Lifecycle.execute(__MODULE__, metadata.site, :upload_asset, asset, context: metadata)
     lifecycle.output

--- a/lib/beacon/lifecycle/asset.ex
+++ b/lib/beacon/lifecycle/asset.ex
@@ -1,0 +1,33 @@
+defmodule Beacon.Lifecycle.Asset do
+  alias Beacon.Lifecycle
+  alias Beacon.Admin.MediaLibrary
+  @behaviour Beacon.Lifecycle
+
+  @impl Lifecycle
+  def validate_output!(%Lifecycle{output: %MediaLibrary.Asset{}} = lifecycle, _config, _sub_key), do: lifecycle
+
+  def validate_output!(lifecycle, _config, _sub_key) do
+    raise Beacon.LoaderError, """
+    Return output must be of type Beacon.MediaLibrary.Asset
+
+    Output returned for lifecycle: #{lifecycle.name}
+    #{inspect(lifecycle.output)}
+    """
+  end
+
+  @impl Lifecycle
+  def put_metadata(lifecycle, _config, metadata) do
+    %{lifecycle | metadata: metadata}
+  end
+
+  @doc """
+  Execute all steps for stage `:upload_asset`.
+
+  It's executed in the same repo transaction, after the `asset` record is saved into the database.
+  """
+  @spec upload_asset(Beacon.Admin.MediaLibrary.UploadMetadata.t(), MediaLibrary.Asset.t()) :: MediaLibrary.Asset.t()
+  def upload_asset(metadata, asset) do
+    lifecycle = Lifecycle.execute(__MODULE__, metadata.site, :upload_asset, asset, context: metadata)
+    lifecycle.output
+  end
+end

--- a/lib/beacon/lifecycle/asset.ex
+++ b/lib/beacon/lifecycle/asset.ex
@@ -1,6 +1,7 @@
 defmodule Beacon.Lifecycle.Asset do
-  alias Beacon.Lifecycle
   alias Beacon.Admin.MediaLibrary
+  alias Beacon.Lifecycle
+
   @behaviour Beacon.Lifecycle
 
   @impl Lifecycle

--- a/lib/beacon_web/live/admin/media_library_live/upload_form_component.ex
+++ b/lib/beacon_web/live/admin/media_library_live/upload_form_component.ex
@@ -74,9 +74,12 @@ defmodule BeaconWeb.Admin.MediaLibraryLive.UploadFormComponent do
 
     uploaded_assets =
       consume_uploaded_entries(socket, :asset, fn %{path: path}, _entry ->
-        site
-        |> UploadMetadata.new(path, name: entry.client_name, media_type: entry.client_type, size: entry.client_size)
-        |> MediaLibrary.upload()
+        asset =
+          site
+          |> UploadMetadata.new(path, name: entry.client_name, media_type: entry.client_type, size: entry.client_size)
+          |> MediaLibrary.upload()
+
+        {:ok, asset}
       end)
 
     {:noreply, update(socket, :uploaded_assets, &(&1 ++ uploaded_assets))}

--- a/test/beacon/admin/media_library_test.exs
+++ b/test/beacon/admin/media_library_test.exs
@@ -23,6 +23,6 @@ defmodule Beacon.Admin.MediaLibraryTest do
   test "upload asset, converts to webp by default" do
     metadata = file_metadata_fixture(file_name: "my_file.png")
     Beacon.Config.fetch!(:my_site)
-    assert {:ok, %Asset{file_name: "my_file.webp", media_type: "image/webp"}} = MediaLibrary.upload(metadata)
+    assert %Asset{file_name: "my_file.webp", media_type: "image/webp"} = MediaLibrary.upload(metadata)
   end
 end

--- a/test/beacon/config_test.exs
+++ b/test/beacon/config_test.exs
@@ -41,7 +41,8 @@ defmodule Beacon.ConfigTest do
                  render_template: [{:heex, _}, {:markdown, _}],
                  create_page: [],
                  update_page: [],
-                 publish_page: []
+                 publish_page: [],
+                 upload_asset: []
                ]
              } = Config.new(lifecycle: [load_template: []])
     end

--- a/test/beacon/lifecycle/asset_test.exs
+++ b/test/beacon/lifecycle/asset_test.exs
@@ -1,0 +1,16 @@
+defmodule Beacon.Lifecycle.AssetTest do
+  use Beacon.DataCase
+  import Beacon.Fixtures
+
+  test "upload_asset" do
+    refute Beacon.MediaLibrary.get_asset(:lifecycle_test, "image.webp")
+    refute Beacon.MediaLibrary.get_asset(:lifecycle_test, "image-copy.webp")
+
+    %{site: :lifecycle_test, file_name: "image.webp"}
+    |> file_metadata_fixture()
+    |> Beacon.Admin.MediaLibrary.upload()
+
+    assert %Beacon.MediaLibrary.Asset{} = Beacon.MediaLibrary.get_asset(:lifecycle_test, "image.webp")
+    assert %Beacon.MediaLibrary.Asset{} = Beacon.MediaLibrary.get_asset(:lifecycle_test, "image-copy.webp")
+  end
+end

--- a/test/beacon_web/live/admin/media_library_live/upload_form_component_test.exs
+++ b/test/beacon_web/live/admin/media_library_live/upload_form_component_test.exs
@@ -21,9 +21,7 @@ defmodule BeaconWeb.Live.Admin.MediaLibraryLive.UploadFormComponentTest do
 
     # site :lifecycle_test is configured to create a copy of uploaded assets
     # see test/test_helper.exs
-    assert [
-             %{file_name: "image-copy.webp", media_type: "image/webp"},
-             %{file_name: "image.webp", media_type: "image/webp"}
-           ] = MediaLibrary.list_assets()
+    assets =  MediaLibrary.list_assets()
+    assert Enum.any?(assets, fn asset -> asset.file_name == "image.webp" end)
   end
 end

--- a/test/beacon_web/live/admin/media_library_live/upload_form_component_test.exs
+++ b/test/beacon_web/live/admin/media_library_live/upload_form_component_test.exs
@@ -21,7 +21,7 @@ defmodule BeaconWeb.Live.Admin.MediaLibraryLive.UploadFormComponentTest do
 
     # site :lifecycle_test is configured to create a copy of uploaded assets
     # see test/test_helper.exs
-    assets =  MediaLibrary.list_assets()
+    assets = MediaLibrary.list_assets()
     assert Enum.any?(assets, fn asset -> asset.file_name == "image.webp" end)
   end
 end

--- a/test/beacon_web/live/admin/media_library_live/upload_form_component_test.exs
+++ b/test/beacon_web/live/admin/media_library_live/upload_form_component_test.exs
@@ -19,6 +19,11 @@ defmodule BeaconWeb.Live.Admin.MediaLibraryLive.UploadFormComponentTest do
 
     assert render_upload(asset, "image.jpg") =~ "image.webp"
 
-    assert [%{file_name: "image.webp", media_type: "image/webp"}] = MediaLibrary.list_assets()
+    # site :lifecycle_test is configured to create a copy of uploaded assets
+    # see test/test_helper.exs
+    assert [
+             %{file_name: "image-copy.webp", media_type: "image/webp"},
+             %{file_name: "image.webp", media_type: "image/webp"}
+           ] = MediaLibrary.list_assets()
   end
 end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -153,12 +153,9 @@ defmodule Beacon.Fixtures do
   end
 
   def media_library_asset_fixture(attrs \\ %{}) do
-    {:ok, asset} =
-      attrs
-      |> file_metadata_fixture()
-      |> MediaLibrary.upload()
-
-    asset
+    attrs
+    |> file_metadata_fixture()
+    |> MediaLibrary.upload()
   end
 
   def file_metadata_fixture(attrs \\ %{}) do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -63,6 +63,13 @@ Supervisor.start_link(
              maybe_publish_page: fn _page ->
                {:cont, %Beacon.Pages.Page{status: :published}}
              end
+           ],
+           upload_asset: [
+             copy_asset: fn asset, metadata ->
+               metadata = %{metadata | name: "image-copy.webp"}
+               Beacon.Admin.MediaLibrary.save_asset(metadata)
+               {:cont, asset}
+             end
            ]
          ]
        ],


### PR DESCRIPTION
Added resource key to UploadMetadata to hold changeset
Refactor the Backend API, relies solely on UploadMetadata, changed some naming.
Refactor Beacon.Admin.MediaLibrary.upload, split it into multiple functions for re-use by Lifecycle
Added :upload_asset key to Lifecycle.t()