### PR TITLE
Convert between snake_case and camelCase automatically.

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -58,6 +58,8 @@ defmodule SamplePhoenixWeb.Router do
 
   pipeline :api do
     plug :accepts, ["json"]
+    plug Accent.Plug.Request, default_case: Accent.Case.Snake
+    plug Accent.Plug.Response, default_case: Accent.Case.Camel, json_codec: Jason
   end
 
   scope "/" do

--- a/dev.exs
+++ b/dev.exs
@@ -59,8 +59,6 @@ defmodule SamplePhoenixWeb.Router do
   pipeline :api do
     plug :accepts, ["json"]
     plug BeaconWeb.API.Plug
-    # plug Accent.Plug.Request, default_case: Accent.Case.Snake
-    # plug Accent.Plug.Response, default_case: Accent.Case.Camel, json_codec: Jason
   end
 
   scope "/" do

--- a/dev.exs
+++ b/dev.exs
@@ -58,8 +58,9 @@ defmodule SamplePhoenixWeb.Router do
 
   pipeline :api do
     plug :accepts, ["json"]
-    plug Accent.Plug.Request, default_case: Accent.Case.Snake
-    plug Accent.Plug.Response, default_case: Accent.Case.Camel, json_codec: Jason
+    plug BeaconWeb.API.Plug
+    # plug Accent.Plug.Request, default_case: Accent.Case.Snake
+    # plug Accent.Plug.Response, default_case: Accent.Case.Camel, json_codec: Jason
   end
 
   scope "/" do

--- a/guides/introduction/api.md
+++ b/guides/introduction/api.md
@@ -9,8 +9,11 @@ use Beacon.Router
 
 scope "/api" do
   pipe_through :api
