### PR TITLE
Change default page format to markdown

### DIFF
--- a/lib/beacon/pages/page.ex
+++ b/lib/beacon/pages/page.ex
@@ -25,7 +25,7 @@ defmodule Beacon.Pages.Page do
     field :raw_schema, {:array, :map}, default: []
     field :order, :integer, default: 1
     field :status, Ecto.Enum, values: [:draft, :published], default: :draft
-    field :format, Beacon.Types.Atom, default: :heex
+    field :format, Beacon.Types.Atom, default: :markdown
     field :extra, :map, default: %{}
 
     belongs_to :layout, Layout


### PR DESCRIPTION
Most pages added so far are markdown, so we have a request to change the default to that instead of heex.

Eventually we can allow this default to be configured for each site, but it's currently a complicated implementation due to how beacon admin handles site selection.  It's probably best to wait until that functionality is improved before adding this into the site config.