### PR TITLE
Fix CSS compiler

### DIFF
--- a/lib/beacon/config.ex
+++ b/lib/beacon/config.ex
@@ -94,7 +94,7 @@ defmodule Beacon.Config do
                 {identifier :: atom(),
                  fun ::
                    (template :: String.t(), Beacon.Template.LoadMetadata.t() ->
-                      {:cont, String.t() | Beacon.Template.t()} | {:halt, String.t() | Beacon.Template.t()} | {:halt, Exception.t()})}
+                      {:cont, String.t()} | {:halt, String.t()} | {:halt, Exception.t()})}
               ]}
            ]}
           | {:render_template,
@@ -154,16 +154,10 @@ defmodule Beacon.Config do
         }
 
   @default_load_template [
-    {:heex,
-     [
-       safe_code_check: &Beacon.Template.HEEx.safe_code_check/2,
-       compile_heex: &Beacon.Template.HEEx.compile/2
-     ]},
+    {:heex, []},
     {:markdown,
      [
-       convert_to_html: &Beacon.Template.Markdown.convert_to_html/2,
-       safe_code_check: &Beacon.Template.HEEx.safe_code_check/2,
-       compile_heex: &Beacon.Template.HEEx.compile/2
+       convert_to_html: &Beacon.Template.Markdown.convert_to_html/2
      ]}
   ]
 