+  plug BeaconWeb.API.Plug
   beacon_api "/beacon"
 end
 ```
+
+The `plug BeaconWeb.API.Plug` is needed only if the client consuming this API wants to send or receive camelCased json keys.
 
 Check out `/lib/beacon/router.ex` for currently available API endpoints.

--- a/lib/beacon/blueprint_converter.ex
+++ b/lib/beacon/blueprint_converter.ex
@@ -55,6 +55,9 @@ defmodule Beacon.BlueprintConverter do
   defp render_node(node) when is_binary(node), do: node
   # Special case to just output content as HTML
   defp render_node(%{"tag" => "raw", "content" => content}), do: content
+  defp render_node(%{"tag" => "img", "attributes" => attributes}) do
+    "<img#{render_attrs(attributes)}/>"
+  end
 
   defp render_node(%{"tag" => tag, "attributes" => attributes, "content" => content}) do
     """

--- a/lib/beacon/blueprint_converter.ex
+++ b/lib/beacon/blueprint_converter.ex
@@ -55,6 +55,7 @@ defmodule Beacon.BlueprintConverter do
   defp render_node(node) when is_binary(node), do: node
   # Special case to just output content as HTML
   defp render_node(%{"tag" => "raw", "content" => content}), do: content
+
   defp render_node(%{"tag" => "img", "attributes" => attributes}) do
     "<img#{render_attrs(attributes)}/>"
   end

--- a/lib/beacon/plug.ex
+++ b/lib/beacon/plug.ex
@@ -1,0 +1,5 @@
+defmodule BeaconWeb.API.Plug do
+  use Plug.Builder
+  plug Accent.Plug.Request, default_case: Accent.Case.Snake
+  plug Accent.Plug.Response, default_case: Accent.Case.Camel, json_codec: Jason
+end

--- a/lib/beacon_web/controllers/api/component_controller.ex
+++ b/lib/beacon_web/controllers/api/component_controller.ex
@@ -20,7 +20,7 @@ defmodule BeaconWeb.API.ComponentController do
   end
 
   @spec create(Plug.Conn.t(), map) :: Plug.Conn.t()
-  def create(conn, %{"definitionId" => component_definition_id, "pageId" => page_id}) do
+  def create(conn, %{"definition_id" => component_definition_id, "page_id" => page_id}) do
     definition = Content.get_component_by(:dev, id: component_definition_id)
     page = Content.get_page!(page_id)
     [parsed_template] = BlueprintConverter.parse_html(definition.body)
@@ -30,12 +30,12 @@ defmodule BeaconWeb.API.ComponentController do
     render(conn, :show, page: page)
   end
 
-  def create(conn, %{"definitionId" => component_definition_id}) do
+  def create(conn, %{"definition_id" => component_definition_id}) do
     definition = Content.get_component_by(:dev, id: component_definition_id)
     [parsed_template] = BlueprintConverter.parse_html(definition.body)
     component_data = build_component(parsed_template)
     rendered_html = BlueprintConverter.generate_html(UUID.generate(), component_data)
-    render(conn, :show, renderedHtml: rendered_html)
+    render(conn, :show, rendered_html: rendered_html)
   end
 
   defp build_component(entry) when is_binary(entry), do: entry

--- a/lib/beacon_web/controllers/api/component_json.ex
+++ b/lib/beacon_web/controllers/api/component_json.ex
@@ -3,25 +3,25 @@ defmodule BeaconWeb.API.ComponentJSON do
 
   def index(%{component_definitions: definitions}) do
     %{
-      menuCategories: [
+      menu_categories: [
         %{
           name: "Base",
           items: for(category <- Component.categories(), do: %{id: category, name: category})
         }
       ],
-      componentDefinitions: for(definition <- definitions, do: definition_data(definition))
+      component_definitions: for(definition <- definitions, do: definition_data(definition))
     }
   end
 
   def show(%{page: page}) do
     %{
-      renderedHtml: page.template
+      rendered_html: page.template
     }
   end
 
-  def show(%{renderedHtml: rendered_html}) do
+  def show(%{rendered_html: rendered_html}) do
     %{
-      renderedHtml: rendered_html
+      rendered_html: rendered_html
     }
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -34,6 +34,7 @@ defmodule Beacon.MixProject do
 
   defp deps do
     [
+      {:accent, "~> 1.1"},
       {:brotli, "~> 0.3.2"},
       {:bypass, "~> 2.1", only: :test},
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "accent": {:hex, :accent, "1.1.1", "20257356446d45078b19b91608f74669b407b39af891ee3db9ee6824d1cae19d", [:mix], [{:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}, {:plug, "~> 1.3", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm", "6d5afa50d4886e3370e04fa501468cbaa6c4b5fe926f72ccfa844ad9e259adae"},
   "brotli": {:hex, :brotli, "0.3.2", "59cf45a399098516f1d34f70d8e010e5c9bf326659d3ef34c7cc56793339002b", [:rebar3], [], "hexpm", "9ec3ef9c753f80d0c657b4905193c55e5198f169fa1d1c044d8601d4d931a2ad"},
   "bunt": {:hex, :bunt, "0.2.1", "e2d4792f7bc0ced7583ab54922808919518d0e57ee162901a16a1b6664ef3b14", [:mix], [], "hexpm", "a330bfb4245239787b15005e66ae6845c9cd524a288f0d141c148b02603777a5"},
   "bypass": {:hex, :bypass, "2.1.0", "909782781bf8e20ee86a9cabde36b259d44af8b9f38756173e8f5e2e1fabb9b1", [:mix], [{:plug, "~> 1.7", [hex: :plug, repo: "hexpm", optional: false]}, {:plug_cowboy, "~> 2.0", [hex: :plug_cowboy, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "d9b5df8fa5b7a6efa08384e9bbecfe4ce61c77d28a4282f79e02f1ef78d96b80"},


### PR DESCRIPTION
Closes #300

Internally elixir uses snake_case consistently, but most JS APIs send and receive camelCase. A new plug makes the translation when sending or receiving transparently.