### PR TITLE
Add `:default_meta_tags` config option

### DIFF
--- a/lib/beacon/config.ex
+++ b/lib/beacon/config.ex
@@ -110,6 +110,11 @@ defmodule Beacon.Config do
   """
   @type extra_page_fields :: [module()]
 
+  @typedoc """
+  Default meta tags added to new pages.
+  """
+  @type default_meta_tags :: [%{binary() => binary()}]
+
   @type t :: %__MODULE__{
           site: Beacon.Types.Site.t(),
           data_source: data_source(),
@@ -122,7 +127,8 @@ defmodule Beacon.Config do
           assets: assets(),
           allowed_media_types: allowed_media_types(),
           lifecycle: lifecycle(),
-          extra_page_fields: extra_page_fields()
+          extra_page_fields: extra_page_fields(),
+          default_meta_tags: default_meta_tags()
         }
 
   @default_load_template [
@@ -173,7 +179,8 @@ defmodule Beacon.Config do
               create_page: [],
               update_page: []
             ],
-            extra_page_fields: []
+            extra_page_fields: [],
+            default_meta_tags: []
 
   @type option ::
           {:site, Beacon.Types.Site.t()}
@@ -188,6 +195,7 @@ defmodule Beacon.Config do
           | {:allowed_media_types, allowed_media_types()}
           | {:lifecycle, lifecycle()}
           | {:extra_page_fields, extra_page_fields()}
+          | {:default_meta_tags, default_meta_tags()}
 
   @doc """
   Build a new `%Beacon.Config{}` instance to hold the entire configuration for each site.
@@ -227,6 +235,8 @@ defmodule Beacon.Config do
     Note that the default config is merged with your config.
 
     * `:extra_page_fields` - `t:extra_page_fields/0` (optional)
+
+    * `:default_meta_tags` - `t:default_meta_tags/0` (optional)
 
   ## Example
 
@@ -311,7 +321,8 @@ defmodule Beacon.Config do
           ],
           upload_asset: [],
         ],
-        extra_page_fields: []
+        extra_page_fields: [],
+        default_meta_tags: []
       }
 
   """
@@ -343,12 +354,15 @@ defmodule Beacon.Config do
     assigned_assets = Keyword.get(opts, :assets, [])
     assets = process_assets_config(allowed_media_types, assigned_assets)
 
+    default_meta_tags = Keyword.get(opts, :default_meta_tags, [%{"name" => "foo_meta_tag"}, %{"name" => "bar_meta_tag"}, %{"name" => "baz_meta_tag"}])
+
     opts =
       opts
       |> Keyword.put(:template_formats, template_formats)
       |> Keyword.put(:lifecycle, lifecycle)
       |> Keyword.put(:allowed_media_types, allowed_media_types)
       |> Keyword.put(:assets, assets)
+      |> Keyword.put(:default_meta_tags, default_meta_tags)
 
     struct!(__MODULE__, opts)
   end

--- a/lib/beacon/config.ex
+++ b/lib/beacon/config.ex
@@ -354,7 +354,7 @@ defmodule Beacon.Config do
     assigned_assets = Keyword.get(opts, :assets, [])
     assets = process_assets_config(allowed_media_types, assigned_assets)
 
-    default_meta_tags = Keyword.get(opts, :default_meta_tags, [%{"name" => "foo_meta_tag"}, %{"name" => "bar_meta_tag"}, %{"name" => "baz_meta_tag"}])
+    default_meta_tags = Keyword.get(opts, :default_meta_tags, [])
 
     opts =
       opts

--- a/lib/beacon/pages.ex
+++ b/lib/beacon/pages.ex
@@ -89,6 +89,15 @@ defmodule Beacon.Pages do
   def create_page(attrs) do
     skip_reload? = Map.get(attrs, :skip_reload, false)
 
+    default_meta_tags =
+      attrs
+      |> Map.fetch!(:site)
+      |> String.to_existing_atom()
+      |> Beacon.Config.fetch!()
+      |> Map.fetch!(:default_meta_tags)
+
+    attrs = Map.put_new(attrs, :meta_tags, default_meta_tags)
+
     Repo.transaction(fn ->
       page_changeset = Page.changeset(attrs)
 

--- a/lib/beacon_web/live/admin/page_live/form_component.ex
+++ b/lib/beacon_web/live/admin/page_live/form_component.ex
@@ -39,7 +39,9 @@ defmodule BeaconWeb.Admin.PageLive.FormComponent do
   end
 
   defp save_page(socket, :new, page_params) do
-    case Pages.create_page(page_params) do
+    parsed_params = Map.new(page_params, fn {key, value} -> {String.to_existing_atom(key), value} end)
+
+    case Pages.create_page(parsed_params) do
       {:ok, _page} ->
         {:noreply,
          socket

--- a/test/beacon/pages_test.exs
+++ b/test/beacon/pages_test.exs
@@ -22,7 +22,7 @@ defmodule Beacon.PagesTest do
     test "includes default meta tags" do
       attrs = %{
         path: "home",
-        site: "my_site",
+        site: "default_meta_tags_test",
         layout_id: layout_fixture().id,
         template: """
         <main>

--- a/test/beacon/pages_test.exs
+++ b/test/beacon/pages_test.exs
@@ -18,6 +18,26 @@ defmodule Beacon.PagesTest do
     end
   end
 
+  describe "create_page/1" do
+    test "includes default meta tags" do
+      attrs = %{
+        path: "home",
+        site: "my_site",
+        layout_id: layout_fixture().id,
+        template: """
+        <main>
+          <h1>my_site#home</h1>
+        </main>
+        """,
+        format: :heex,
+        skip_reload: true
+      }
+
+      assert {:ok, page} = Pages.create_page(attrs)
+      assert page.meta_tags == [%{"name" => "foo_meta_tag"}, %{"name" => "bar_meta_tag"}, %{"name" => "baz_meta_tag"}]
+    end
+  end
+
   test "list_pages_for_site order" do
     page_fixture(path: "", order: 0)
     page_fixture(path: "blog_a", order: 0)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -25,6 +25,15 @@ Supervisor.start_link(
          data_source: Beacon.BeaconTest.TestDataSource
        ],
        [
+         site: :default_meta_tags_test,
+         data_source: Beacon.BeaconTest.BeaconDataSource,
+         default_meta_tags: [
+           %{"name" => "foo_meta_tag"},
+           %{"name" => "bar_meta_tag"},
+           %{"name" => "baz_meta_tag"}
+         ]
+       ],
+       [
          site: :lifecycle_test,
          lifecycle: [
            load_template: [


### PR DESCRIPTION
### Asana task
[Improve meta tag functionality](https://app.asana.com/0/1203282419046399/1204726099802197/f)

### Goal
We want sites to be able to configure default meta tags which are automatically added to new pages

### Implementation
Adds an optional `:default_meta_tags` to `Beacon.Config`, which is just a list of meta tags (maps).  Using meta tag maps allow the most customization e.g. setting default content values, name vs. property.