### PR TITLE
make sure we find published pages

### DIFF
--- a/lib/beacon/content.ex
+++ b/lib/beacon/content.ex
@@ -524,7 +524,7 @@ defmodule Beacon.Content do
   def list_published_pages(site) do
     events =
       from event in PageEvent,
-        where: event.site == ^site,
+        where: event.site == ^site and event.event == :published,
         distinct: [asc: event.page_id],
         order_by: [desc: event.inserted_at]
 


### PR DESCRIPTION
due to some data migration some events ended up
with the same timestamp which was causing this
query to return the created event since it was
inserted before and causing the page to not get loaded