### PR TITLE
Fix bug in seeds file listing on installation.md

### DIFF
--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -296,7 +296,7 @@ For more info on site options, check out `Beacon.start_link/1`.
       <main>
         <h2>A blog</h2>
         <ul>
-          <li>Path Params Blog Slug: <%%= @beacon_path_params.blog_slug %></li>
+          <li>Path Params Blog Slug: <%%= @beacon_path_params["blog_slug"] %></li>
           <li>Live Data blog_slug_uppercase: <%%= @beacon_live_data.blog_slug_uppercase %></li>
         </ul>
       </main>


### PR DESCRIPTION
The URL params will be passed with string keys, but the  line with `@beacon_path_params.blog_slug` is looking for an atom as the key, and so will fail with a KeyError, like so:
```
(KeyError) key :blog_slug not found in: %{"blog_slug" => "my_first_post"}
```
This took me a little while to figure out, so hopefully this will save someone some time, and come up when they google the error message.