### PR TITLE
Update page_module_loader.ex

### DIFF
--- a/lib/beacon/loader/page_module_loader.ex
+++ b/lib/beacon/loader/page_module_loader.ex
@@ -41,7 +41,7 @@ defmodule Beacon.Loader.PageModuleLoader do
 
     with %Content.Page{} = page <- Beacon.Content.get_published_page(page.site, page.id),
          {:ok, ^page_module, _ast} <- do_load_page!(page, :request),
-         %Phoenix.LiveView.Rendered{} = rendered <- Beacon.Template.render(assigns) do
+         %Phoenix.LiveView.Rendered{} = rendered <- Beacon.Template.render(page_module, assigns) do
       rendered
     else
       _ ->


### PR DESCRIPTION
Try to fix error in the main branch resulting from not including the page module in calls to Beacon.Template.render() when loading pages from ETS pre-rendered.