### PR TITLE
Implement page compilation on demand

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -264,6 +264,10 @@ seeds = fn ->
           <p>From dynamic_helper:</p>
           <%= dynamic_helper("upcase", %{name: "beacon"}) %>
         </div>
+
+        <div>
+          <p>RANDOM:<%= Enum.random(1..100) %></p>
+        </div>
       </main>
       """,
       helpers: [

--- a/lib/beacon/application.ex
+++ b/lib/beacon/application.ex
@@ -14,8 +14,7 @@ defmodule Beacon.Application do
       Beacon.Repo
     ]
 
-    # We store routes by order and length so the most visited pages will likely be in the first rows
-    :ets.new(:beacon_pages, [:ordered_set, :named_table, :public, read_concurrency: true])
+    Beacon.Router.init()
 
     :ets.new(:beacon_assets, [:set, :named_table, :public, read_concurrency: true])
 

--- a/lib/beacon/config.ex
+++ b/lib/beacon/config.ex
@@ -94,7 +94,7 @@ defmodule Beacon.Config do
                 {identifier :: atom(),
                  fun ::
                    (template :: String.t(), Beacon.Template.LoadMetadata.t() ->
-                      {:cont, Beacon.Template.t()} | {:halt, Beacon.Template.t()} | {:halt, Exception.t()})}
+                      {:cont, String.t() | Beacon.Template.t()} | {:halt, String.t() | Beacon.Template.t()} | {:halt, Exception.t()})}
               ]}
            ]}
           | {:render_template,

--- a/lib/beacon/config.ex
+++ b/lib/beacon/config.ex
@@ -93,7 +93,7 @@ defmodule Beacon.Config do
               [
                 {identifier :: atom(),
                  fun ::
-                   (Beacon.Template.t(), Beacon.Template.LoadMetadata.t() ->
+                   (template :: String.t(), Beacon.Template.LoadMetadata.t() ->
                       {:cont, Beacon.Template.t()} | {:halt, Beacon.Template.t()} | {:halt, Exception.t()})}
               ]}
            ]}
@@ -168,14 +168,8 @@ defmodule Beacon.Config do
   ]
 
   @default_render_template [
-    {:heex,
-     [
-       eval_heex_ast: &Beacon.Template.HEEx.eval_ast/2
-     ]},
-    {:markdown,
-     [
-       eval_heex_ast: &Beacon.Template.HEEx.eval_ast/2
-     ]}
+    {:heex, []},
+    {:markdown, []}
   ]
 
   @default_media_types ["image/jpeg", "image/gif", "image/png", "image/webp", ".pdf"]
@@ -283,15 +277,14 @@ defmodule Beacon.Config do
           load_template: [
             {:custom_format,
              [
-               validate: fn template, _metadata -> MyEngine.validate(template) end
+               validate: fn template, _metadata -> MyEngine.validate(template) end,
+               build_rendered: fn template, _metadata -> %Phoenix.LiveView.Rendered{static: template}  end,
              ]}
           ],
           render_template: [
             {:custom_format,
              [
-               assigns: fn template, %{assigns: assigns} -> MyEngine.parse_to_html(template, assigns) end,
-               compile: &Beacon.Template.HEEx.compile/2,
-               eval: &Beacon.Template.HEEx.eval_ast/2
+               assigns: fn %Phoenix.LiveView.Rendered{static: template} , %{assigns: assigns} -> MyEngine.parse_to_html(template, assigns) end
              ]}
           ],
           after_publish_page: [
@@ -329,20 +322,15 @@ defmodule Beacon.Config do
               compile_heex: &Beacon.Template.HEEx.compile/2
             ],
             custom_format: [
-              validate: #Function<41.3316493/2 in :erl_eval.expr/6>
+              validate: #Function<41.3316493/2 in :erl_eval.expr/6>,
+              build_rendered: #Function<41.3316494/2 in :erl_eval.expr/6>
             ]
           ],
           render_template: [
-            heex: [
-              eval_heex_ast: &Beacon.Template.HEEx.eval_ast/2
-            ],
-            markdown: [
-              eval_heex_ast: &Beacon.Template.HEEx.eval_ast/2
-            ],
+            heex: [],
+            markdown: [],
             custom_format: [
-              assigns: #Function<41.3316493/2 in :erl_eval.expr/6>,
-              compile: &Beacon.Template.HEEx.compile/2,
-              eval: &Beacon.Template.HEEx.eval_ast/2
+              assigns: #Function<41.3316493/2 in :erl_eval.expr/6>
             ]
           ],
           after_create_page: [],

--- a/lib/beacon/lifecycle/template.ex
+++ b/lib/beacon/lifecycle/template.ex
@@ -1,7 +1,6 @@
 defmodule Beacon.Lifecycle.Template do
   @moduledoc false
 
-  require Logger
   alias Beacon.Lifecycle
   @behaviour Beacon.Lifecycle
 

--- a/lib/beacon/lifecycle/template.ex
+++ b/lib/beacon/lifecycle/template.ex
@@ -91,14 +91,18 @@ defmodule Beacon.Lifecycle.Template do
   @doc """
   Render a `page` template using the registered format used on the `page`.
 
