### PR TITLE
Rename layout.body to layout.template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,4 +74,4 @@ mix test
 iex -S mix dev
 ```
 
-Check out https://github.com/BeaconCMS/beacon/blob/main/dev.exs and visit http://localhost:4000/dev/home
+Check out https://github.com/BeaconCMS/beacon/blob/main/dev.exs and visit http://localhost:4001/dev/home

--- a/dev.exs
+++ b/dev.exs
@@ -168,7 +168,7 @@ seeds = fn ->
         %{"name" => "layout-meta-tag-two", "content" => "value"}
       ],
       stylesheet_urls: [],
-      body: """
+      template: """
       <%= @inner_content %>
       """
     })
@@ -351,7 +351,7 @@ seeds = fn ->
       site: "other",
       title: "other",
       stylesheet_urls: [],
-      body: """
+      template: """
       <%= @inner_content %>
       """
     })

--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -238,7 +238,7 @@ For more info on site options, check out `Beacon.start_link/1`.
         site: "<%= site %>",
         title: "Sample Home Page",
         stylesheet_urls: [],
-        body: """
+        template: """
         <header>
           Header
         </header>

--- a/lib/beacon/content.ex
+++ b/lib/beacon/content.ex
@@ -155,9 +155,9 @@ defmodule Beacon.Content do
 
   defp validate_layout_template(changeset) do
     site = Changeset.get_field(changeset, :site)
-    body = Changeset.get_field(changeset, :body)
+    template = Changeset.get_field(changeset, :template)
     metadata = %Beacon.Template.LoadMetadata{site: site, path: "nopath"}
-    do_validate_template(changeset, :body, :heex, body, metadata)
+    do_validate_template(changeset, :template, :heex, template, metadata)
   end
 
   @doc false

--- a/lib/beacon/content.ex
+++ b/lib/beacon/content.ex
@@ -86,7 +86,7 @@ defmodule Beacon.Content do
     changeset = Layout.changeset(%Layout{}, attrs)
 
     Repo.transact(fn ->
-      with {:ok, ^changeset} <- validate_layout_body(changeset),
+      with {:ok, ^changeset} <- validate_layout_template(changeset),
            {:ok, layout} <- Repo.insert(changeset),
            {:ok, _event} <- create_layout_event(layout, "created") do
         {:ok, layout}
@@ -120,7 +120,7 @@ defmodule Beacon.Content do
   def update_layout(%Layout{} = layout, attrs) do
     changeset = Layout.changeset(layout, attrs)
 
-    with {:ok, ^changeset} <- validate_layout_body(changeset) do
+    with {:ok, ^changeset} <- validate_layout_template(changeset) do
       Repo.update(changeset)
     end
   end
@@ -136,7 +136,7 @@ defmodule Beacon.Content do
     changeset = Layout.changeset(layout, %{})
 
     Repo.transact(fn ->
-      with {:ok, ^changeset} <- validate_layout_body(changeset),
+      with {:ok, ^changeset} <- validate_layout_template(changeset),
            {:ok, event} <- create_layout_event(layout, "published"),
            {:ok, _snapshot} <- create_layout_snapshot(layout, event) do
         :ok = PubSub.layout_published(layout)
@@ -153,7 +153,7 @@ defmodule Beacon.Content do
     |> publish_layout()
   end
 
-  defp validate_layout_body(changeset) do
+  defp validate_layout_template(changeset) do
     site = Changeset.get_field(changeset, :site)
     body = Changeset.get_field(changeset, :body)
     metadata = %Beacon.Template.LoadMetadata{site: site, path: "nopath"}

--- a/lib/beacon/content/layout.ex
+++ b/lib/beacon/content/layout.ex
@@ -19,7 +19,7 @@ defmodule Beacon.Content.Layout do
           id: String.t(),
           site: Beacon.Types.Site.t(),
           title: String.t(),
-          body: String.t(),
+          template: String.t(),
           meta_tags: [map()],
           stylesheet_urls: [String.t()],
           inserted_at: DateTime.t(),
@@ -29,7 +29,7 @@ defmodule Beacon.Content.Layout do
   schema "beacon_layouts" do
     field :site, Beacon.Types.Site
     field :title, :string
-    field :body, :string
+    field :template, :string
     field :meta_tags, {:array, :map}, default: []
     field :stylesheet_urls, {:array, :string}, default: []
 
@@ -46,7 +46,7 @@ defmodule Beacon.Content.Layout do
   @doc false
   def changeset(%__MODULE__{} = layout, attrs) do
     layout
-    |> cast(attrs, [:site, :title, :body, :meta_tags, :stylesheet_urls])
-    |> validate_required([:site, :title, :body])
+    |> cast(attrs, [:site, :title, :template, :meta_tags, :stylesheet_urls])
+    |> validate_required([:site, :title, :template])
   end
 end

--- a/lib/beacon/loader/layout_module_loader.ex
+++ b/lib/beacon/loader/layout_module_loader.ex
@@ -29,7 +29,7 @@ defmodule Beacon.Loader.LayoutModuleLoader do
 
   defp render_layout(layout) do
     file = "site-#{layout.site}-layout-#{layout.title}"
-    ast = Beacon.Template.HEEx.compile_heex_template!(file, layout.body)
+    ast = Beacon.Template.HEEx.compile_heex_template!(file, layout.template)
 
     quote do
       def render(unquote(layout.id), var!(assigns)) when is_map(var!(assigns)) do

--- a/lib/beacon/tailwind_compiler.ex
+++ b/lib/beacon/tailwind_compiler.ex
@@ -147,7 +147,7 @@ defmodule Beacon.TailwindCompiler do
       Task.async(fn ->
         Enum.map(Content.list_layouts(site, per_page: :infinity), fn layout ->
           layout_path = Path.join(tmp_dir, "#{site}_layout_#{remove_special_chars(layout.title)}.template")
-          File.write!(layout_path, layout.body)
+          File.write!(layout_path, layout.template)
           layout_path
         end)
       end),

--- a/priv/repo/migrations/20230808180704_rename_layout_body_to_template.exs
+++ b/priv/repo/migrations/20230808180704_rename_layout_body_to_template.exs
@@ -1,0 +1,7 @@
+defmodule Beacon.Repo.Migrations.RenameLayoutBodyToTemplate do
+  use Ecto.Migration
+
+  def change do
+    rename table(:beacon_layouts), :body, to: :template
+  end
+end

--- a/priv/templates/install/seeds.exs
+++ b/priv/templates/install/seeds.exs
@@ -27,7 +27,7 @@ layout =
     site: "<%= site %>",
     title: "Sample Home Page",
     stylesheet_urls: [],
-    body: """
+    template: """
     <header>
       Header
     </header>

--- a/test/beacon/content_test.exs
+++ b/test/beacon/content_test.exs
@@ -70,8 +70,8 @@ defmodule Beacon.ContentTest do
     end
 
     test "validate body heex on create" do
-      assert {:error, %Ecto.Changeset{errors: [body: {"invalid", [compilation_error: compilation_error]}]}} =
-               Content.create_layout(%{site: :test, title: "test", body: "<div"})
+      assert {:error, %Ecto.Changeset{errors: [template: {"invalid", [compilation_error: compilation_error]}]}} =
+               Content.create_layout(%{site: :test, title: "test", template: "<div"})
 
       assert compilation_error =~ "expected closing `>`"
     end
@@ -79,8 +79,8 @@ defmodule Beacon.ContentTest do
     test "validate body heex on update" do
       layout = layout_fixture()
 
-      assert {:error, %Ecto.Changeset{errors: [body: {"invalid", [compilation_error: compilation_error]}]}} =
-               Content.update_layout(layout, %{body: "<div"})
+      assert {:error, %Ecto.Changeset{errors: [template: {"invalid", [compilation_error: compilation_error]}]}} =
+               Content.update_layout(layout, %{template: "<div"})
 
       assert compilation_error =~ "expected closing `>`"
     end
@@ -89,10 +89,10 @@ defmodule Beacon.ContentTest do
       layout = layout_fixture()
 
       # simulate incorrect data inserted manually
-      {1, nil} = Repo.update_all(Layout, set: [body: "<div"])
+      {1, nil} = Repo.update_all(Layout, set: [template: "<div"])
       layout = Repo.reload(layout)
 
-      assert {:error, %Ecto.Changeset{errors: [body: {"invalid", [compilation_error: compilation_error]}]}} = Content.publish_layout(layout)
+      assert {:error, %Ecto.Changeset{errors: [template: {"invalid", [compilation_error: compilation_error]}]}} = Content.publish_layout(layout)
 
       assert compilation_error =~ "expected closing `>`"
     end

--- a/test/beacon/content_test.exs
+++ b/test/beacon/content_test.exs
@@ -18,7 +18,7 @@ defmodule Beacon.ContentTest do
       Content.create_layout!(%{
         site: "my_site",
         title: "test",
-        body: "<p>layout</p>"
+        template: "<p>layout</p>"
       })
 
       assert %LayoutEvent{event: :created} = Repo.one(LayoutEvent)

--- a/test/beacon/loader_test.exs
+++ b/test/beacon/loader_test.exs
@@ -29,7 +29,7 @@ defmodule Beacon.LoaderTest do
 
       layout =
         layout_fixture(
-          body: """
+          template: """
           <header>layout_v1</header>
           <%= @inner_content %>
           """
@@ -75,7 +75,7 @@ defmodule Beacon.LoaderTest do
 
       {:ok, layout} =
         Content.update_layout(layout, %{
-          body: """
+          template: """
           <header>layout_v2</header>
           <%= @inner_content %>
           """
@@ -84,7 +84,7 @@ defmodule Beacon.LoaderTest do
       Content.publish_layout(layout)
 
       Content.update_layout(layout, %{
-        body: """
+        template: """
         <header>layout_v3_unpublished</header>
         <%= @inner_content %>
         """

--- a/test/beacon/tailwind_compiler_test.exs
+++ b/test/beacon/tailwind_compiler_test.exs
@@ -18,7 +18,7 @@ defmodule Beacon.TailwindCompilerTest do
 
     layout =
       layout_fixture(
-        body: """
+        template: """
         <header class="text-gray-100">Page header</header>
         <%= @inner_content %>
         """

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -38,7 +38,7 @@ defmodule Beacon.Fixtures do
       title: "Sample Home Page",
       meta_tags: [],
       stylesheet_urls: [],
-      body: """
+      template: """
       <header>Page header</header>
       <%= @inner_content %>
       <footer>Page footer</footer>


### PR DESCRIPTION
Fixes https://github.com/BeaconCMS/beacon/issues/311

Adding a new migration to alter the column name in the table causes the older migration files to fail. Not sure what's the best way around this, so I just modified the previous migration files. 