### PR TITLE
Fix publish process

### DIFF
--- a/lib/beacon/content.ex
+++ b/lib/beacon/content.ex
@@ -133,18 +133,24 @@ defmodule Beacon.Content do
   Event + snapshot
   """
   @doc type: :layouts
-  @spec publish_layout(Layout.t()) :: {:ok, Layout.t()} | any()
+  @spec publish_layout(Layout.t()) :: {:ok, Layout.t()} | {:error, Changeset.t() | term()}
   def publish_layout(%Layout{} = layout) do
-    changeset = Layout.changeset(layout, %{})
+    publish = fn layout ->
+      changeset = Layout.changeset(layout, %{})
 
-    Repo.transact(fn ->
-      with {:ok, _changeset} <- validate_layout_template(changeset),
-           {:ok, event} <- create_layout_event(layout, "published"),
-           {:ok, _snapshot} <- create_layout_snapshot(layout, event) do
-        :ok = PubSub.layout_published(layout)
-        {:ok, layout}
-      end
-    end)
+      Repo.transact(fn ->
+        with {:ok, _changeset} <- validate_layout_template(changeset),
+             {:ok, event} <- create_layout_event(layout, "published"),
+             {:ok, _snapshot} <- create_layout_snapshot(layout, event) do
+          {:ok, layout}
+        end
+      end)
+    end
+
+    with {:ok, layout} <- publish.(layout),
+         :ok <- PubSub.layout_published(layout) do
+      {:ok, layout}
+    end
   end
 
   @doc type: :layouts
@@ -513,19 +519,25 @@ defmodule Beacon.Content do
   can keep editing the page as needed without impacting the published page.
   """
   @doc type: :pages
-  @spec publish_page(Page.t()) :: {:ok, Page.t()} | {:error, Changeset.t()}
+  @spec publish_page(Page.t()) :: {:ok, Page.t()} | {:error, Changeset.t() | term()}
   def publish_page(%Page{} = page) do
-    changeset = Page.update_changeset(page, %{})
+    publish = fn page ->
+      changeset = Page.update_changeset(page, %{})
 
-    Repo.transact(fn ->
-      with {:ok, _changeset} <- validate_page_template(changeset),
-           {:ok, event} <- create_page_event(page, "published"),
-           {:ok, _snapshot} <- create_page_snapshot(page, event),
-           %Page{} = page <- Lifecycle.Page.after_publish_page(page) do
-        :ok = PubSub.page_published(page)
-        {:ok, page}
-      end
-    end)
+      Repo.transact(fn ->
+        with {:ok, _changeset} <- validate_page_template(changeset),
+             {:ok, event} <- create_page_event(page, "published"),
+             {:ok, _snapshot} <- create_page_snapshot(page, event),
+             %Page{} = page <- Lifecycle.Page.after_publish_page(page) do
+          {:ok, page}
+        end
+      end)
+    end
+
+    with {:ok, page} <- publish.(page),
+         :ok <- PubSub.page_published(page) do
+      {:ok, page}
+    end
   end
 
   @doc type: :pages

--- a/lib/beacon/lifecycle/template.ex
+++ b/lib/beacon/lifecycle/template.ex
@@ -103,7 +103,7 @@ defmodule Beacon.Lifecycle.Template do
     template =
       case page_module.render(assigns) do
         %Phoenix.LiveView.Rendered{} = rendered -> rendered
-        :not_loaded -> Beacon.Loader.PageModuleLoader.load_page_template!(page, page_module, assigns)
+        :not_loaded -> Beacon.Loader.load_page_template(page, page_module, assigns)
       end
 
     context = [path: page.path, assigns: assigns, env: env]

--- a/lib/beacon/loader/layout_module_loader.ex
+++ b/lib/beacon/loader/layout_module_loader.ex
@@ -12,7 +12,8 @@ defmodule Beacon.Loader.LayoutModuleLoader do
     render_function = render_layout(layout)
     ast = render(module, render_function, component_module)
     :ok = Loader.reload_module!(module, ast)
-    {:ok, ast}
+    :ok = Beacon.PubSub.layout_loaded(layout)
+    {:ok, module, ast}
   end
 
   defp render(module_name, render_function, component_module) do
@@ -32,11 +33,11 @@ defmodule Beacon.Loader.LayoutModuleLoader do
     ast = Beacon.Template.HEEx.compile_heex_template!(file, layout.template)
 
     quote do
-      def render(unquote(layout.id), var!(assigns)) when is_map(var!(assigns)) do
+      def render(var!(assigns)) when is_map(var!(assigns)) do
         unquote(ast)
       end
 