-  This stage runs in the render callback of the LiveView responsible for displaying the page.
+  ## Notes
+
+    - This stage runs in the render callback of the LiveView responsible for displaying the page.
+    - It will load and compile the page module if it wasn't not loaded yet.
+
   """
   @spec render_template(Beacon.Content.Page.t(), module(), map(), Macro.Env.t()) :: Beacon.Template.t()
   def render_template(page, page_module, assigns, env) do
     template =
       case page_module.render(assigns) do
         %Phoenix.LiveView.Rendered{} = rendered -> rendered
-        :not_loaded -> Beacon.Loader.PageModuleLoader.load_page!(page, page_module, assigns)
+        :not_loaded -> Beacon.Loader.PageModuleLoader.load_page_template!(page, page_module, assigns)
       end
 
     context = [path: page.path, assigns: assigns, env: env]

--- a/lib/beacon/loader.ex
+++ b/lib/beacon/loader.ex
@@ -198,12 +198,12 @@ defmodule Beacon.Loader do
 
   @doc false
   def layout_module_for_site(layout_id) do
-    "Layout#{layout_id}" |> Macro.camelize() |> module_for_site()
+    module_for_site("Layout#{layout_id}")
   end
 
   @doc false
   def page_module_for_site(page_id) do
-    "Page#{page_id}" |> Macro.camelize() |> module_for_site()
+    module_for_site("Page#{page_id}")
   end
 
   defp module_for_site(resource) do

--- a/lib/beacon/loader.ex
+++ b/lib/beacon/loader.ex
@@ -172,7 +172,7 @@ defmodule Beacon.Loader do
     |> Content.list_published_pages()
     |> Enum.map(fn page ->
       Task.async(fn ->
-        {:ok, _ast} = Beacon.Loader.PageModuleLoader.load_page!(page)
+        {:ok, _module, _ast} = Beacon.Loader.PageModuleLoader.load_page!(page)
         :ok
       end)
     end)
@@ -198,19 +198,19 @@ defmodule Beacon.Loader do
 
   @doc false
   def layout_module_for_site(site, layout_id) do
-    prefix = Macro.camelize("layout_#{layout_id}")
-    module_for_site(site, prefix)
+    resource = Macro.camelize("layout_#{layout_id}")
+    module_for_site(site, resource)
   end
 
   @doc false
   def page_module_for_site(site, page_id) do
-    prefix = Macro.camelize("page_#{page_id}")
-    module_for_site(site, prefix)
+    resource = Macro.camelize("page_#{page_id}")
+    module_for_site(site, resource)
   end
 
-  defp module_for_site(site, prefix) do
+  defp module_for_site(site, resource) do
     site_hash = :crypto.hash(:md5, Atom.to_string(site)) |> Base.encode16()
-    Module.concat([BeaconWeb.LiveRenderer, "#{prefix}#{site_hash}"])
+    Module.concat([BeaconWeb.LiveRenderer, "#{site_hash}#{resource}"])
   end
 
   # This retry logic exists because a module may be in the process of being reloaded, in which case we want to retry
@@ -358,7 +358,7 @@ defmodule Beacon.Loader do
          :ok <- load_snippet_helpers(page.site),
          {:ok, _ast} <- Beacon.Loader.LayoutModuleLoader.load_layout!(layout),
          :ok <- load_stylesheets(page.site),
-         {:ok, _ast} <- Beacon.Loader.PageModuleLoader.load_page!(page) do
+         {:ok, _module, _ast} <- Beacon.Loader.PageModuleLoader.load_page!(page) do
       :ok = Beacon.PubSub.page_loaded(page)
       :ok
     else

--- a/lib/beacon/loader.ex
+++ b/lib/beacon/loader.ex
@@ -197,19 +197,21 @@ defmodule Beacon.Loader do
   end
 
   @doc false
-  def layout_module_for_site(site, layout_id) do
-    resource = Macro.camelize("layout_#{layout_id}")
-    module_for_site(site, resource)
+  def layout_module_for_site(layout_id) do
+    "Layout#{layout_id}" |> Macro.camelize() |> module_for_site()
   end
 
   @doc false
-  def page_module_for_site(site, page_id) do
-    resource = Macro.camelize("page_#{page_id}")
-    module_for_site(site, resource)
+  def page_module_for_site(page_id) do
+    "Page#{page_id}" |> Macro.camelize() |> module_for_site()
+  end
+
+  defp module_for_site(resource) do
+    Module.concat([BeaconWeb.LiveRenderer, resource])
   end
 
   defp module_for_site(site, resource) do
-    site_hash = :crypto.hash(:md5, Atom.to_string(site)) |> Base.encode16()
+    site_hash = :md5 |> :crypto.hash(Atom.to_string(site)) |> Base.encode16()
     Module.concat([BeaconWeb.LiveRenderer, "#{site_hash}#{resource}"])
   end
 
@@ -368,7 +370,7 @@ defmodule Beacon.Loader do
 
   @doc false
   def do_unload_page(page) do
-    module = page_module_for_site(page.site, page.id)
+    module = page_module_for_site(page.id)
     :code.delete(module)
     :code.purge(module)
     Beacon.Router.del_page(page.site, page.path)

--- a/lib/beacon/loader.ex
+++ b/lib/beacon/loader.ex
@@ -91,7 +91,7 @@ defmodule Beacon.Loader do
   def load_page(%Content.Page{} = page) do
     page = Repo.preload(page, :event_handlers)
     config = Beacon.Config.fetch!(page.site)
-    GenServer.call(name(config.site), {:load_page, page}, 60_000)
+    GenServer.call(name(config.site), {:load_page, page}, 30_000)
   end
 
   @doc false
@@ -360,8 +360,8 @@ defmodule Beacon.Loader do
          :ok <- load_snippet_helpers(page.site),
          {:ok, _ast} <- Beacon.Loader.LayoutModuleLoader.load_layout!(layout),
          :ok <- load_stylesheets(page.site),
-         {:ok, _module, _ast} <- Beacon.Loader.PageModuleLoader.load_page!(page) do
-      :ok = Beacon.PubSub.page_loaded(page)
+         {:ok, _module, _ast} <- Beacon.Loader.PageModuleLoader.load_page!(page),
+         :ok <- Beacon.PubSub.page_loaded(page) do
       :ok
     else
       _ -> raise Beacon.LoaderError, message: "failed to load resources for page #{page.title} of site #{page.site}"

--- a/lib/beacon/loader/layout_module_loader.ex
+++ b/lib/beacon/loader/layout_module_loader.ex
@@ -8,7 +8,7 @@ defmodule Beacon.Loader.LayoutModuleLoader do
 
   def load_layout!(%Content.Layout{} = layout) do
     component_module = Loader.component_module_for_site(layout.site)
-    module = Loader.layout_module_for_site(layout.site, layout.id)
+    module = Loader.layout_module_for_site(layout.id)
     render_function = render_layout(layout)
     ast = render(module, render_function, component_module)
     :ok = Loader.reload_module!(module, ast)

--- a/lib/beacon/loader/page_module_loader.ex
+++ b/lib/beacon/loader/page_module_loader.ex
@@ -247,7 +247,7 @@ defmodule Beacon.Loader.PageModuleLoader do
 
   def handle_call({:load_page!, page, stage}, _from, config) do
     component_module = Loader.component_module_for_site(page.site)
-    page_module = Loader.page_module_for_site(page.site, page.id)
+    page_module = Loader.page_module_for_site(page.id)
 
     # Group function heads together to avoid compiler warnings
     functions = [

--- a/lib/beacon/loader/page_module_loader.ex
+++ b/lib/beacon/loader/page_module_loader.ex
@@ -34,6 +34,16 @@ defmodule Beacon.Loader.PageModuleLoader do
     GenServer.call(name(config.site), {:load_page!, page, stage}, 300_000)
   end
 
+  # TODO: retry
+  def load_page!(%Content.Page{} = page, page_module, assigns) do
+    Logger.debug("compiling #{page_module}")
+
+    %Content.Page{} = page = Beacon.Content.get_published_page(page.site, page.id)
+    {:ok, ^page_module, _ast} = load_page!(page, :request)
+    %Phoenix.LiveView.Rendered{} = rendered = page_module.render(assigns)
+    rendered
+  end
+
   defp build(module_name, component_module, functions) do
     quote do
       defmodule unquote(module_name) do

--- a/lib/beacon/loader/page_module_loader.ex
+++ b/lib/beacon/loader/page_module_loader.ex
@@ -172,12 +172,12 @@ defmodule Beacon.Loader.PageModuleLoader do
       [] ->
         quote do
           def render(var!(assigns)) when is_map(var!(assigns)) do
-            [{_, _, template}] = templates(var!(assigns))
-            template
+            [primary] = templates(var!(assigns))
+            primary
           end
 
           def templates(var!(assigns)) when is_map(var!(assigns)) do
-            [{"primary", nil, unquote(primary)}]
+            [unquote(primary)]
           end
         end
 
@@ -191,9 +191,9 @@ defmodule Beacon.Loader.PageModuleLoader do
 
           def templates(var!(assigns)) when is_map(var!(assigns)) do
             [
-              {"primary", nil, unquote(primary)}
+              unquote(primary)
               | for [name, weight, template] <- unquote(variants) do
-                  {name, weight, template}
+                  {weight, template}
                 end
             ]
           end

--- a/lib/beacon/router.ex
+++ b/lib/beacon/router.ex
@@ -182,12 +182,12 @@ defmodule Beacon.Router do
   end
 
   @doc false
-  def add_page(site, path, {_page_id, _layout_id, _format, _template, _page_module, _component_module} = metadata) do
+  def add_page(site, path, {_page_id, _layout_id, _format, _page_module, _component_module} = metadata) do
     add_page(:beacon_pages, site, path, metadata)
   end
 
   @doc false
-  def add_page(table, site, path, {_page_id, _layout_id, _format, _template, _page_module, _component_module} = metadata) do
+  def add_page(table, site, path, {_page_id, _layout_id, _format, _page_module, _component_module} = metadata) do
     :ets.insert(table, {{site, path}, metadata})
   end
 
@@ -309,5 +309,22 @@ defmodule Beacon.Router do
       end)
 
     match?
+  end
+
+  @doc false
+  def path_params(page_path, path_info) do
+    page_path = String.split(page_path, "/")
+
+    Enum.zip_reduce(page_path, path_info, %{}, fn
+      ":" <> segment, value, acc ->
+        Map.put(acc, segment, value)
+
+      "*" <> segment, value, acc ->
+        position = Enum.find_index(path_info, &(&1 == value))
+        Map.put(acc, segment, Enum.drop(path_info, position))
+
+      _, _, acc ->
+        acc
+    end)
   end
 end

--- a/lib/beacon/router.ex
+++ b/lib/beacon/router.ex
@@ -8,6 +8,14 @@ defmodule Beacon.Router do
   In your app router, add `use Beacon.Router` and call one the of the available macros.
   """
 
