### PR TITLE
Move layout and page template validation to context

### DIFF
--- a/lib/beacon/content/layout.ex
+++ b/lib/beacon/content/layout.ex
@@ -48,29 +48,5 @@ defmodule Beacon.Content.Layout do
     layout
     |> cast(attrs, [:site, :title, :body, :meta_tags, :stylesheet_urls])
     |> validate_required([:site, :title, :body])
-    |> validate_body()
   end
-
-  defp validate_body(changeset) do
-    site = Changeset.get_field(changeset, :site)
-    body = Changeset.get_field(changeset, :body, "")
-    do_validate_body(changeset, site, body)
-  end
-
-  defp do_validate_body(changeset, site, body) when is_atom(site) and is_binary(body) do
-    metadata = %Beacon.Template.LoadMetadata{site: site, path: ""}
-
-    case Beacon.Template.HEEx.compile(body, metadata) do
-      {:cont, _ast} ->
-        changeset
-
-      {:halt, %{description: description}} ->
-        add_error(changeset, :body, "invalid", compilation_error: description)
-
-      {:halt, _} ->
-        add_error(changeset, :body, "invalid")
-    end
-  end
-
-  defp do_validate_body(changeset, _site, _body), do: changeset
 end

--- a/lib/beacon/content/page.ex
+++ b/lib/beacon/content/page.ex
@@ -93,7 +93,6 @@ defmodule Beacon.Content.Page do
     |> validate_string([:path])
     |> foreign_key_constraint(:layout_id)
     |> remove_empty_meta_attributes(:meta_tags)
-    |> validate_template()
   end
 
   # TODO: The inclusion of the fields [:title, :description, :meta_tags] here requires some more consideration, but we
@@ -124,7 +123,6 @@ defmodule Beacon.Content.Page do
     |> validate_raw_schema(attrs["raw_schema"])
     |> remove_all_newlines([:description])
     |> remove_empty_meta_attributes(:meta_tags)
-    |> validate_template()
     |> Content.PageField.apply_changesets(page.site, extra_attrs)
   end
 
@@ -186,43 +184,6 @@ defmodule Beacon.Content.Page do
     case Jason.decode(raw_schema) do
       {:ok, raw_schema} -> put_change(changeset, :raw_schema, raw_schema)
       {:error, _} -> add_error(changeset, :raw_schema, "invalid schema")
-    end
-  end
-
-  defp validate_template(changeset) do
-    site = Changeset.get_field(changeset, :site)
-    path = Changeset.get_field(changeset, :path, "")
-    format = Changeset.get_field(changeset, :format)
-    template = Changeset.get_field(changeset, :template, "")
-    do_validate_template(changeset, site, path, format, template)
-  end
-
-  defp do_validate_template(changeset, site, path, format, template) when is_atom(site) and is_atom(format) and is_binary(template) do
-    metadata = %Beacon.Template.LoadMetadata{site: site, path: path}
-
-    case validate_with_format(format, template, metadata) do
-      {:cont, _} ->
-        changeset
-
-      {:halt, %{description: description}} ->
-        add_error(changeset, :template, "invalid", compilation_error: description)
-
-      {:halt, %{message: message}} ->
-        add_error(changeset, :template, "invalid", compilation_error: message)
-
-      {:halt, _} ->
-        add_error(changeset, :template, "invalid")
-    end
-  end
-
-  defp do_validate_template(changeset, _site, _path, _format, _template), do: changeset
-
-  defp validate_with_format(format, template, metadata) do
-    case format do
-      :heex -> Beacon.Template.HEEx.compile(template, metadata)
-      :markdown -> Beacon.Template.Markdown.convert_to_html(template, metadata)
-      # TODO: execute template validation for custom engines provived by users
-      _ -> {:cont, :skip}
     end
   end
 end


### PR DESCRIPTION
The same pattern used on page variants, which is more effective since it only validates when necessary and not on every change.