-      def layout_assigns(unquote(layout.id)) do
+      def layout_assigns do
         %{
           title: unquote(layout.title),
           meta_tags: unquote(Macro.escape(layout.meta_tags)),

--- a/lib/beacon/site_supervisor.ex
+++ b/lib/beacon/site_supervisor.ex
@@ -15,10 +15,7 @@ defmodule Beacon.SiteSupervisor do
       if Code.ensure_loaded?(Mix.Project) and Mix.env() == :test do
         []
       else
-        [
-          {Beacon.Loader.PageModuleLoader, config},
-          {Beacon.Loader, config}
-        ]
+        [{Beacon.Loader, config}]
       end
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/beacon_web/components/layouts.ex
+++ b/lib/beacon_web/components/layouts.ex
@@ -30,7 +30,7 @@ defmodule BeaconWeb.Layouts do
   def render_dynamic_layout(%{__dynamic_layout_id__: layout_id} = assigns) do
     layout_id
     |> Beacon.Loader.layout_module_for_site()
-    |> Beacon.Loader.call_function_with_retry(:render, [layout_id, assigns])
+    |> Beacon.Loader.call_function_with_retry(:render, [assigns])
   end
 
   def live_socket_path(%{__site__: site}) do
@@ -46,7 +46,7 @@ defmodule BeaconWeb.Layouts do
   defp compiled_layout_assigns(layout_id) do
     layout_id
     |> Beacon.Loader.layout_module_for_site()
-    |> Beacon.Loader.call_function_with_retry(:layout_assigns, [layout_id])
+    |> Beacon.Loader.call_function_with_retry(:layout_assigns, [])
   end
 
   def render_page_title(%{__dynamic_page_id__: _, __site__: site, __live_path__: path} = assigns) do
@@ -68,7 +68,7 @@ defmodule BeaconWeb.Layouts do
       %{title: layout_title} =
         layout_id
         |> Beacon.Loader.layout_module_for_site()
-        |> Beacon.Loader.call_function_with_retry(:layout_assigns, [layout_id])
+        |> Beacon.Loader.call_function_with_retry(:layout_assigns, [])
 
       layout_title || missing_page_title()
     end

--- a/test/beacon/lifecycle/template_test.exs
+++ b/test/beacon/lifecycle/template_test.exs
@@ -6,7 +6,6 @@ defmodule Beacon.Lifecycle.TemplateTest do
 
   setup_all do
     start_supervised!({Beacon.Loader, Beacon.Config.fetch!(:my_site)})
-    start_supervised!({Beacon.Loader.PageModuleLoader, Beacon.Config.fetch!(:my_site)})
     :ok
   end
 

--- a/test/beacon/loader/page_module_loader_test.exs
+++ b/test/beacon/loader/page_module_loader_test.exs
@@ -7,7 +7,6 @@ defmodule Beacon.Loader.PageModuleLoaderTest do
 
   setup_all do
     start_supervised!({Beacon.Loader, Beacon.Config.fetch!(:my_site)})
-    start_supervised!({Beacon.Loader.PageModuleLoader, Beacon.Config.fetch!(:my_site)})
     :ok
   end
 
@@ -171,15 +170,6 @@ defmodule Beacon.Loader.PageModuleLoaderTest do
 
       PageModuleLoader.unload_page!(page)
       refute :erlang.module_loaded(module)
-    end
-
-    test "unload page template" do
-      page = page_fixture(site: "my_site", path: "1") |> Repo.preload([:event_handlers, :variants])
-      {:ok, module, _ast} = PageModuleLoader.load_page!(page)
-      assert %Phoenix.LiveView.Rendered{} = module.render(%{})
-
-      PageModuleLoader.unload_page_template!(page)
-      assert module.render(%{}) == :not_loaded
     end
   end
 end

--- a/test/beacon/loader_test.exs
+++ b/test/beacon/loader_test.exs
@@ -7,7 +7,6 @@ defmodule Beacon.LoaderTest do
 
   setup_all do
     start_supervised!({Beacon.Loader, Beacon.Config.fetch!(:my_site)})
-    start_supervised!({Beacon.Loader.PageModuleLoader, Beacon.Config.fetch!(:my_site)})
     :ok
   end
 

--- a/test/beacon_web/publish_test.exs
+++ b/test/beacon_web/publish_test.exs
@@ -8,7 +8,6 @@ defmodule BeaconWeb.PublishTest do
 
   defp start_loader(_) do
     start_supervised!({Beacon.Loader, Beacon.Config.fetch!(:my_site)})
-    start_supervised!({Beacon.Loader.PageModuleLoader, Beacon.Config.fetch!(:my_site)})
     :ok
   end
 


### PR DESCRIPTION
- Move the pubsub broadcast outside of the repo transaction since `Beacon.Loader` query the database to find the latest published page/layout.
- Revert `PageModuleLoader` as a simple module and let only `Loader` be a genserver so we have a single queue for loading resources since they depend on each other.
- Revert page template unloading, introduced at https://github.com/BeaconCMS/beacon/pull/335, since we require users to refresh the page to see the updated markup and the pubsub fix is all we need.