### PR TITLE
backend arity fix

### DIFF
--- a/lib/beacon/admin/media_library/backend.ex
+++ b/lib/beacon/admin/media_library/backend.ex
@@ -8,16 +8,28 @@ defmodule Beacon.Admin.MediaLibrary.Backend do
   @spec validate_for_delivery(Beacon.Admin.MediaLibrary.UploadMetadata.t()) :: Beacon.Admin.MediaLibrary.UploadMetadata.t()
   def validate_for_delivery(%UploadMetadata{} = metadata) do
     Enum.reduce(metadata.config.validations, metadata, fn
-      validation, {md, config} -> validation.(md, config)
       validation, md -> validation.(md)
+    end)
+  end
+
+  @spec validate_for_delivery({Beacon.Admin.MediaLibrary.UploadMetadata.t(), any()}) :: Beacon.Admin.MediaLibrary.UploadMetadata.t()
+  def validate_for_delivery({%UploadMetadata{} = metadata, config}) do
+    Enum.reduce(metadata.config.validations, metadata, fn
+      validation, md -> validation.(md, config)
     end)
   end
 
   @spec send_to_cdns(Beacon.Admin.MediaLibrary.UploadMetadata.t()) :: Beacon.Admin.MediaLibrary.UploadMetadata.t()
   def send_to_cdns(%UploadMetadata{} = metadata) do
     Enum.reduce(metadata.config.backends, metadata, fn
-      backend, {md, config} -> backend.send_to_cdn(md, config)
       backend, md -> backend.send_to_cdn(md)
+    end)
+  end
+
+  @spec send_to_cdns({Beacon.Admin.MediaLibrary.UploadMetadata.t(), any()}) :: Beacon.Admin.MediaLibrary.UploadMetadata.t()
+  def send_to_cdns({%UploadMetadata{} = metadata, config}) do
+    Enum.reduce(metadata.config.backends, metadata, fn
+      backend, md -> backend.send_to_cdn(md, config)
     end)
   end
 end


### PR DESCRIPTION
Backends can be configured as a list of of modules or a list of {module, config} tuples.
The `Beacon.Admin.MediaLibrary.Backend` functions' params were broken with respect to the tuple implementation.
This was fixed by splitting the functions and pattern matching in the head of the function.