### PR TITLE
Reload layout

### DIFF
--- a/lib/beacon/lifecycle/template.ex
+++ b/lib/beacon/lifecycle/template.ex
@@ -70,10 +70,12 @@ defmodule Beacon.Lifecycle.Template do
 
   def validate_output!(lifecycle, _site, _type) do
     raise Beacon.LoaderError, """
-    Return output must be of type Phoenix.LiveView.Rendered.
+    excpected output to be a %Phoenix.LiveView.Rendered{} struct
 
-    Output returned:
-    #{inspect(lifecycle.output)}
+    Got:
+
+      #{inspect(lifecycle.output)}
+
     """
   end
 

--- a/lib/beacon/loader.ex
+++ b/lib/beacon/loader.ex
@@ -300,7 +300,8 @@ defmodule Beacon.Loader do
          :ok <- load_snippet_helpers(site),
          :ok <- load_stylesheets(site),
          {:ok, _ast} <- Beacon.Loader.LayoutModuleLoader.load_layout!(layout),
-         :ok <- unload_pages_template(site, layout.id) do
+         :ok <- unload_pages_template(site, layout.id),
+         :ok <- Beacon.PubSub.layout_loaded(layout) do
       :ok
     else
       _ -> raise Beacon.LoaderError, message: "failed to load resources for layout #{layout.title} of site #{layout.site}"

--- a/lib/beacon/pub_sub.ex
+++ b/lib/beacon/pub_sub.ex
@@ -12,8 +12,14 @@ defmodule Beacon.PubSub do
 
   defp topic_layouts(site), do: "beacon:#{site}:layouts"
 
+  defp topic_layout(site, id), do: "beacon:#{site}:layouts:#{id}"
+
   def subscribe_to_layouts(site) do
     Phoenix.PubSub.subscribe(@pubsub, topic_layouts(site))
+  end
+
+  def subscribe_to_layout(site, id) do
+    Phoenix.PubSub.subscribe(@pubsub, topic_layout(site, id))
   end
 
   def layout_published(%Layout{} = layout) do
@@ -21,6 +27,14 @@ defmodule Beacon.PubSub do
     |> topic_layouts()
     |> broadcast({:layout_published, %{site: layout.site, id: layout.id}})
   end
+
+  def layout_loaded(%Layout{} = layout) do
+    layout.site
+    |> topic_layout(layout.id)
+    |> local_broadcast({:layout_loaded, layout(layout)})
+  end
+
+  defp layout(layout), do: %{site: layout.site, id: layout.id}
 
   # Pages
 

--- a/test/beacon/lifecycle/template_test.exs
+++ b/test/beacon/lifecycle/template_test.exs
@@ -1,22 +1,32 @@
 defmodule Beacon.Lifecycle.TemplateTest do
-  use ExUnit.Case, async: true
+  use Beacon.DataCase, async: false
 
+  import Beacon.Fixtures
   alias Beacon.Lifecycle
 
-  describe "load_template" do
-    setup do
-      page = %Beacon.Content.Page{
-        site: :lifecycle_test,
-        path: "/test/lifecycle",
-        format: :markdown,
-        template: "<div>{ title }</div>"
-      }
+  setup_all do
+    start_supervised!({Beacon.Loader, Beacon.Config.fetch!(:my_site)})
+    start_supervised!({Beacon.Loader.PageModuleLoader, Beacon.Config.fetch!(:my_site)})
+    :ok
+  end
 
-      [page: page]
-    end
+  test "load_template" do
+    page = %Beacon.Content.Page{
+      site: :lifecycle_test,
+      path: "/test/lifecycle",
+      format: :markdown,
+      template: "<div>{ title }</div>"
+    }
 
-    test "load stage", %{page: page} do
-      assert Lifecycle.Template.load_template(page) == "<div>beacon</div>"
-    end
+    assert Lifecycle.Template.load_template(page) == "<div>beacon</div>"
+  end
+
+  test "render_template" do
+    page = page_fixture(site: "my_site") |> Repo.preload([:event_handlers, :variants])
+    {:ok, page_module, _ast} = Beacon.Loader.PageModuleLoader.load_page!(page)
+    env = BeaconWeb.PageLive.make_env()
+
+    assert %Phoenix.LiveView.Rendered{static: ["<main>\n  <h1>my_site#home</h1>\n</main>"]} =
+             Lifecycle.Template.render_template(page, page_module, %{}, env)
   end
 end

