### PR TITLE
Fix list_published_pages edge case and convert timestamps to utc_datetime_usec

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -6,8 +6,7 @@ config :beacon, :generators, binary_id: true
 
 config :phoenix, :json_library, Jason
 
-config :beacon, Beacon.Repo,
-  migration_timestamps: [type: :utc_datetime_usec]
+config :beacon, Beacon.Repo, migration_timestamps: [type: :utc_datetime_usec]
 
 if Mix.env() == :dev do
   esbuild = fn args ->

--- a/config/config.exs
+++ b/config/config.exs
@@ -6,6 +6,9 @@ config :beacon, :generators, binary_id: true
 
 config :phoenix, :json_library, Jason
 
+config :beacon, Beacon.Repo,
+  migration_timestamps: [type: :utc_datetime_usec]
+
 if Mix.env() == :dev do
   esbuild = fn args ->
     [

--- a/lib/beacon/admin/media_library.ex
+++ b/lib/beacon/admin/media_library.ex
@@ -112,12 +112,10 @@ defmodule Beacon.Admin.MediaLibrary do
 
   """
   def soft_delete_asset(%Asset{} = asset) do
-    now = DateTime.truncate(DateTime.utc_now(), :second)
-
     update =
       Repo.update_all(
         from(asset in Asset, where: asset.id == ^asset.id),
-        set: [deleted_at: now]
+        set: [deleted_at: DateTime.utc_now()]
       )
 
     case update do

--- a/lib/beacon/admin/media_library/asset.ex
+++ b/lib/beacon/admin/media_library/asset.ex
@@ -1,9 +1,8 @@
 defmodule Beacon.Admin.MediaLibrary.Asset do
-  use Ecto.Schema
-  import Ecto.Changeset
+  use Beacon.Schema
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
+  @type t :: %__MODULE__{}
+
   schema "beacon_assets" do
     field :file_body, :binary
     field :file_name, :string

--- a/lib/beacon/content.ex
+++ b/lib/beacon/content.ex
@@ -524,9 +524,9 @@ defmodule Beacon.Content do
   def list_published_pages(site) do
     events =
       from event in PageEvent,
-        where: event.site == ^site and event.event == :published,
+        where: event.site == ^site,
         distinct: [asc: event.page_id],
-        order_by: [desc: event.inserted_at]
+        order_by: fragment("inserted_at desc, case when event = 'published' then 0 else 1 end")
 
     Repo.all(
       from snapshot in PageSnapshot,

--- a/lib/beacon/content/component.ex
+++ b/lib/beacon/content/component.ex
@@ -11,13 +11,10 @@ defmodule Beacon.Content.Component do
   > in inconsistent behavior and crashes.
   """
 
-  use Ecto.Schema
-  import Ecto.Changeset
+  use Beacon.Schema
 
   @type t :: %__MODULE__{}
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
   schema "beacon_components" do
     field :body, :string
     field :name, :string

--- a/lib/beacon/content/layout.ex
+++ b/lib/beacon/content/layout.ex
@@ -11,8 +11,7 @@ defmodule Beacon.Content.Layout do
   > in inconsistent behavior and crashes.
   """
 
-  use Ecto.Schema
-  import Ecto.Changeset
+  use Beacon.Schema
 
   @version 1
 
@@ -23,12 +22,10 @@ defmodule Beacon.Content.Layout do
           body: String.t(),
           meta_tags: [map()],
           stylesheet_urls: [String.t()],
-          inserted_at: NaiveDateTime.t(),
-          updated_at: NaiveDateTime.t()
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
         }
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
   schema "beacon_layouts" do
     field :site, Beacon.Types.Site
     field :title, :string

--- a/lib/beacon/content/layout_event.ex
+++ b/lib/beacon/content/layout_event.ex
@@ -12,10 +12,8 @@ defmodule Beacon.Content.LayoutEvent do
 
   """
 
-  use Ecto.Schema
+  use Beacon.Schema
   alias Beacon.Content.Layout
-
-  @timestamps_opts type: :utc_datetime_usec
 
   @type t :: %__MODULE__{
           id: Ecto.UUID.t(),
@@ -23,11 +21,9 @@ defmodule Beacon.Content.LayoutEvent do
           layout_id: Ecto.UUID.t(),
           layout: Layout.t(),
           event: String.t(),
-          inserted_at: NaiveDateTime.t()
+          inserted_at: DateTime.t()
         }
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
   schema "beacon_layout_events" do
     field :site, Beacon.Types.Site
     field :event, Ecto.Enum, values: [:created, :published]

--- a/lib/beacon/content/layout_snapshot.ex
+++ b/lib/beacon/content/layout_snapshot.ex
@@ -12,9 +12,7 @@ defmodule Beacon.Content.LayoutSnapshot do
 
   """
 
-  use Ecto.Schema
-
-  @timestamps_opts type: :utc_datetime_usec
+  use Beacon.Schema
 
   @type t :: %__MODULE__{
           id: Ecto.UUID.t(),
@@ -24,11 +22,9 @@ defmodule Beacon.Content.LayoutSnapshot do
           layout: Beacon.Content.Layout.t(),
           event_id: Ecto.UUID.t(),
           event: Beacon.Content.LayoutEvent.t() | nil,
-          inserted_at: NaiveDateTime.t()
+          inserted_at: DateTime.t()
         }
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
   schema "beacon_layout_snapshots" do
     field :site, Beacon.Types.Site
     field :schema_version, :integer

--- a/lib/beacon/content/page.ex
+++ b/lib/beacon/content/page.ex
@@ -21,16 +21,13 @@ defmodule Beacon.Content.Page do
   > in inconsistent behavior and crashes.
   """
 
-  use Ecto.Schema
-  import Ecto.Changeset
+  use Beacon.Schema
   alias Beacon.Content
 
   @version 1
 
   @type t :: %__MODULE__{}
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
   schema "beacon_pages" do
     field :site, Beacon.Types.Site
     field :path, :string

--- a/lib/beacon/content/page_event.ex
+++ b/lib/beacon/content/page_event.ex
@@ -12,10 +12,8 @@ defmodule Beacon.Content.PageEvent do
 
   """
 
-  use Ecto.Schema
+  use Beacon.Schema
   alias Beacon.Content.Page
-
-  @timestamps_opts type: :utc_datetime_usec
 
   @typedoc """
   The event name. Can be one of :created, :published, :unpublished
@@ -28,11 +26,9 @@ defmodule Beacon.Content.PageEvent do
           page_id: Ecto.UUID.t(),
           page: Page.t(),
           event: event(),
-          inserted_at: NaiveDateTime.t()
+          inserted_at: DateTime.t()
         }
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
   schema "beacon_page_events" do
     field :site, Beacon.Types.Site
     field :event, Ecto.Enum, values: [:created, :published, :unpublished]

