### PR TITLE
Support phoenix html 4.x

### DIFF
--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -268,7 +268,7 @@ For more info on site options, check out `Beacon.start_link/1`.
         </ul>
 
         <.form :let={f} for={%{}} as={:greeting} phx-submit="hello">
-          Name: <%= text_input f, :name %> <%= submit "Hello" %>
+          Name: <.input type="text" field={f[:name]} /> <.button>Hello</.button>
         </.form>
 
         <%= if assigns[:message], do: assigns.message %>

--- a/lib/beacon/loader/component_module_loader.ex
+++ b/lib/beacon/loader/component_module_loader.ex
@@ -22,7 +22,6 @@ defmodule Beacon.Loader.ComponentModuleLoader do
     quote do
       defmodule unquote(component_module) do
         import Phoenix.Component
-        use Phoenix.HTML
 
         def my_component(name, assigns \\ []), do: render(name, Enum.into(assigns, %{}))
 

--- a/lib/beacon/loader/error_page_module_loader.ex
+++ b/lib/beacon/loader/error_page_module_loader.ex
@@ -14,7 +14,6 @@ defmodule Beacon.Loader.ErrorPageModuleLoader do
     ast =
       quote do
         defmodule unquote(error_module) do
-          use Phoenix.HTML
           require EEx
           import Phoenix.Component
           require Logger

--- a/lib/beacon/loader/layout_module_loader.ex
+++ b/lib/beacon/loader/layout_module_loader.ex
@@ -19,7 +19,6 @@ defmodule Beacon.Loader.LayoutModuleLoader do
   defp render(module_name, render_function, component_module) do
     quote do
       defmodule unquote(module_name) do
-        use Phoenix.HTML
         import Phoenix.Component
         unquote(Loader.maybe_import_my_component(component_module, render_function))
 

--- a/lib/beacon/loader/page_module_loader.ex
+++ b/lib/beacon/loader/page_module_loader.ex
@@ -82,7 +82,6 @@ defmodule Beacon.Loader.PageModuleLoader do
   defp build(module_name, component_module, functions) do
     quote do
       defmodule unquote(module_name) do
-        use Phoenix.HTML
         import Phoenix.Component
         unquote(Loader.maybe_import_my_component(component_module, functions))
 

--- a/lib/beacon_web.ex
+++ b/lib/beacon_web.ex
@@ -45,8 +45,6 @@ defmodule BeaconWeb do
 
   defp html_helpers do
     quote do
-      # HTML escaping functionality
-      import Phoenix.HTML
       # Core UI components and translation
       import BeaconWeb.CoreComponents
       import BeaconWeb.Gettext

--- a/lib/beacon_web/live/page_live.ex
+++ b/lib/beacon_web/live/page_live.ex
@@ -1,6 +1,5 @@
 defmodule BeaconWeb.PageLive do
   use BeaconWeb, :live_view
-  use Phoenix.HTML
   require Logger
   import Phoenix.Component
   alias Beacon.Lifecycle

--- a/mix.exs
+++ b/mix.exs
@@ -52,6 +52,7 @@ defmodule Beacon.MixProject do
       {:solid, "~> 0.14"},
       phoenix_dep(),
       {:phoenix_ecto, "~> 4.4"},
+      {:phoenix_html, "~> 2.14.2 or ~> 3.0 or ~> 4.0"},
       {:phoenix_live_reload, "~> 1.3", only: :dev},
       phoenix_live_view_dep(),
       {:phoenix_pubsub, "~> 2.1"},

--- a/test/beacon_web/live/page_live_test.exs
+++ b/test/beacon_web/live/page_live_test.exs
@@ -46,8 +46,10 @@ defmodule BeaconWeb.Live.PageLiveTest do
           <% end %>
 
           <.form :let={f} for={%{}} as={:greeting} phx-submit="hello">
-            Name: <%= text_input f, :name %>
-            <%= submit "Hello" %>
+            Name: <BeaconWeb.CoreComponents.input type="text" field={f[:name]} />
+            <BeaconWeb.CoreComponents.button type="submit">
+              Hello
+            </BeaconWeb.CoreComponents.button>
           </.form>
 
           <%= if assigns[:message], do: assigns.message %>

--- a/test/support/beacon.ex
+++ b/test/support/beacon.ex
@@ -25,8 +25,6 @@ defmodule Beacon.BeaconTest do
 
   defp view_helpers do
     quote do
-      use Phoenix.HTML
-
       import Phoenix.Component
       import Phoenix.View
 


### PR DESCRIPTION
I _think_ this resolves the issue reported here https://github.com/BeaconCMS/beacon/issues/403

All the tests are passing after removing the `import` and `use` of `Phoenix.HTML`.

I updated the tests to consume `input` and `button` from `BeaconWeb.CoreComponents`.

Not sure if I'm missing something important though!