@@ -277,8 +271,7 @@ defmodule Beacon.Config do
           load_template: [
             {:custom_format,
              [
-               validate: fn template, _metadata -> MyEngine.validate(template) end,
-               build_rendered: fn template, _metadata -> %Phoenix.LiveView.Rendered{static: template}  end,
+               validate: fn template, _metadata -> MyEngine.validate(template) end
              ]}
           ],
           render_template: [
@@ -312,18 +305,12 @@ defmodule Beacon.Config do
         ]
         lifecycle: [
           load_template: [
-            heex: [
-              safe_code_check: &Beacon.Template.HEEx.safe_code_check/2,
-              compile_heex: &Beacon.Template.HEEx.compile/2
-            ],
+            heex: [],
             markdown: [
               convert_to_html: &Beacon.Template.Markdown.convert_to_html/2,
-              safe_code_check: &Beacon.Template.HEEx.safe_code_check/2,
-              compile_heex: &Beacon.Template.HEEx.compile/2
             ],
             custom_format: [
-              validate: #Function<41.3316493/2 in :erl_eval.expr/6>,
-              build_rendered: #Function<41.3316494/2 in :erl_eval.expr/6>
+              validate: #Function<41.3316493/2 in :erl_eval.expr/6>
             ]
           ],
           render_template: [

--- a/lib/beacon/content.ex
+++ b/lib/beacon/content.ex
@@ -2072,10 +2072,10 @@ defmodule Beacon.Content do
 
   defp do_validate_template(changeset, field, :heex = _format, template, metadata) when is_binary(template) do
     Changeset.validate_change(changeset, field, fn ^field, template ->
-      case Beacon.Template.HEEx.compile(template, metadata) do
-        {:cont, _ast} -> []
-        {:halt, %{description: description}} -> [{field, {"invalid", compilation_error: description}}]
-        {:halt, _} -> [{field, "invalid"}]
+      case Beacon.Template.HEEx.compile(metadata.site, metadata.path, template) do
+        {:ok, _ast} -> []
+        {:error, %{description: description}} -> [{field, {"invalid", compilation_error: description}}]
+        {:error, _} -> [{field, "invalid"}]
       end
     end)
   end

--- a/lib/beacon/lifecycle/template.ex
+++ b/lib/beacon/lifecycle/template.ex
@@ -33,7 +33,8 @@ defmodule Beacon.Lifecycle.Template do
       lifecycle
     else
       raise Beacon.LoaderError, """
-      For site: #{site_config.site}
+      failed to validate lifecycle input for site: #{site_config.site}
+
       #{format_allowed_error_text(format_allowed?, sub_key, allowed_formats)}
 
       #{unconfigured_error_text(format_configured?, sub_key)}
@@ -81,9 +82,9 @@ defmodule Beacon.Lifecycle.Template do
 
   @doc """
   Load a `page` template using the registered format used on the `page`.
-  This stage runs after fetching the page from the database and before storing the template into ETS.
+  This stage runs after fetching the page from the database and before compiling and storing the template into ETS.
   """
-  @spec load_template(Beacon.Content.Page.t()) :: Beacon.Template.t()
+  @spec load_template(Beacon.Content.Page.t()) :: String.t()
   def load_template(page) do
     lifecycle = Lifecycle.execute(__MODULE__, page.site, :load_template, page.template, sub_key: page.format, context: %{path: page.path})
     lifecycle.output

--- a/lib/beacon/loader/component_module_loader.ex
+++ b/lib/beacon/loader/component_module_loader.ex
@@ -33,7 +33,7 @@ defmodule Beacon.Loader.ComponentModuleLoader do
 
   defp render_component(%Content.Component{site: site, name: name, body: body}) do
     file = "site-#{site}-component-#{name}"
-    ast = Beacon.Template.HEEx.compile_heex_template!(file, body)
+    {:ok, ast} = Beacon.Template.HEEx.compile(site, "",  body, file)
 
     quote do
       def render(unquote(name), var!(assigns)) when is_map(var!(assigns)) do

--- a/lib/beacon/loader/component_module_loader.ex
+++ b/lib/beacon/loader/component_module_loader.ex
@@ -33,7 +33,7 @@ defmodule Beacon.Loader.ComponentModuleLoader do
 
   defp render_component(%Content.Component{site: site, name: name, body: body}) do
     file = "site-#{site}-component-#{name}"
-    {:ok, ast} = Beacon.Template.HEEx.compile(site, "",  body, file)
+    {:ok, ast} = Beacon.Template.HEEx.compile(site, "", body, file)
 
     quote do
       def render(unquote(name), var!(assigns)) when is_map(var!(assigns)) do

--- a/lib/beacon/loader/layout_module_loader.ex
+++ b/lib/beacon/loader/layout_module_loader.ex
@@ -30,7 +30,7 @@ defmodule Beacon.Loader.LayoutModuleLoader do
 
   defp render_layout(layout) do
     file = "site-#{layout.site}-layout-#{layout.title}"
-    ast = Beacon.Template.HEEx.compile_heex_template!(file, layout.template)
+    {:ok, ast} = Beacon.Template.HEEx.compile(layout.site, "", layout.template, file)
 
     quote do
       def render(var!(assigns)) when is_map(var!(assigns)) do

--- a/lib/beacon/loader/page_module_loader.ex
+++ b/lib/beacon/loader/page_module_loader.ex
@@ -4,6 +4,7 @@ defmodule Beacon.Loader.PageModuleLoader do
   alias Beacon.Content
   alias Beacon.Lifecycle
   alias Beacon.Loader
+  alias Beacon.Template.HEEx
 
   require Logger
 
@@ -208,7 +209,9 @@ defmodule Beacon.Loader.PageModuleLoader do
   end
 
   defp render(page, :request) do
-    primary = Lifecycle.Template.load_template(page)
+    primary_template = Lifecycle.Template.load_template(page)
+    {:ok, primary} = HEEx.compile(page.site, page.path, primary_template)
+
     variants = load_variants(page)
 
     case variants do
@@ -248,10 +251,14 @@ defmodule Beacon.Loader.PageModuleLoader do
     %{variants: variants} = Beacon.Repo.preload(page, :variants)
 
     for variant <- variants do
+      page = %{page | template: variant.template}
+      template = Lifecycle.Template.load_template(page)
+      {:ok, page} = HEEx.compile(page.site, page.path, template)
+
       [
         variant.name,
         variant.weight,
-        Lifecycle.Template.load_template(%{page | template: variant.template})
+        page
       ]
     end
   end

--- a/lib/beacon/loader/page_module_loader.ex
+++ b/lib/beacon/loader/page_module_loader.ex
@@ -253,12 +253,12 @@ defmodule Beacon.Loader.PageModuleLoader do
     for variant <- variants do
       page = %{page | template: variant.template}
       template = Lifecycle.Template.load_template(page)
-      {:ok, page} = HEEx.compile(page.site, page.path, template)
+      {:ok, ast} = HEEx.compile(page.site, page.path, template)
 
       [
         variant.name,
         variant.weight,
-        page
+        ast
       ]
     end
   end

--- a/lib/beacon/router.ex
+++ b/lib/beacon/router.ex
@@ -221,14 +221,6 @@ defmodule Beacon.Router do
     |> List.flatten()
   end
 
-  def dump_page_modules(site, fun \\ &Function.identity/1) do
-    site
-    |> dump_pages()
-    |> Enum.map(fn {{^site, _path} = key, {_page_id, _layout_id, _format, page_module, _component_module}} ->
-      fun.(Tuple.append(key, page_module))
-    end)
-  end
-
   @doc false
   def lookup_path(site, path) do
     lookup_path(@ets_table, site, path)

--- a/lib/beacon/tailwind_compiler.ex
+++ b/lib/beacon/tailwind_compiler.ex
@@ -189,17 +189,10 @@ defmodule Beacon.TailwindCompiler do
         end)
       end),
       Task.async(fn ->
-        # parse from laoded pages (ETS) so it can fetch callback transformations
-        # thay may include additoinal stylesheet classes as the markdown parser does
-        Beacon.Router.dump_page_modules(site, fn {_site, path, page_module} ->
-          template =
-            page_module
-            |> Beacon.Template.render()
-            |> fetch_static()
-            |> List.to_string()
-
-          page_path = Path.join(tmp_dir, "#{site}_page_#{remove_special_chars(path)}.template")
-          File.write!(page_path, template)
+        Enum.map(Content.list_published_pages(site), fn page ->
+          page_path = Path.join(tmp_dir, "#{site}_page_#{remove_special_chars(page.path)}.template")
+          post_processed_template = Beacon.Lifecycle.Template.load_template(page)
+          File.write!(page_path, post_processed_template)
           page_path
         end)
       end),
@@ -214,9 +207,6 @@ defmodule Beacon.TailwindCompiler do
     |> Task.await_many()
     |> List.flatten()
   end
-
-  defp fetch_static(%{static: static}), do: static
-  defp fetch_static(_), do: []
 
   # import app css into input css used by tailwind-cli to load tailwind functions and directives
   defp generate_input_css_file!(tmp_dir) do
@@ -246,7 +236,7 @@ defmodule Beacon.TailwindCompiler do
     input_css_path
   end
 
-  defp remove_special_chars(name), do: String.replace(name, ~r/[^[:alnum:]_-]+/, "_")
+  defp remove_special_chars(name), do: String.replace(name, ~r/[^[:alnum:]_]+/, "_")
 
   # include paths for the following scenarios:
   # - regular app

--- a/test/beacon/tailwind_compiler_test.exs
+++ b/test/beacon/tailwind_compiler_test.exs
@@ -33,7 +33,20 @@ defmodule Beacon.TailwindCompilerTest do
 
     published_page_fixture(
       layout_id: layout.id,
-      path: "/a",
+      path: "/tailwind-test",
+      template: """
+      <main>
+        <h2 class="text-gray-200">Some Values:</h2>
+        <%= for val <- @beacon_live_data[:vals] do %>
+          <%= my_component("sample_component", val: val) %>
+        <% end %>
+      </main>
+      """
+    )
+
+    published_page_fixture(
+      layout_id: layout.id,
+      path: "/tailwind-test-post-process",
       template: """
       <main>
         <h2 class="text-gray-200">Some Values:</h2>
@@ -87,6 +100,11 @@ defmodule Beacon.TailwindCompilerTest do
 
         refute output =~ "text-gray-300"
       end)
+    end
+
+    test "fetch post processed page templates" do
+      assert {:ok, output} = TailwindCompiler.compile(@site)
+      assert output =~ "text-blue-200"
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -19,7 +19,22 @@ Supervisor.start_link(
          tailwind_config: Path.join([File.cwd!(), "test", "support", "tailwind.config.templates.js.eex"]),
          data_source: Beacon.BeaconTest.BeaconDataSource,
          live_socket_path: "/custom_live",
-         extra_page_fields: [Beacon.BeaconTest.PageFields.TagsField]
+         extra_page_fields: [Beacon.BeaconTest.PageFields.TagsField],
+         lifecycle: [
+           load_template: [
+             {:heex,
+              [
+                tailwind_test: fn
+                  template, %{site: :my_site, path: "/tailwind-test-post-process"} ->
+                    template = String.replace(template, "text-gray-200", "text-blue-200")
+                    {:cont, template}
+
+                  template, _metadata ->
+                    {:cont, template}
+                end
+              ]}
+           ]
+         ]
        ],
        [
          site: :s3_site,
@@ -58,8 +73,8 @@ Supervisor.start_link(
               [
                 div_to_p: fn template, _metadata -> {:cont, String.replace(template, "div", "p")} end,
                 assigns: fn template, _metadata -> {:cont, String.replace(template, "{ title }", "Beacon")} end,
-                compile: fn template, _metadata ->
-                  ast = Beacon.Template.HEEx.compile_heex_template!("nofile", template)
+                compile: fn template, metadata ->
+                  {:ok, ast} = Beacon.Template.HEEx.compile(metadata.site, metadata.path, template)
                   {:cont, ast}
                 end,
                 eval: fn template, _metadata ->


### PR DESCRIPTION
- Revert part of #376 to allow compiling CSS on app boot
- Change the `:load_template` lifecycle to only return the template binary so it doesn't compile it

Close #392