--- a/lib/beacon/content/page_snapshot.ex
+++ b/lib/beacon/content/page_snapshot.ex
@@ -12,9 +12,7 @@ defmodule Beacon.Content.PageSnapshot do
 
   """
 
-  use Ecto.Schema
-
-  @timestamps_opts type: :utc_datetime_usec
+  use Beacon.Schema
 
   @type t :: %__MODULE__{
           id: Ecto.UUID.t(),
@@ -24,11 +22,9 @@ defmodule Beacon.Content.PageSnapshot do
           page: Beacon.Content.Page.t(),
           event_id: Ecto.UUID.t(),
           event: Beacon.Content.PageEvent.t() | nil,
-          inserted_at: NaiveDateTime.t()
+          inserted_at: DateTime.t()
         }
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
   schema "beacon_page_snapshots" do
     field :site, Beacon.Types.Site
     field :schema_version, :integer

--- a/lib/beacon/content/snippets/helper.ex
+++ b/lib/beacon/content/snippets/helper.ex
@@ -11,12 +11,10 @@ defmodule Beacon.Content.Snippets.Helper do
   > in inconsistent behavior and crashes.
   """
 
-  use Ecto.Schema
+  use Beacon.Schema
 
   @type t :: %__MODULE__{}
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
   schema "beacon_snippet_helpers" do
     field :site, Beacon.Types.Site
     field :name, :string

