### PR TITLE
Fix meta tag ordering issue

### DIFF
--- a/lib/beacon_web/live/admin/page_live/meta_tags_inputs.ex
+++ b/lib/beacon_web/live/admin/page_live/meta_tags_inputs.ex
@@ -70,8 +70,12 @@ defmodule BeaconWeb.Admin.PageLive.MetaTagsInputs do
   # Convert params map %{"0" => %{...}, "1" => %{...}} into a list of maps
   def coerce_meta_tag_param(params, field) do
     case Map.fetch(params, field) do
-      {:ok, map} -> Map.put(params, field, Map.values(map))
-      :error -> params
+      {:ok, map} ->
+        list = Enum.sort_by(map, fn {key, value} -> String.to_integer(key) end)
+        Map.put(params, field, Keyword.values(list))
+
+      :error ->
+        params
     end
   end
 end

--- a/lib/beacon_web/live/admin/page_live/meta_tags_inputs.ex
+++ b/lib/beacon_web/live/admin/page_live/meta_tags_inputs.ex
@@ -71,7 +71,7 @@ defmodule BeaconWeb.Admin.PageLive.MetaTagsInputs do
   def coerce_meta_tag_param(params, field) do
     case Map.fetch(params, field) do
       {:ok, map} ->
-        list = Enum.sort_by(map, fn {key, value} -> String.to_integer(key) end)
+        list = Enum.sort_by(map, fn {key, _value} -> String.to_integer(key) end)
         Map.put(params, field, Keyword.values(list))
 
       :error ->


### PR DESCRIPTION
### Issue

When there are more than 10 meta tags on a page, editing the meta tags will cause the fields to re-render in a different order. This is very disorienting and makes it impossible to update meta tags.

### Cause

Fields are stored in assigns with their index, starting at 0, and sorted using erlang term ordering.  However, the number is a String type.  Therefore the ordering is fine for single digits (0 to 9) but when the 11th field (index 10) is added, sorting becomes "0", "1", "10", "2", "3", etc...

### Fix

`Enum.sort_by(..., &String.to_integer/1)`