+  @ets_table :beacon_router
+
+  @doc false
+  # We store routes by order and length so the most visited pages will likely be in the first rows
+  def init do
+    :ets.new(@ets_table, [:ordered_set, :named_table, :public, read_concurrency: true])
+  end
+
   defmacro __using__(_opts) do
     quote do
       unquote(prelude())
@@ -183,7 +191,7 @@ defmodule Beacon.Router do
 
   @doc false
   def add_page(site, path, {_page_id, _layout_id, _format, _page_module, _component_module} = metadata) do
-    add_page(:beacon_pages, site, path, metadata)
+    add_page(@ets_table, site, path, metadata)
   end
 
   @doc false
@@ -193,12 +201,12 @@ defmodule Beacon.Router do
 
   @doc false
   def del_page(site, path) do
-    :ets.delete(:beacon_pages, {site, path})
+    :ets.delete(@ets_table, {site, path})
   end
 
   @doc false
   def dump_pages do
-    case :ets.match(:beacon_pages, :"$1") do
+    case :ets.match(@ets_table, :"$1") do
       [] -> []
       [pages] -> pages
     end
@@ -206,7 +214,7 @@ defmodule Beacon.Router do
 
   @doc false
   def lookup_path(site, path) do
-    lookup_path(:beacon_pages, site, path)
+    lookup_path(@ets_table, site, path)
   end
 
   # Lookup for a path stored in ets that is coming from a live view.
@@ -313,7 +321,7 @@ defmodule Beacon.Router do
 
   @doc false
   def path_params(page_path, path_info) do