--- a/lib/beacon/content/stylesheet.ex
+++ b/lib/beacon/content/stylesheet.ex
@@ -12,13 +12,10 @@ defmodule Beacon.Content.Stylesheet do
 
   """
 
-  use Ecto.Schema
-  import Ecto.Changeset
+  use Beacon.Schema
 
   @type t :: %__MODULE__{}
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
   schema "beacon_stylesheets" do
     field :content, :string
     field :name, :string

--- a/lib/beacon/media_library/asset.ex
+++ b/lib/beacon/media_library/asset.ex
@@ -1,11 +1,9 @@
 defmodule Beacon.MediaLibrary.Asset do
   @moduledoc false
 
-  use Ecto.Schema
+  use Beacon.Schema
   @derive BeaconWeb.Cache.Stale
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
   schema "beacon_assets" do
     field :file_body, :binary
     field :file_name, :string

--- a/lib/beacon/schema.ex
+++ b/lib/beacon/schema.ex
@@ -1,0 +1,14 @@
+defmodule Beacon.Schema do
+  @moduledoc false
+
+  defmacro __using__(_) do
+    quote do
+      use Ecto.Schema
+      import Ecto.Changeset
+      alias Ecto.Changeset
+      @primary_key {:id, :binary_id, autogenerate: true}
+      @foreign_key_type :binary_id
+      @timestamps_opts type: :utc_datetime_usec
+    end
+  end
+end

--- a/priv/repo/migrations/20230630205632_convert_timestamps_to_utc_datetime_usec.exs
+++ b/priv/repo/migrations/20230630205632_convert_timestamps_to_utc_datetime_usec.exs
@@ -1,0 +1,52 @@
+defmodule Beacon.Repo.Migrations.ConvertTimestampsToUtcDatetimeUsec do
+  use Ecto.Migration
+
+  defp convert(table) do
+    alter table(table) do
+      modify :inserted_at, :utc_datetime_usec
+      modify :updated_at, :utc_datetime_usec
+    end
+
+    query = """
+      SELECT id, inserted_at, updated_at FROM #{table}
+    """
+
+    types = %{id: :binary_id, inserted_at: :utc_datetime_usec, updated_at: :utc_datetime_usec}
+
+    case repo().query(query) do
+      {:ok, result} ->
+        for row <- result.rows do
+          %{id: id, inserted_at: inserted_at, updated_at: updated_at} = repo().load(types, {result.columns, row})
+          {:ok, id} = Ecto.UUID.dump(id)
+
+          execute(fn ->
+            repo().query!(
+              """
+              UPDATE #{table}
+                 SET inserted_at = $1, updated_at = $2
+               WHERE id = $3
+              """,
+              [inserted_at, updated_at, id],
+              log: :info
+            )
+          end)
+        end
+
+      _ ->
+        :skip
+    end
+  end
+
+  def up do
+    convert("beacon_pages")
+    convert("beacon_layouts")
+    convert("beacon_components")
+    convert("beacon_page_versions")
+    convert("beacon_stylesheets")
+    convert("beacon_snippet_helpers")
+    convert("beacon_assets")
+  end
+
+  def down do
+  end
+end

--- a/test/beacon/content_test.exs
+++ b/test/beacon/content_test.exs
@@ -77,7 +77,7 @@ defmodule Beacon.ContentTest do
       assert %PageSnapshot{page: %Page{title: "snapshot test"}} = Repo.one(PageSnapshot)
     end
 
-    test "list published pages" do
+    test "list_published_pages" do
       # publish page_a twice
       page_a = page_fixture(path: "/a", title: "page_a v1")
       {:ok, page_a} = Content.publish_page(page_a)
@@ -93,6 +93,20 @@ defmodule Beacon.ContentTest do
       _page_c = page_fixture(path: "/c", title: "page_c v1")
 
       assert [%Page{title: "page_a v2"}] = Content.list_published_pages(:my_site)
+    end
+
+    test "list_published_pages with same inserted_at missing usec" do
+      page = page_fixture(path: "/d", title: "page v1")
+      Beacon.Repo.query!("UPDATE beacon_page_events SET inserted_at = '2020-01-01'", [])
+      Beacon.Repo.query!("UPDATE beacon_page_snapshots SET inserted_at = '2020-01-01'", [])
+
+      assert Content.list_published_pages(:my_site) == []
+
+      {:ok, _page} = Content.publish_page(page)
+      Beacon.Repo.query!("UPDATE beacon_page_events SET inserted_at = '2020-01-01'", [])
+      Beacon.Repo.query!("UPDATE beacon_page_snapshots SET inserted_at = '2020-01-01'", [])
+
+      assert [%Page{title: "page v1"}] = Content.list_published_pages(:my_site)
     end
 
     test "get_page_status" do


### PR DESCRIPTION
- Make sure `Beacon.Content.list_published_pages/1` finds the published page when `inserted_at` is equal.
- And another related change is to use `utc_datetime_usec` by default for timestamps to avoid such order issues.

Using DateTime over NaiveDateTime since it makes more sense and adding usec because it may be useful.

- https://elixirforum.com/t/why-use-utc-datetime-over-naive-datetime-for-ecto/32532/4
- https://elixirforum.com/t/why-cant-timestamptz-be-set-up-as-default-timestamp-for-migrations-in-config/25778/2