### PR TITLE
Add etag support for assets

### DIFF
--- a/lib/beacon/media_library/asset.ex
+++ b/lib/beacon/media_library/asset.ex
@@ -2,6 +2,7 @@ defmodule Beacon.MediaLibrary.Asset do
   @moduledoc false
 
   use Ecto.Schema
+  @derive BeaconWeb.Cache.Stale
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id

--- a/lib/beacon_web/cache.ex
+++ b/lib/beacon_web/cache.ex
@@ -1,0 +1,129 @@
+# Extracted code from
+# https://github.com/hexpm/hexpm/blob/main/lib/hexpm_web/controllers/controller_helpers.ex
+defmodule BeaconWeb.Cache do
+  import Plug.Conn
+  import Phoenix.Controller
+
+  @max_cache_age 60
+
+  def cache(conn, control, vary) do
+    conn
+    |> maybe_put_resp_header("cache-control", parse_control(control))
+    |> maybe_put_resp_header("vary", parse_vary(vary))
+  end
+
+  # privacy can be: `:public` or `:private`
+  def asset_cache(conn, privacy \\ :public) do
+    control = [privacy, "max-age": @max_cache_age]
+    vary = ["accept", "accept-encoding"]
+    cache(conn, control, vary)
+  end
+
+  defp parse_vary(nil), do: nil
+  defp parse_vary(vary), do: Enum.map_join(vary, ", ", &"#{&1}")
+
+  defp parse_control(nil), do: nil
+
+  defp parse_control(control) do
+    Enum.map_join(control, ", ", fn
+      atom when is_atom(atom) -> "#{atom}"
+      {key, value} -> "#{key}=#{value}"
+    end)
+  end
+
+  defp maybe_put_resp_header(conn, _header, nil), do: conn
+  defp maybe_put_resp_header(conn, header, value), do: put_resp_header(conn, header, value)
+
+  def when_stale(conn, entities, opts \\ [], fun) do
+    etag = etag(entities)
+    modified = if Keyword.get(opts, :modified, true), do: last_modified(entities)
+
+    conn =
+      conn
+      |> put_etag(etag)
+      |> put_last_modified(modified)
+
+    if fresh?(conn, etag: etag, modified: modified) do
+      send_resp(conn, 304, "")
+    else
+      fun.(conn)
+    end
+  end
+
+  defp put_etag(conn, nil) do
+    conn
+  end
+
+  defp put_etag(conn, etag) do
+    put_resp_header(conn, "etag", etag)
+  end
+
+  defp put_last_modified(conn, nil) do
+    conn
+  end
+
+  defp put_last_modified(conn, modified) do
+    put_resp_header(conn, "last-modified", :cowboy_clock.rfc1123(modified))
+  end
+
+  defp fresh?(conn, opts) do
+    not expired?(conn, opts)
+  end
+
+  defp expired?(conn, opts) do
+    modified_since = List.first(get_req_header(conn, "if-modified-since"))
+    none_match = List.first(get_req_header(conn, "if-none-match"))
+
+    if modified_since || none_match do
+      modified_since?(modified_since, opts[:modified]) or none_match?(none_match, opts[:etag])
+    else
+      true
+    end
+  end
+
+  defp modified_since?(header, last_modified) do
+    if header && last_modified do
+      modified_since = :httpd_util.convert_request_date(String.to_charlist(header))
+      modified_since = :calendar.datetime_to_gregorian_seconds(modified_since)
+      last_modified = :calendar.datetime_to_gregorian_seconds(last_modified)
+      last_modified > modified_since
+    else
+      false
+    end
+  end
+
+  defp none_match?(none_match, etag) do
+    if none_match && etag do
+      none_match = Plug.Conn.Utils.list(none_match)
+      etag not in none_match and "*" not in none_match
+    else
+      false
+    end
+  end
+
+  defp etag(schemas) do
+    binary =
+      schemas
+      |> List.wrap()
+      |> Enum.map(&BeaconWeb.Cache.Stale.etag/1)
+      |> List.flatten()
+      |> :erlang.term_to_binary()
+
+    :crypto.hash(:md5, binary)
+    |> Base.encode16(case: :lower)
+  end
+
+  def last_modified(schemas) do
+    schemas
+    |> List.wrap()
+    |> Enum.map(&BeaconWeb.Cache.Stale.last_modified/1)
+    |> List.flatten()
+    |> Enum.reject(&is_nil/1)
+    |> Enum.map(&time_to_erl/1)
+    |> Enum.max()
+  end
+
+  defp time_to_erl(%NaiveDateTime{} = datetime), do: NaiveDateTime.to_erl(datetime)
+  defp time_to_erl(%DateTime{} = datetime), do: NaiveDateTime.to_erl(datetime)
+  defp time_to_erl(%Date{} = date), do: {Date.to_erl(date), {0, 0, 0}}
+end