-    page_path = String.split(page_path, "/")
+    page_path = String.split(page_path, "/", [])
 
     Enum.zip_reduce(page_path, path_info, %{}, fn
       ":" <> segment, value, acc ->

--- a/lib/beacon/site_supervisor.ex
+++ b/lib/beacon/site_supervisor.ex
@@ -15,7 +15,10 @@ defmodule Beacon.SiteSupervisor do
       if Code.ensure_loaded?(Mix.Project) and Mix.env() == :test do
         []
       else
-        [{Beacon.Loader, config}]
+        [
+          {Beacon.Loader.PageModuleLoader, config},
+          {Beacon.Loader, config}
+        ]
       end
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/beacon/template.ex
+++ b/lib/beacon/template.ex
@@ -66,11 +66,11 @@ defmodule Beacon.Template do
   end
 
   @doc false
-  def choose_template([{_, _, primary}]), do: primary
+  def choose_template([primary]), do: primary
   def choose_template([primary | variants]), do: choose_template(variants, Enum.random(1..100), primary)
 
   @doc false
-  def choose_template([], _, {_, _, primary}), do: primary
-  def choose_template([{_name, weight, template} | _], n, _) when weight >= n, do: template
-  def choose_template([{_name, weight, _} | variants], n, {_, _, primary}), do: choose_template(variants, n - weight, primary)
+  def choose_template([], _, primary), do: primary
+  def choose_template([{weight, template} | _], n, _) when weight >= n, do: template
+  def choose_template([{weight, _} | variants], n, primary), do: choose_template(variants, n - weight, primary)
 end

--- a/lib/beacon/template.ex
+++ b/lib/beacon/template.ex
@@ -16,35 +16,47 @@ defmodule Beacon.Template.RenderMetadata do
   Metadata passed to page rendering lifecycle.
   """
 
-  defstruct [:site, :path, :assigns, :env]
+  defstruct [:site, :path, :page_module, :assigns, :env]
 
   @type t :: %__MODULE__{
           site: Beacon.Types.Site.t(),
           path: String.t(),
+          page_module: module(),
           assigns: Phoenix.LiveView.Socket.assigns(),
           env: Macro.Env.t()
         }
 end
 
 defmodule Beacon.Template do
+  @moduledoc """
+  Template for layouts, pages, and any other resource that display HTML/HEEx.
+
+  Templates are defined as [Phoenix.LiveView.Rendered](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.Rendered.html) structs,
+  which holds nested static literal strings and also dynamic content for the LiveView engine.
+
+  Template engines that do not support dynamic content can make use of the `:static` field to store its contents.
+  """
+
   @typedoc """
-  Compiled template.
+  The AST representation of a `t:Phoenix.LiveView.Rendered.t/0` struct.
   """
   @type ast :: Macro.t()
 
-  @type t :: String.t() | ast()
-
-  defguard is_ast(template) when not is_binary(template)
+  @type t :: Phoenix.LiveView.Rendered.t() | ast()
 
   @doc false
   # this function is used only for debugging HEEx templates
   # it is NOT supposed to be used to render templates
   def __render__(site, path_list) when is_list(path_list) do
     case Beacon.Router.lookup_path(site, path_list) do
-      {{site, path}, {_page_id, _layout_id, format, template, _page_module, _component_module}} ->
+      {{site, path}, {_page_id, _layout_id, format, page_module, _component_module}} ->
+        assigns = %{__changed__: %{}, __live_path__: [], __beacon_page_module__: nil, __beacon_component_module__: nil}
+
+        template = page_module.render(assigns)
+
         Beacon.Lifecycle.Template.render_template(site, template, format,
           path: path,
-          assigns: %{__changed__: %{}, __live_path__: [], __beacon_page_module__: nil, __beacon_component_module__: nil},
+          assigns: assigns,
           env: BeaconWeb.PageLive.make_env()
         )
 
@@ -52,4 +64,13 @@ defmodule Beacon.Template do
         raise BeaconWeb.NotFoundError, "page not found: #{inspect(path_list)}"
     end
   end
+
+  @doc false
+  def choose_template([{_, _, primary}]), do: primary
+  def choose_template([primary | variants]), do: choose_template(variants, Enum.random(1..100), primary)
+
+  @doc false
+  def choose_template([], _, {_, _, primary}), do: primary
+  def choose_template([{_name, weight, template} | _], n, _) when weight >= n, do: template
+  def choose_template([{_name, weight, _} | variants], n, {_, _, primary}), do: choose_template(variants, n - weight, primary)
 end

--- a/lib/beacon/template.ex
+++ b/lib/beacon/template.ex
@@ -49,16 +49,10 @@ defmodule Beacon.Template do
   # it is NOT supposed to be used to render templates
   def __render__(site, path_list) when is_list(path_list) do
     case Beacon.Router.lookup_path(site, path_list) do
-      {{site, path}, {_page_id, _layout_id, format, page_module, _component_module}} ->
-        assigns = %{__changed__: %{}, __live_path__: [], __beacon_page_module__: nil, __beacon_component_module__: nil}
-
-        template = page_module.render(assigns)
-
-        Beacon.Lifecycle.Template.render_template(site, template, format,
-          path: path,
-          assigns: assigns,
-          env: BeaconWeb.PageLive.make_env()
-        )
+      {{site, path}, {page_id, _layout_id, format, page_module, component_module}} ->
+        assigns = %{__changed__: %{}, __live_path__: [], __beacon_page_module__: page_module, __beacon_component_module__: component_module}
+        page = %Beacon.Content.Page{id: page_id, site: site, path: path, format: format}
+        Beacon.Lifecycle.Template.render_template(page, page_module, assigns, BeaconWeb.PageLive.make_env())
 
       _ ->
         raise BeaconWeb.NotFoundError, "page not found: #{inspect(path_list)}"

--- a/lib/beacon_web/components/layouts.ex
+++ b/lib/beacon_web/components/layouts.ex
@@ -40,7 +40,7 @@ defmodule BeaconWeb.Layouts do
   defp compiled_page_assigns(page_id) do
     page_id
     |> Beacon.Loader.page_module_for_site()
-    |> Beacon.Loader.call_function_with_retry(:page_assigns, [page_id])
+    |> Beacon.Loader.call_function_with_retry(:page_assigns, [])
   end
 
   defp compiled_layout_assigns(layout_id) do
@@ -60,7 +60,7 @@ defmodule BeaconWeb.Layouts do
     %{title: page_title} =
       page_id
       |> Beacon.Loader.page_module_for_site()
-      |> Beacon.Loader.call_function_with_retry(:page_assigns, [page_id])
+      |> Beacon.Loader.call_function_with_retry(:page_assigns, [])
 
     if page_title do
       page_title
@@ -147,7 +147,7 @@ defmodule BeaconWeb.Layouts do
     %{raw_schema: raw_schema} =
       page_id
       |> Beacon.Loader.page_module_for_site()
-      |> Beacon.Loader.call_function_with_retry(:page_assigns, [page_id])
+      |> Beacon.Loader.call_function_with_retry(:page_assigns, [])
 
     is_empty = fn raw_schema ->
       raw_schema |> Enum.map(&Map.values/1) |> List.flatten() == []

--- a/lib/beacon_web/components/layouts.ex
+++ b/lib/beacon_web/components/layouts.ex
@@ -27,9 +27,9 @@ defmodule BeaconWeb.Layouts do
   def dynamic_layout?(%{__dynamic_layout_id__: _}), do: true
   def dynamic_layout?(_), do: false
 
-  def render_dynamic_layout(%{__dynamic_layout_id__: layout_id, __site__: site} = assigns) do
-    site
-    |> Beacon.Loader.layout_module_for_site(layout_id)
+  def render_dynamic_layout(%{__dynamic_layout_id__: layout_id} = assigns) do
+    layout_id
+    |> Beacon.Loader.layout_module_for_site()
     |> Beacon.Loader.call_function_with_retry(:render, [layout_id, assigns])
   end
 
@@ -37,15 +37,15 @@ defmodule BeaconWeb.Layouts do
     Beacon.Config.fetch!(site).live_socket_path
   end
 
-  defp compiled_page_assigns(site, page_id) do
-    site
-    |> Beacon.Loader.page_module_for_site(page_id)
+  defp compiled_page_assigns(page_id) do
+    page_id
+    |> Beacon.Loader.page_module_for_site()
     |> Beacon.Loader.call_function_with_retry(:page_assigns, [page_id])
   end
 
-  defp compiled_layout_assigns(site, layout_id) do
-    site
-    |> Beacon.Loader.layout_module_for_site(layout_id)
+  defp compiled_layout_assigns(layout_id) do
+    layout_id
+    |> Beacon.Loader.layout_module_for_site()
     |> Beacon.Loader.call_function_with_retry(:layout_assigns, [layout_id])
   end
 
@@ -56,18 +56,18 @@ defmodule BeaconWeb.Layouts do
 
   def render_page_title(assigns), do: page_title(assigns)
 
-  def page_title(%{__dynamic_layout_id__: layout_id, __dynamic_page_id__: page_id, __site__: site}) do
+  def page_title(%{__dynamic_layout_id__: layout_id, __dynamic_page_id__: page_id}) do
     %{title: page_title} =
-      site
-      |> Beacon.Loader.page_module_for_site(page_id)
+      page_id
+      |> Beacon.Loader.page_module_for_site()
       |> Beacon.Loader.call_function_with_retry(:page_assigns, [page_id])
 
     if page_title do
       page_title
     else
       %{title: layout_title} =
-        site
-        |> Beacon.Loader.layout_module_for_site(layout_id)
+        layout_id
+        |> Beacon.Loader.layout_module_for_site()
         |> Beacon.Loader.call_function_with_retry(:layout_assigns, [layout_id])
 
       layout_title || missing_page_title()
@@ -123,8 +123,8 @@ defmodule BeaconWeb.Layouts do
     compiled_page_meta_tags(assigns)
   end
 
-  defp compiled_page_meta_tags(%{__dynamic_page_id__: page_id, __site__: site}) do
-    %{meta_tags: meta_tags} = compiled_page_assigns(site, page_id)
+  defp compiled_page_meta_tags(%{__dynamic_page_id__: page_id}) do
+    %{meta_tags: meta_tags} = compiled_page_assigns(page_id)
     meta_tags
   end
 
@@ -138,15 +138,15 @@ defmodule BeaconWeb.Layouts do
     compiled_layout_meta_tags(assigns)
   end
 
-  defp compiled_layout_meta_tags(%{__dynamic_layout_id__: layout_id, __site__: site}) do
-    %{meta_tags: meta_tags} = compiled_layout_assigns(site, layout_id)
+  defp compiled_layout_meta_tags(%{__dynamic_layout_id__: layout_id}) do
+    %{meta_tags: meta_tags} = compiled_layout_assigns(layout_id)
     meta_tags
   end
 
-  def render_schema(%{__dynamic_page_id__: page_id, __site__: site} = assigns) do
+  def render_schema(%{__dynamic_page_id__: page_id} = assigns) do
     %{raw_schema: raw_schema} =
-      site
-      |> Beacon.Loader.page_module_for_site(page_id)
+      page_id
+      |> Beacon.Loader.page_module_for_site()
       |> Beacon.Loader.call_function_with_retry(:page_assigns, [page_id])
 
     is_empty = fn raw_schema ->
@@ -189,8 +189,8 @@ defmodule BeaconWeb.Layouts do
     compiled_layout_resource_links(assigns)
   end
 
-  defp compiled_layout_resource_links(%{__dynamic_layout_id__: layout_id, __site__: site}) do
-    %{resource_links: resource_links} = compiled_layout_assigns(site, layout_id)
+  defp compiled_layout_resource_links(%{__dynamic_layout_id__: layout_id}) do
+    %{resource_links: resource_links} = compiled_layout_assigns(layout_id)
     resource_links
   end
 end

--- a/lib/beacon_web/live/page_live.ex
+++ b/lib/beacon_web/live/page_live.ex
@@ -24,28 +24,10 @@ defmodule BeaconWeb.PageLive do
   end
 
   def render(assigns) do
-    {{site, path}, {page_id, _layout_id, format, page_module, _component_module}} =
-      lookup_route!(assigns.__site__, assigns.__live_path__)
-
+    {{site, path}, {page_id, _layout_id, format, page_module, _component_module}} = lookup_route!(assigns.__site__, assigns.__live_path__)
     assigns = Phoenix.Component.assign(assigns, :beacon_path_params, Beacon.Router.path_params(path, assigns.__live_path__))
-    template = do_render(site, page_id, page_module, assigns)
-    Lifecycle.Template.render_template(site, template, format, path: path, assigns: assigns, env: __ENV__)
-  end
-
-  # TODO: backpressure and move to a proper module
-  defp do_render(site, page_id, page_module, assigns) do
-    require Logger
-
-    case page_module.render(assigns) do
-      :not_loaded ->
-        Logger.debug("compiling #{page_module}")
-        page = Beacon.Content.get_published_page(site, page_id)
-        {:ok, page_module, _ast} = Beacon.Loader.PageModuleLoader.load_page!(page, :request)
-        page_module.render(assigns)
-
-      rendered ->
-        rendered
-    end
+    page = %Beacon.Content.Page{id: page_id, site: site, path: path, format: format}
+    Lifecycle.Template.render_template(page, page_module, assigns, __ENV__)
   end
 
   defp lookup_route!(site, path) do

--- a/lib/beacon_web/live/page_live.ex
+++ b/lib/beacon_web/live/page_live.ex
@@ -84,7 +84,6 @@ defmodule BeaconWeb.PageLive do
 
     socket =
       socket
-      |> assign(:beacon, %{site: site})
       |> assign(:beacon_live_data, live_data)
       |> assign(:__live_path__, path)
       |> assign(:__page_updated_at, DateTime.utc_now())

--- a/lib/beacon_web/live/page_live.ex
+++ b/lib/beacon_web/live/page_live.ex
@@ -25,10 +25,7 @@ defmodule BeaconWeb.PageLive do
 
   def render(assigns) do
     {{site, path}, {page_id, _layout_id, format, page_module, _component_module}} = lookup_route!(assigns.__site__, assigns.__live_path__)
-
-    # TODO: remove beacon_path_params?
-    # assigns = Phoenix.Component.assign(assigns, :beacon_path_params, Beacon.Router.path_params(path, assigns.__live_path__))
-
+    assigns = Phoenix.Component.assign(assigns, :beacon_path_params, Beacon.Router.path_params(path, assigns.__live_path__))
     page = %Beacon.Content.Page{id: page_id, site: site, path: path, format: format}
     Lifecycle.Template.render_template(page, page_module, assigns, __ENV__)
   end

--- a/lib/beacon_web/live/page_live.ex
+++ b/lib/beacon_web/live/page_live.ex
@@ -66,7 +66,7 @@ defmodule BeaconWeb.PageLive do
     socket.assigns.__beacon_page_module__
     |> Beacon.Loader.call_function_with_retry(
       :handle_event,
-      [socket.assigns.__live_path__, event_name, event_params, socket]
+      [event_name, event_params, socket]
     )
     |> case do
       {:noreply, %Phoenix.LiveView.Socket{} = socket} ->

--- a/lib/beacon_web/live/page_live.ex
+++ b/lib/beacon_web/live/page_live.ex
@@ -25,7 +25,10 @@ defmodule BeaconWeb.PageLive do
 
   def render(assigns) do
     {{site, path}, {page_id, _layout_id, format, page_module, _component_module}} = lookup_route!(assigns.__site__, assigns.__live_path__)
-    assigns = Phoenix.Component.assign(assigns, :beacon_path_params, Beacon.Router.path_params(path, assigns.__live_path__))
+
+    # TODO: remove beacon_path_params?
+    # assigns = Phoenix.Component.assign(assigns, :beacon_path_params, Beacon.Router.path_params(path, assigns.__live_path__))
+
     page = %Beacon.Content.Page{id: page_id, site: site, path: path, format: format}
     Lifecycle.Template.render_template(page, page_module, assigns, __ENV__)
   end

--- a/lib/beacon_web/live/page_live.ex
+++ b/lib/beacon_web/live/page_live.ex
@@ -34,8 +34,11 @@ defmodule BeaconWeb.PageLive do
 
   # TODO: backpressure and move to a proper module
   defp do_render(site, page_id, page_module, assigns) do
+    require Logger
+
     case page_module.render(assigns) do
       :not_loaded ->
+        Logger.debug("compiling #{page_module}")
         page = Beacon.Content.get_published_page(site, page_id)
         {:ok, page_module, _ast} = Beacon.Loader.PageModuleLoader.load_page!(page, :request)
         page_module.render(assigns)

--- a/test/beacon/lifecycle/template_test.exs
+++ b/test/beacon/lifecycle/template_test.exs
@@ -19,26 +19,4 @@ defmodule Beacon.Lifecycle.TemplateTest do
       assert Lifecycle.Template.load_template(page) == "<div>beacon</div>"
     end
   end
-
-  describe "render_template" do
-    setup do
-      opts = [
-        path: "/test/lifecycle",
-        assigns: %{},
-        env: __ENV__
-      ]
-
-      [opts: opts, format: :markdown, template: "<div>{ title }</div>"]
-    end
-
-    test "template must be valid heex", %{template: template, format: format, opts: opts} do
-      assert %Phoenix.LiveView.Rendered{static: ["<p>Beacon</p>"]} = Lifecycle.Template.render_template(:lifecycle_test, template, format, opts)
-    end
-
-    test "render must return a Phoenix.LiveView.Rendered struct", %{template: template, format: format, opts: opts} do
-      assert_raise Beacon.LoaderError, ~r/Return output must be of type Phoenix.LiveView.Rendered.*/, fn ->
-        Lifecycle.Template.render_template(:lifecycle_test_fail, template, format, opts)
-      end
-    end
-  end
 end

--- a/test/beacon/loader/page_module_loader_test.exs
+++ b/test/beacon/loader/page_module_loader_test.exs
@@ -12,11 +12,11 @@ defmodule Beacon.Loader.PageModuleLoaderTest do
       page_2 = page_fixture(site: "my_site", path: "2", helpers: [page_helper_params(name: "page_2_upcase")])
       [page_1, page_2] = Repo.preload([page_1, page_2], :event_handlers)
 
-      {:ok, ast} = PageModuleLoader.load_page!(page_1)
+      {:ok, _module, ast} = PageModuleLoader.load_page!(page_1)
       assert has_function?(ast, :page_1_upcase)
       assert has_function?(ast, :dynamic_helper)
 
-      {:ok, ast} = PageModuleLoader.load_page!(page_2)
+      {:ok, _module, ast} = PageModuleLoader.load_page!(page_2)
       assert has_function?(ast, :page_2_upcase)
       assert has_function?(ast, :dynamic_helper)
     end
@@ -71,7 +71,7 @@ defmodule Beacon.Loader.PageModuleLoaderTest do
 
       Beacon.Loader.load_page(page)
 
-      {:ok, ast} = PageModuleLoader.load_page!(page)
+      {:ok, _module, ast} = PageModuleLoader.load_page!(page)
 
       assert has_fields?(ast, [{"content", "MY TEST PAGE"}, {"property", "og:description"}])
       assert has_fields?(ast, [{"content", "http://example.com/page/meta-tag"}, {"property", "og:url"}])
@@ -116,7 +116,7 @@ defmodule Beacon.Loader.PageModuleLoaderTest do
 
       Beacon.Loader.load_page(page)
 
-      {:ok, ast} = PageModuleLoader.load_page!(page)
+      {:ok, _module, ast} = PageModuleLoader.load_page!(page)
 
       assert has_fields?(ast,
                "@context": "https://schema.org",
@@ -135,5 +135,36 @@ defmodule Beacon.Loader.PageModuleLoaderTest do
       end)
 
     present
+  end
+
+  describe "render" do
+    test "render primary template" do
+      page = page_fixture(site: "my_site", path: "1") |> Repo.preload([:event_handlers, :variants])
+      {:ok, module, _ast} = PageModuleLoader.load_page!(page)
+      assert %Phoenix.LiveView.Rendered{static: ["<main>\n  <h1>my_site#home</h1>\n</main>"]} = module.render(%{})
+    end
+
+    test "render all templates" do
+      page = page_fixture(site: "my_site", path: "1")
+      Beacon.Content.create_variant_for_page(page, %{name: "variant_a", weight: 1, template: "<div>variant_a</div>"})
+      Beacon.Content.create_variant_for_page(page, %{name: "variant_b", weight: 2, template: "<div>variant_b</div>"})
+      page = Repo.preload(page, [:event_handlers, :variants])
+      {:ok, module, _ast} = PageModuleLoader.load_page!(page)
+
+      assert [
+               {"primary", nil,
+                %Phoenix.LiveView.Rendered{
+                  static: ["<main>\n  <h1>my_site#home</h1>\n</main>"]
+                }},
+               {"variant_a", 1,
+                %Phoenix.LiveView.Rendered{
+                  static: ["<div>variant_a</div>"]
+                }},
+               {"variant_b", 2,
+                %Phoenix.LiveView.Rendered{
+                  static: ["<div>variant_b</div>"]
+                }}
+             ] = module.templates(%{})
+    end
   end
 end

--- a/test/beacon/loader/page_module_loader_test.exs
+++ b/test/beacon/loader/page_module_loader_test.exs
@@ -6,6 +6,12 @@ defmodule Beacon.Loader.PageModuleLoaderTest do
   alias Beacon.Loader.PageModuleLoader
   alias Beacon.Repo
 
+  setup_all do
+    start_supervised!({Beacon.Loader, Beacon.Config.fetch!(:my_site)})
+    start_supervised!({Beacon.Loader.PageModuleLoader, Beacon.Config.fetch!(:my_site)})
+    :ok
+  end
+
   describe "dynamic_helper" do
     test "generate each helper function and the proxy dynamic_helper" do
       page_1 = page_fixture(site: "my_site", path: "1", helpers: [page_helper_params(name: "page_1_upcase")])
@@ -34,13 +40,6 @@ defmodule Beacon.Loader.PageModuleLoaderTest do
   end
 
   describe "page_assigns/1" do
-    defp start_loader(_) do
-      start_supervised!({Beacon.Loader, Beacon.Config.fetch!(:my_site)})
-      :ok
-    end
-
-    setup [:start_loader]
-
     test "interpolates meta tag snippets" do
       snippet_helper_fixture(%{
         site: "my_site",

--- a/test/beacon/loader/page_module_loader_test.exs
+++ b/test/beacon/loader/page_module_loader_test.exs
@@ -151,18 +151,9 @@ defmodule Beacon.Loader.PageModuleLoaderTest do
       {:ok, module, _ast} = PageModuleLoader.load_page!(page)
 
       assert [
-               {"primary", nil,
-                %Phoenix.LiveView.Rendered{
-                  static: ["<main>\n  <h1>my_site#home</h1>\n</main>"]
-                }},
-               {"variant_a", 1,
-                %Phoenix.LiveView.Rendered{
-                  static: ["<div>variant_a</div>"]
-                }},
-               {"variant_b", 2,
-                %Phoenix.LiveView.Rendered{
-                  static: ["<div>variant_b</div>"]
-                }}
+               %Phoenix.LiveView.Rendered{static: ["<main>\n  <h1>my_site#home</h1>\n</main>"]},
+               {1, %Phoenix.LiveView.Rendered{static: ["<div>variant_a</div>"]}},
+               {2, %Phoenix.LiveView.Rendered{static: ["<div>variant_b</div>"]}}
              ] = module.templates(%{})
     end
   end

--- a/test/beacon/loader_test.exs
+++ b/test/beacon/loader_test.exs
@@ -7,6 +7,7 @@ defmodule Beacon.LoaderTest do
 
   setup_all do
     start_supervised!({Beacon.Loader, Beacon.Config.fetch!(:my_site)})
+    start_supervised!({Beacon.Loader.PageModuleLoader, Beacon.Config.fetch!(:my_site)})
     :ok
   end
 

--- a/test/beacon/loader_test.exs
+++ b/test/beacon/loader_test.exs
@@ -112,7 +112,7 @@ defmodule Beacon.LoaderTest do
     end
 
     test "unload page", %{page: page} do
-      module = Beacon.Loader.page_module_for_site(page.site, page.id)
+      module = Beacon.Loader.page_module_for_site(page.id)
       assert Keyword.has_key?(module.__info__(:functions), :page_assigns)
 
       Beacon.Loader.do_unload_page(page)

--- a/test/beacon/router_test.exs
+++ b/test/beacon/router_test.exs
@@ -25,7 +25,7 @@ defmodule Beacon.RouterTest do
   describe "lookup" do
     # we don't care about values in this test but we create the same structure
     # see Router.add_page/4
-    @value {nil, nil, nil, nil, nil, nil}
+    @metadata {nil, nil, nil, nil, nil}
 
     setup do
       [table: :ets.new(:beacon_router_test, [:ordered_set, :protected])]
@@ -36,9 +36,9 @@ defmodule Beacon.RouterTest do
     end
 
     test "exact match on static paths", %{table: table} do
-      Router.add_page(table, :test, "", @value)
-      Router.add_page(table, :test, "home", @value)
-      Router.add_page(table, :test, "blog/posts/2020-01-my-post", @value)
+      Router.add_page(table, :test, "", @metadata)
+      Router.add_page(table, :test, "home", @metadata)
+      Router.add_page(table, :test, "blog/posts/2020-01-my-post", @metadata)
 
       assert {{:test, ""}, _} = Router.lookup_path(table, :test, [])
       assert {{:test, "home"}, _} = Router.lookup_path(table, :test, ["home"])
@@ -46,49 +46,49 @@ defmodule Beacon.RouterTest do
     end
 
     test "multiple dynamic segments", %{table: table} do
-      Router.add_page(table, :test, "/users/:user_id/posts/:id/edit", @value)
+      Router.add_page(table, :test, "/users/:user_id/posts/:id/edit", @metadata)
 
       assert {{:test, "/users/:user_id/posts/:id/edit"}, _} = Router.lookup_path(table, :test, ["users", "1", "posts", "100", "edit"])
     end
 
     test "dynamic segments lookup in batch", %{table: table} do
-      Router.add_page(table, :test, "/:page", @value)
-      Router.add_page(table, :test, "/users/:user_id/posts/:id/edit", @value)
+      Router.add_page(table, :test, "/:page", @metadata)
+      Router.add_page(table, :test, "/users/:user_id/posts/:id/edit", @metadata)
 
       assert {{:test, "/:page"}, _} = Router.lookup_path(table, :test, ["home"], 1)
       assert {{:test, "/users/:user_id/posts/:id/edit"}, _} = Router.lookup_path(table, :test, ["users", "1", "posts", "100", "edit"], 1)
     end
 
     test "dynamic segments with same prefix", %{table: table} do
-      Router.add_page(table, :test, "/posts/:post_id", @value)
-      Router.add_page(table, :test, "/posts/authors/:author_id", @value)
+      Router.add_page(table, :test, "/posts/:post_id", @metadata)
+      Router.add_page(table, :test, "/posts/authors/:author_id", @metadata)
 
       assert {{:test, "/posts/:post_id"}, _} = Router.lookup_path(table, :test, ["posts", "1"])
       assert {{:test, "/posts/authors/:author_id"}, _} = Router.lookup_path(table, :test, ["posts", "authors", "1"])
     end
 
     test "catch all", %{table: table} do
-      Router.add_page(table, :test, "/posts/*slug", @value)
+      Router.add_page(table, :test, "/posts/*slug", @metadata)
 
       assert {{:test, "/posts/*slug"}, _} = Router.lookup_path(table, :test, ["posts", "2022", "my-post"])
     end
 
     test "catch all with existing path with same prefix", %{table: table} do
-      Router.add_page(table, :test, "/press/releases/*slug", @value)
-      Router.add_page(table, :test, "/press/releases", @value)
+      Router.add_page(table, :test, "/press/releases/*slug", @metadata)
+      Router.add_page(table, :test, "/press/releases", @metadata)
 
       assert {{:test, "/press/releases/*slug"}, _} = Router.lookup_path(table, :test, ["press", "releases", "announcement"])
       assert {{:test, "/press/releases"}, _} = Router.lookup_path(table, :test, ["press", "releases"])
     end
 
     test "catch all must match at least 1 segment", %{table: table} do
-      Router.add_page(table, :test, "/posts/*slug", @value)
+      Router.add_page(table, :test, "/posts/*slug", @metadata)
 
       refute Router.lookup_path(table, :test, ["posts"])
     end
 
     test "mixed dynamic segments", %{table: table} do
-      Router.add_page(table, :test, "/posts/:year/*slug", @value)
+      Router.add_page(table, :test, "/posts/:year/*slug", @metadata)
 
       assert {{:test, "/posts/:year/*slug"}, _} = Router.lookup_path(table, :test, ["posts", "2022", "my-post"])
     end

--- a/test/beacon_web/live/page_live_test.exs
+++ b/test/beacon_web/live/page_live_test.exs
@@ -9,6 +9,7 @@ defmodule BeaconWeb.Live.PageLiveTest do
 
   setup_all do
     start_supervised!({Beacon.Loader, Beacon.Config.fetch!(:my_site)})
+    start_supervised!({Beacon.Loader.PageModuleLoader, Beacon.Config.fetch!(:my_site)})
     :ok
   end
 

--- a/test/beacon_web/publish_test.exs
+++ b/test/beacon_web/publish_test.exs
@@ -8,6 +8,7 @@ defmodule BeaconWeb.PublishTest do
 
   defp start_loader(_) do
     start_supervised!({Beacon.Loader, Beacon.Config.fetch!(:my_site)})
+    start_supervised!({Beacon.Loader.PageModuleLoader, Beacon.Config.fetch!(:my_site)})
     :ok
   end
 


### PR DESCRIPTION
The main change is getting rid of `Code.eval_quoted/3` which was necessary to render the pages since we were storing the template AST in ETS, but it was not scaling well.

The first design for page rendering was compiling a single module containing all page templates but it was causing a huge spike in memory utilization to compile 700+ pages, something around 4gb. The second design was then removing that module and storing all template AST in ETS, which consume only 2.6mb of data and the lookup is incredible fast but it doesn't scale to serve too many requests, especially sudden spikes, each `Code.eval_quoted/3` call increases CPU utilization up to 100% faster than we can afford. The third design (this PR) is a mix of both, it will compile a module per page containing the `render/1` function that returns a `%Phoenix.LiveView.Rendered{}` struct and also store page metadata in ETS, including the name of each page module. So the page module is used to store and serve the templates while ETS is an index of pages used to match the request with a page module. The last change required to make this work is compiling the `render/1` function lazily, when the app starts the function is empty (returns `:not_loaded`) then on the first request to that page it will actually recompile the module with the actual implementation, this way there's no memory utilization spike during deployment allowing the app to start, and that recompilation is barely noticeable by users visiting the page, and also Elixir behaves much better compiling modules by demand than compiling all at once.