### PR TITLE
Fix Template Beacon Seeds File syntax

### DIFF
--- a/priv/templates/install/seeds.exs
+++ b/priv/templates/install/seeds.exs
@@ -91,8 +91,8 @@ Content.publish_layout(layout)
   <main>
     <h2>A blog</h2>
     <ul>
-      <li>Path Params Blog Slug: <%%= @beacon_path_params.blog_slug %></li>
-      <li>Live Data blog_slug_uppercase: <%%= @beacon_live_data.blog_slug_uppercase %></li>
+      <li>Path Params Blog Slug: <%= @beacon_path_params["blog_slug"] %></li>
+      <li>Live Data blog_slug_uppercase: <%= @beacon_live_data[:blog_slug_uppercase] %></li>
     </ul>
   </main>
   """


### PR DESCRIPTION
Hey @everyone.

I was just playing with the installer and I noticed a difference from the beacon_demo project and the default beacon project.
Whenever I run the seeds the url /blog/:blog_slug does not seem to work.
The reason I suspect is because the syntax used.
With the update using the syntax from inside the beacon_demo project the path seem to work.

Expected behavior:
/blog/:blog_slug should render page with matching path