--- a/test/beacon/loader/page_module_loader_test.exs
+++ b/test/beacon/loader/page_module_loader_test.exs
@@ -167,10 +167,10 @@ defmodule Beacon.Loader.PageModuleLoaderTest do
     test "unload page" do
       page = page_fixture(site: "my_site", path: "1") |> Repo.preload([:event_handlers, :variants])
       {:ok, module, _ast} = PageModuleLoader.load_page!(page)
-      assert Code.loaded?(module)
+      assert :erlang.module_loaded(module)
 
       PageModuleLoader.unload_page!(page)
-      refute Code.loaded?(module)
+      refute :erlang.module_loaded(module)
     end
 
     test "unload page template" do

--- a/test/beacon/loader_test.exs
+++ b/test/beacon/loader_test.exs
@@ -115,11 +115,9 @@ defmodule Beacon.LoaderTest do
       module = Beacon.Loader.page_module_for_site(page.id)
       assert Keyword.has_key?(module.__info__(:functions), :page_assigns)
 
-      Beacon.Loader.do_unload_page(page)
+      Beacon.Loader.unload_page(page)
 
-      assert_raise UndefinedFunctionError, fn ->
-        module.__info__(:functions)
-      end
+      refute Code.loaded?(module)
     end
   end
 end

--- a/test/beacon/loader_test.exs
+++ b/test/beacon/loader_test.exs
@@ -117,7 +117,7 @@ defmodule Beacon.LoaderTest do
 
       Beacon.Loader.unload_page(page)
 
-      refute Code.loaded?(module)
+      refute :erlang.module_loaded(module)
     end
   end
 end

--- a/test/beacon_web/live/page_live_test.exs
+++ b/test/beacon_web/live/page_live_test.exs
@@ -185,6 +185,8 @@ defmodule BeaconWeb.Live.PageLiveTest do
     end
 
     test "reload layout", %{conn: conn, layout: layout} do
+      Beacon.PubSub.subscribe_to_layout(layout.site, layout.id)
+
       {:ok, layout} =
         Content.update_layout(layout, %{
           "template" => """
@@ -193,7 +195,11 @@ defmodule BeaconWeb.Live.PageLiveTest do
           """
         })
 
+      id = layout.id
+
       {:ok, _layout} = Content.publish_layout(layout)
+
+      assert_receive {:layout_loaded, %{id: ^id, site: :my_site}}
 
       {:ok, _view, html} = live(conn, "/home")
       assert html =~ ~s|updated_layout|

--- a/test/beacon_web/live/page_live_test.exs
+++ b/test/beacon_web/live/page_live_test.exs
@@ -90,7 +90,7 @@ defmodule BeaconWeb.Live.PageLiveTest do
 
     Beacon.reload_site(:my_site)
 
-    :ok
+    [layout: layout]
   end
 
   describe "meta tags" do
@@ -182,6 +182,21 @@ defmodule BeaconWeb.Live.PageLiveTest do
       {:ok, _view, html} = live(conn, "/home")
 
       assert html =~ ~s(phx-socket="/custom_live")
+    end
+
+    test "reload layout", %{conn: conn, layout: layout} do
+      {:ok, layout} =
+        Content.update_layout(layout, %{
+          "template" => """
+          <%= @inner_content %>
+          <span>updated_layout</span>
+          """
+        })
+
+      {:ok, _layout} = Content.publish_layout(layout)
+
+      {:ok, _view, html} = live(conn, "/home")
+      assert html =~ ~s|updated_layout|
     end
   end
 

--- a/test/beacon_web/live/page_live_test.exs
+++ b/test/beacon_web/live/page_live_test.exs
@@ -199,7 +199,7 @@ defmodule BeaconWeb.Live.PageLiveTest do
 
       {:ok, _layout} = Content.publish_layout(layout)
 
-      assert_receive {:layout_loaded, %{id: ^id, site: :my_site}}
+      assert_receive {:layout_loaded, %{id: ^id, site: :my_site}}, 1_000
 
       {:ok, _view, html} = live(conn, "/home")
       assert html =~ ~s|updated_layout|


### PR DESCRIPTION
Reloading a layout will force all pages using that layout to be recompiled without a template which will be reloaded on demand as requests try to render such pages, since we can't just recompile all page modules at once. It won't change the page the user is visiting, only on the next request or after refreshing the page.