### PR TITLE
fix: remove requirement on :stylesheet_urls from Layout schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ beacon-*.tar
 /assets/node_modules
 # tailwind.install
 /assets/css/app.css
+/assets/tailwind.config.js
 
 # Dev temp files
 /dev/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.9" # optional since v1.27.0
+services:
+  db:
+    image: postgres:13.1
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.9" # optional since v1.27.0
+version: "3.9"
 services:
   db:
     image: postgres:13.1

--- a/lib/beacon/content/layout.ex
+++ b/lib/beacon/content/layout.ex
@@ -50,7 +50,6 @@ defmodule Beacon.Content.Layout do
   def changeset(%__MODULE__{} = layout, attrs) do
     layout
     |> cast(attrs, [:site, :title, :body, :meta_tags, :stylesheet_urls])
-    # TODO: make stylesheet optional
-    |> validate_required([:site, :title, :body, :stylesheet_urls])
+    |> validate_required([:site, :title, :body])
   end
 end

--- a/test/beacon_web/live/page_live_test.exs
+++ b/test/beacon_web/live/page_live_test.exs
@@ -167,6 +167,20 @@ defmodule BeaconWeb.Live.PageLiveTest do
       assert page_title(view) =~ "layout_title"
     end
 
+    test "on layout (without stylesheet)", %{conn: conn} do
+      # ensure no stylesheets are present
+      assert Beacon.Repo.all(Beacon.Content.Stylesheet) == []
+
+      # same test as above, as a sanity check
+      layout = published_layout_fixture(title: "layout_title")
+      page = published_page_fixture(layout_id: layout.id, title: nil, path: "/layout_title")
+      Beacon.Loader.load_page(page)
+
+      {:ok, view, _html} = live(conn, "/layout_title")
+
+      assert page_title(view) =~ "layout_title"
+    end
+
     test "on page overwrite layout", %{conn: conn} do
       stylesheet_fixture()
       layout = published_layout_fixture(title: "layout_title")


### PR DESCRIPTION
closes #150 

It turns out that the stylesheets were already optional as the changeset was configured.

An additional validation through either `validate_change` or a combination of `get_field`/`get_change` and `add_error` must be done if an array field is to be considered invalid on an empty list, but this is not a concern in any of the other schemas which I found in the code.