### PR TITLE
create Beacon.MediaTypes.normalize/1

### DIFF
--- a/lib/beacon/media_library/upload_metadata.ex
+++ b/lib/beacon/media_library/upload_metadata.ex
@@ -4,6 +4,7 @@ defmodule Beacon.MediaLibrary.UploadMetadata do
   """
 
   alias Beacon.MediaLibrary.Asset
+  alias Beacon.MediaTypes
 
   defstruct [:site, :config, :allowed_media_accept_types, :path, :name, :media_type, :size, :output, :resource]
 
@@ -29,7 +30,12 @@ defmodule Beacon.MediaLibrary.UploadMetadata do
 
     config = Beacon.Config.fetch!(site)
     name = Keyword.get(opts, :name, Path.basename(path))
-    media_type = Keyword.get(opts, :media_type, media_type_from_name(name))
+
+    media_type =
+      opts
+      |> Keyword.get(:media_type, media_type_from_name(name))
+      |> MediaTypes.normalize()
+
     size = Keyword.get(opts, :size)
     output = Keyword.get(opts, :output)
     resource = Keyword.get(opts, :resource, Asset.bare_changeset())

--- a/lib/beacon/media_types.ex
+++ b/lib/beacon/media_types.ex
@@ -1,0 +1,10 @@
+defmodule Beacon.MediaTypes do
+  # Browsers' media types are often out of date,
+  # returning and empty string or a deprecated assignation
+  # which the elixir MIME library no longer supports.
+  def normalize(""), do: nil
+
+  def normalize("application/font-woff"), do: "font/woff"
+
+  def normalize(media_type), do: media_type
+end

--- a/lib/beacon/media_types.ex
+++ b/lib/beacon/media_types.ex
@@ -14,8 +14,6 @@ defmodule Beacon.MediaTypes do
   which the Elixir MIME library no longer supports.
   """
   def normalize(""), do: nil
-
   def normalize("application/font-woff"), do: "font/woff"
-
   def normalize(media_type), do: media_type
 end

--- a/lib/beacon/media_types.ex
+++ b/lib/beacon/media_types.ex
@@ -9,9 +9,9 @@ defmodule Beacon.MediaTypes do
   """
 
   @doc """
-    Browsers' media types are often out of date,
-    returning and empty string or a deprecated media type
-    which the elixir MIME library no longer supports.
+  Browsers' media types are often out of date,
+  returning an empty string or a deprecated media type
+  which the Elixir MIME library no longer supports.
   """
   def normalize(""), do: nil
 

--- a/lib/beacon/media_types.ex
+++ b/lib/beacon/media_types.ex
@@ -1,7 +1,18 @@
 defmodule Beacon.MediaTypes do
-  # Browsers' media types are often out of date,
-  # returning and empty string or a deprecated assignation
-  # which the elixir MIME library no longer supports.
+  @moduledoc """
+    #{__MODULE__} serves as a context to encapsulate business logic
+    around media types that is not handled by the MIME library.
+
+    Primary concerns:
+    - Convenience functions
+    - Functions to handle edge cases between the browser and elxir
+  """
+
+  @doc """
+    Browsers' media types are often out of date,
+    returning and empty string or a deprecated media type
+    which the elixir MIME library no longer supports.
+  """
   def normalize(""), do: nil
 
   def normalize("application/font-woff"), do: "font/woff"

--- a/lib/beacon/media_types.ex
+++ b/lib/beacon/media_types.ex
@@ -1,11 +1,11 @@
 defmodule Beacon.MediaTypes do
   @moduledoc """
-    #{__MODULE__} serves as a context to encapsulate business logic
-    around media types that is not handled by the MIME library.
+  #{__MODULE__} serves as a context to encapsulate business logic
+  around media types that is not handled by the MIME library.
 
-    Primary concerns:
+  Primary concerns:
     - Convenience functions
-    - Functions to handle edge cases between the browser and elxir
+    - Functions to handle edge cases between the browser and Elixir
   """
 
   @doc """

--- a/lib/beacon_web/live/admin/media_library_live/upload_form_component.ex
+++ b/lib/beacon_web/live/admin/media_library_live/upload_form_component.ex
@@ -83,8 +83,7 @@ defmodule BeaconWeb.Admin.MediaLibraryLive.UploadFormComponent do
           site -> site
         end
 
-      media_type =
-        uploaded_assets =
+      uploaded_assets =
         consume_uploaded_entries(socket, :asset, fn %{path: path}, _entry ->
           asset =
             site

--- a/lib/beacon_web/live/admin/media_library_live/upload_form_component.ex
+++ b/lib/beacon_web/live/admin/media_library_live/upload_form_component.ex
@@ -83,7 +83,8 @@ defmodule BeaconWeb.Admin.MediaLibraryLive.UploadFormComponent do
           site -> site
         end
 
-      uploaded_assets =
+      media_type =
+        uploaded_assets =
         consume_uploaded_entries(socket, :asset, fn %{path: path}, _entry ->
           asset =
             site


### PR DESCRIPTION
  Browsers' media types are often out of date, returning and empty string or a deprecated assignation which the elixir MIME library no longer supports.

created Beacon.MediaTypes.normalize/1 which handles these cases