--- a/lib/beacon_web/cache.ex
+++ b/lib/beacon_web/cache.ex
@@ -49,7 +49,7 @@ defmodule BeaconWeb.Cache do
     end
   end
 
-  defp put_etag(conn, nil) do
+  defp put_etag(conn, "") do
     conn
   end
 

--- a/lib/beacon_web/cache.ex
+++ b/lib/beacon_web/cache.ex
@@ -2,7 +2,6 @@
 # https://github.com/hexpm/hexpm/blob/main/lib/hexpm_web/controllers/controller_helpers.ex
 defmodule BeaconWeb.Cache do
   import Plug.Conn
-  import Phoenix.Controller
 
   @max_cache_age 60
 

--- a/lib/beacon_web/cache/stale.ex
+++ b/lib/beacon_web/cache/stale.ex
@@ -1,0 +1,59 @@
+# Extracted code from
+# https://github.com/hexpm/hexpm/blob/main/lib/hexpm_web/stale.ex
+defprotocol BeaconWeb.Cache.Stale do
+  def etag(schema)
+  def last_modified(schema)
+end
+
+defimpl BeaconWeb.Cache.Stale, for: Atom do
+  def etag(nil), do: nil
+
+  # This is not a good solution because we don't know when a missing
+  # association was modified but this is the best we have for now
+  def last_modified(nil), do: ~N[0000-01-01 00:00:00]
+end
+
+defimpl BeaconWeb.Cache.Stale, for: Any do
+  defmacro __deriving__(module, _struct, opts) do
+    etag_keys = Keyword.get(opts, :etag, [:__struct__, :id, :updated_at])
+    last_modified_key = Keyword.get(opts, :last_modified, :updated_at)
+    assocs = Keyword.get(opts, :assocs, [])
+
+    quote do
+      defimpl BeaconWeb.Cache.Stale, for: unquote(module) do
+        alias BeaconWeb.Cache.Stale
+        alias BeaconWeb.Cache.Stale.Any
+
+        def etag(schema) do
+          assocs = unquote(assocs)
+          etag_keys = unquote(etag_keys)
+          [Map.take(schema, etag_keys), Any.recurse_fields(schema, assocs, &Stale.etag/1)]
+        end
+
+        def last_modified(schema) do
+          assocs = unquote(assocs)
+          last_modified_key = unquote(last_modified_key)
+          last_modified = fetch_last_modified(schema, last_modified_key)
+          [last_modified, Any.recurse_fields(schema, assocs, &Stale.last_modified/1)]
+        end
+
+        defp fetch_last_modified(_schema, nil), do: ~N[0000-01-01 00:00:00]
+        defp fetch_last_modified(schema, key), do: Map.fetch!(schema, key)
+      end
+    end
+  end
+
+  def etag(_), do: raise("not implemented")
+  def last_modified(_), do: raise("not implemented")
+
+  def recurse_fields(schema, keys, fun) do
+    Enum.map(keys, fn key ->
+      Map.fetch!(schema, key)
+      |> recurse_field(fun)
+    end)
+  end
+
+  defp recurse_field(%Ecto.Association.NotLoaded{}, _fun), do: []
+  defp recurse_field(schemas, fun) when is_list(schemas), do: Enum.map(schemas, fun)
+  defp recurse_field(schema, fun), do: fun.(schema)
+end

--- a/lib/beacon_web/controllers/media_library_controller.ex
+++ b/lib/beacon_web/controllers/media_library_controller.ex
@@ -6,14 +6,17 @@ defmodule BeaconWeb.MediaLibraryController do
   alias Beacon.MediaLibrary
   alias Beacon.MediaLibrary.Asset
 
-  def show(conn, %{"asset" => asset}) do
+  def show(conn, %{"asset" => asset_name}) do
     with %{params: %{"site" => site}} <- fetch_query_params(conn),
-         %Asset{file_body: file_body, media_type: media_type} <- MediaLibrary.get_asset(site, asset) do
-      conn
-      |> put_resp_header("content-type", "#{media_type}; charset=utf-8")
-      |> send_resp(200, file_body)
+         %Asset{file_body: file_body, media_type: media_type} = asset <- MediaLibrary.get_asset(site, asset_name) do
+      BeaconWeb.Cache.when_stale(conn, asset, fn conn ->
+        conn
+        |> put_resp_header("content-type", "#{media_type}; charset=utf-8")
+        |> BeaconWeb.Cache.asset_cache(:public)
+        |> send_resp(200, file_body)
+      end)
     else
-      _ -> raise BeaconWeb.NotFoundError, "asset #{inspect(asset)} not found"
+      _ -> raise BeaconWeb.NotFoundError, "asset #{inspect(asset_name)} not found"
     end
   end
 end


### PR DESCRIPTION
Grabbed code from:
https://github.com/hexpm/hexpm/

Allows us to etag any future schema and is aware of associations.
We could apply this page controllers, etc.