### PR TITLE
Control site boot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ beacon-*.tar
 # LSP
 /.elixir_ls
 /.elixir-tools
+/.lexical
 
 # Local iex config
 .iex.exs

--- a/dev.exs
+++ b/dev.exs
@@ -179,7 +179,7 @@ dev_seeds = fn ->
       extra: %{"alt" => "logo"}
     )
 
-  img1 = Beacon.MediaLibrary.upload(metadata)
+  _img1 = Beacon.MediaLibrary.upload(metadata)
 
   metadata =
     Beacon.MediaLibrary.UploadMetadata.new(
@@ -190,7 +190,7 @@ dev_seeds = fn ->
       extra: %{"alt" => "alternate logo"}
     )
 
-  img2 = Beacon.MediaLibrary.upload(metadata)
+  _img2 = Beacon.MediaLibrary.upload(metadata)
 
   home_live_data = Beacon.Content.create_live_data!(%{site: "dev", path: "/"})
 

--- a/dev.exs
+++ b/dev.exs
@@ -165,7 +165,7 @@ dev_seeds = fn ->
     site: "dev",
     name: "author_name",
     body: ~S"""
-    author_id =  get_in(assigns, ["page", "extra", "author_id"])
+    author_id = get_in(assigns, ["page", "extra", "author_id"])
     "author_#{author_id}"
     """
   })
@@ -980,6 +980,7 @@ end
 dev_site = [
   site: :dev,
   endpoint: SamplePhoenix.Endpoint,
+  skip_boot?: true,
   extra_page_fields: [BeaconTagsField],
   lifecycle: [upload_asset: [thumbnail: &Beacon.Lifecycle.Asset.thumbnail/2, _480w: &Beacon.Lifecycle.Asset.variant_480w/2]],
   default_meta_tags: [
@@ -1009,7 +1010,7 @@ Task.start(fn ->
     {Beacon,
      sites: [
        dev_site,
-       [site: :dy, endpoint: SamplePhoenix.Endpoint]
+       [site: :dy, endpoint: SamplePhoenix.Endpoint, skip_boot?: true]
      ]},
     SamplePhoenix.Endpoint
   ]
@@ -1022,6 +1023,9 @@ Task.start(fn ->
 
   dev_seeds.()
   dy_seeds.()
+
+  Beacon.boot(:dev)
+  Beacon.boot(:dy)
 
   Process.sleep(:infinity)
 end)

--- a/lib/beacon/authorization.ex
+++ b/lib/beacon/authorization.ex
@@ -52,6 +52,6 @@ defmodule Beacon.Authorization do
   end
 
   defp get_authorization_source(site) do
-    Beacon.Registry.config!(site).authorization_source
+    Beacon.Config.fetch!(site).authorization_source
   end
 end

--- a/lib/beacon/beacon.ex
+++ b/lib/beacon/beacon.ex
@@ -88,7 +88,14 @@ defmodule Beacon do
     Supervisor.child_spec({Beacon.SiteSupervisor, config}, id: config.site)
   end
 
-  # FIXME: spec/doc/error handling
+  @doc """
+  Boot a site, populating default data, the router, and loading modules.
+
+  This function is called by the site supervisor, and should not be called directly most of the times,
+  it's useful to seed data where you need to start the Repo but not boot the entire site,
+  and also useful on test environments.
+  """
+  @spec boot(atom) :: :ok
   def boot(site) do
     Beacon.Boot.do_init(Config.fetch!(site))
     Beacon.Config.update_value(site, :skip_boot?, false)

--- a/lib/beacon/beacon.ex
+++ b/lib/beacon/beacon.ex
@@ -95,7 +95,7 @@ defmodule Beacon do
   it's useful to seed data where you need to start the Repo but not boot the entire site,
   and also useful on test environments.
   """
-  @spec boot(atom) :: :ok
+  @spec boot(Beacon.Types.Site.t()) :: :ok
   def boot(site) do
     Beacon.Boot.do_init(Config.fetch!(site))
     Beacon.Config.update_value(site, :skip_boot?, false)

--- a/lib/beacon/beacon.ex
+++ b/lib/beacon/beacon.ex
@@ -88,6 +88,13 @@ defmodule Beacon do
     Supervisor.child_spec({Beacon.SiteSupervisor, config}, id: config.site)
   end
 
+  # FIXME: spec/doc/error handling
+  def boot(site) do
+    Beacon.Boot.do_init(Config.fetch!(site))
+    Beacon.Config.update_value(site, :skip_boot?, false)
+    :ok
+  end
+
   @tailwind_version "3.3.1"
   @doc false
   def tailwind_version, do: @tailwind_version

--- a/lib/beacon/boot.ex
+++ b/lib/beacon/boot.ex
@@ -23,41 +23,41 @@ defmodule Beacon.Boot do
   def init(config), do: do_init(config)
 
   def do_init(config) do
-    boot = fn ->
-      task_supervisor = task_supervisor(config.site)
+    Logger.info("Beacon.Boot booting site #{config.site}")
 
-      # Layouts and pages depend on the components module so we need to load it first
-      Beacon.Loader.populate_default_components(config.site)
-      Beacon.Loader.reload_components_module(config.site)
+    task_supervisor = task_supervisor(config.site)
 
-      Beacon.Loader.populate_default_layouts(config.site)
+    # Layouts and pages depend on the components module so we need to load it first
+    Beacon.Loader.populate_default_components(config.site)
+    Beacon.Loader.reload_components_module(config.site)
 
-      # Error pages depend on default layouts
-      Beacon.Loader.populate_default_error_pages(config.site)
+    Beacon.Loader.populate_default_layouts(config.site)
 
-      assets = [
-        Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_runtime_js(config.site) end),
-        Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_runtime_css(config.site) end)
-      ]
+    # Error pages depend on default layouts
+    Beacon.Loader.populate_default_error_pages(config.site)
 
-      modules = [
-        Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_stylesheet_module(config.site) end),
-        Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_snippets_module(config.site) end),
-        Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_live_data_module(config.site) end),
-        Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_layouts_modules(config.site) end),
-        Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_error_page_module(config.site) end),
-        Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_pages_modules(config.site, per_page: 20) end)
-        # TODO: load main pages (order_by: path, per_page: 10) to avoid SEO issues
-      ]
+    assets = [
+      Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_runtime_js(config.site) end),
+      Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_runtime_css(config.site) end)
+    ]
 
-      Task.await_many(modules, :timer.minutes(2))
+    modules = [
+      Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_stylesheet_module(config.site) end),
+      Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_snippets_module(config.site) end),
+      Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_live_data_module(config.site) end),
+      Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_layouts_modules(config.site) end),
+      Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_error_page_module(config.site) end),
+      Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_pages_modules(config.site, per_page: 20) end)
+      # TODO: load main pages (order_by: path, per_page: 10) to avoid SEO issues
+    ]
 
-      # TODO: revisit this timeout after we upgrade to Tailwind v4
-      Task.await_many(assets, :timer.minutes(5))
-    end
+    Task.await_many(modules, :timer.minutes(2))
 
-    {time, _} = :timer.tc(boot, :seconds)
-    Logger.info("Beacon.Boot finished booting site #{config.site} in #{time} seconds")
+    # TODO: revisit this timeout after we upgrade to Tailwind v4
+    Task.await_many(assets, :timer.minutes(5))
+
+    # TODO: add telemetry to measure booting time
+    Logger.info("Beacon.Boot finished booting site #{config.site}")
 
     :ignore
   end

--- a/lib/beacon/boot.ex
+++ b/lib/beacon/boot.ex
@@ -15,57 +15,54 @@ defmodule Beacon.Boot do
     Beacon.Registry.via({site, __MODULE__})
   end
 
-  if Beacon.Config.env_test?() do
-    def init(config) do
-      # Reloads only the components module because it gets imported into other modules, to avoid compilation issues
+  def init(%{site: site, skip_boot?: true}) do
+    Logger.debug("Beacon.Boot is disabled on site #{site}")
+    :ignore
+  end
+
+  def init(config), do: do_init(config)
+
+  def do_init(config) do
+    boot = fn ->
+      task_supervisor = task_supervisor(config.site)
+
+      # Layouts and pages depend on the components module so we need to load it first
+      Beacon.Loader.populate_default_components(config.site)
       Beacon.Loader.reload_components_module(config.site)
-      :ignore
-    end
-  else
-    def init(config) do
-      boot = fn ->
-        task_supervisor = task_supervisor(config.site)
 
-        populate = [
-          Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.populate_default_components(config.site) end),
-          Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.populate_default_layouts(config.site) end),
-          Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.populate_default_error_pages(config.site) end)
-        ]
+      Beacon.Loader.populate_default_layouts(config.site)
 
-        Task.await_many(populate, :timer.minutes(1))
+      # Error pages depend on default layouts
+      Beacon.Loader.populate_default_error_pages(config.site)
 
-        assets = [
-          Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_runtime_js(config.site) end),
-          Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_runtime_css(config.site) end)
-        ]
+      assets = [
+        Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_runtime_js(config.site) end),
+        Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_runtime_css(config.site) end)
+      ]
 
-        # Layouts and pages depend on the components module so we need to load it first
-        Beacon.Loader.reload_components_module(config.site)
+      modules = [
+        Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_stylesheet_module(config.site) end),
+        Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_snippets_module(config.site) end),
+        Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_live_data_module(config.site) end),
+        Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_layouts_modules(config.site) end),
+        Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_error_page_module(config.site) end),
+        Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_pages_modules(config.site, per_page: 20) end)
+        # TODO: load main pages (order_by: path, per_page: 10) to avoid SEO issues
+      ]
 
-        modules = [
-          Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_stylesheet_module(config.site) end),
-          Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_snippets_module(config.site) end),
-          Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_live_data_module(config.site) end),
-          Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_layouts_modules(config.site) end),
-          Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_error_page_module(config.site) end),
-          Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_pages_modules(config.site, per_page: 20) end)
-          # TODO: load main pages (order_by: path, per_page: 10) to avoid SEO issues
-        ]
+      Task.await_many(modules, :timer.minutes(2))
 
-        Task.await_many(modules, :timer.minutes(2))
-
-        # TODO: revisit this timeout after we upgrade to Tailwind v4
-        Task.await_many(assets, :timer.minutes(5))
-      end
-
-      {time, _} = :timer.tc(boot, :seconds)
-      Logger.info("Finished booting site #{config.site} in #{time} seconds")
-
-      :ignore
+      # TODO: revisit this timeout after we upgrade to Tailwind v4
+      Task.await_many(assets, :timer.minutes(5))
     end
 
-    defp task_supervisor(site) do
-      Beacon.Registry.via({site, TaskSupervisor})
-    end
+    {time, _} = :timer.tc(boot, :seconds)
+    Logger.info("Beacon.Boot finished booting site #{config.site} in #{time} seconds")
+
+    :ignore
+  end
+
+  defp task_supervisor(site) do
+    Beacon.Registry.via({site, TaskSupervisor})
   end
 end

--- a/lib/beacon/registry.ex
+++ b/lib/beacon/registry.ex
@@ -29,20 +29,6 @@ defmodule Beacon.Registry do
   end
 
   @doc false
-  def config!(site) when is_atom(site) do
-    case lookup({:site, site}) do
-      {_pid, config} ->
-        config
-
-      _ ->
-        raise RuntimeError, """
-        site #{inspect(site)} was not found. Make sure it's configured and started,
-        see `Beacon.start_link/1` for more info.
-        """
-    end
-  end
-
-  @doc false
   def update_config(site, fun) when is_atom(site) and is_function(fun, 1) do
     result =
       Registry.update_value(__MODULE__, {:site, site}, fn config ->
@@ -55,9 +41,10 @@ defmodule Beacon.Registry do
     end
   end
 
-  defp lookup(site) do
+  @doc false
+  def lookup(key) do
     __MODULE__
-    |> Registry.lookup(site)
+    |> Registry.lookup(key)
     |> List.first()
   end
 end

--- a/lib/beacon/router_server.ex
+++ b/lib/beacon/router_server.ex
@@ -14,17 +14,15 @@ defmodule Beacon.RouterServer do
     String.to_atom("beacon_router_#{site}")
   end
 
-  def start_link({config, _} = opts) do
-    GenServer.start_link(__MODULE__, opts, name: name(config.site))
+  def start_link(config) do
+    GenServer.start_link(__MODULE__, config, name: name(config.site))
   end
 
-  def init({config, opts}) do
-    skip_seed = Keyword.get(opts, :skip_seed, false)
-
+  def init(config) do
     # We store routes by order and length so the most visited pages will likely be in the first rows
     :ets.new(table_name(config.site), [:ordered_set, :named_table, :public, read_concurrency: true])
 
-    if skip_seed do
+    if config.skip_boot? do
       {:ok, config}
     else
       {:ok, config, {:continue, :async_init}}

--- a/lib/beacon/site_supervisor.ex
+++ b/lib/beacon/site_supervisor.ex
@@ -13,7 +13,7 @@ defmodule Beacon.SiteSupervisor do
       {Beacon.Config, config},
       {Task.Supervisor, name: Beacon.Registry.via({config.site, TaskSupervisor})},
       {Beacon.Content, config},
-      {Beacon.RouterServer, {config, skip_seed: Beacon.Config.env_test?()}},
+      {Beacon.RouterServer, config},
       {DynamicSupervisor,
        name: Beacon.Registry.via({config.site, Beacon.LoaderSupervisor}), strategy: :one_for_one, max_restarts: 10, max_seconds: 30},
       {Beacon.Loader, config},

--- a/lib/beacon/site_supervisor.ex
+++ b/lib/beacon/site_supervisor.ex
@@ -4,12 +4,13 @@ defmodule Beacon.SiteSupervisor do
   use Supervisor
 
   def start_link(config) do
-    Supervisor.start_link(__MODULE__, config, name: Beacon.Registry.via({:site, config.site}, config))
+    Supervisor.start_link(__MODULE__, config, name: Beacon.Registry.via({:site, config.site}))
   end
 
   @impl true
   def init(config) do
     children = [
+      {Beacon.Config, config},
       {Task.Supervisor, name: Beacon.Registry.via({config.site, TaskSupervisor})},
       {Beacon.Content, config},
       {Beacon.RouterServer, {config, skip_seed: Beacon.Config.env_test?()}},

--- a/test/beacon/beacon_test.exs
+++ b/test/beacon/beacon_test.exs
@@ -4,12 +4,12 @@ defmodule Beacon.BeaconTest do
   describe "boot" do
     test "disable skip_boot config" do
       assert config().skip_boot?
-      Beacon.boot(:boot_test)
+      Beacon.boot(:not_booted)
       refute config().skip_boot?
     end
   end
 
   defp config do
-    Beacon.Config.fetch!(:boot_test)
+    Beacon.Config.fetch!(:not_booted)
   end
 end

--- a/test/beacon/beacon_test.exs
+++ b/test/beacon/beacon_test.exs
@@ -1,0 +1,15 @@
+defmodule Beacon.BeaconTest do
+  use Beacon.DataCase, async: false
+
+  describe "boot" do
+    test "disable skip_boot config" do
+      assert config().skip_boot?
+      Beacon.boot(:boot_test)
+      refute config().skip_boot?
+    end
+  end
+
+  defp config do
+    Beacon.Config.fetch!(:boot_test)
+  end
+end

--- a/test/beacon/config_test.exs
+++ b/test/beacon/config_test.exs
@@ -26,7 +26,7 @@ defmodule Beacon.ConfigTest do
     end
 
     test "updates key from config" do
-      assert %Config{live_socket_path: "/new_live"} = Config.update_value(:boot_test, :live_socket_path, "/new_live")
+      assert %Config{live_socket_path: "/new_live"} = Config.update_value(:not_booted, :live_socket_path, "/new_live")
     end
   end
 

--- a/test/beacon/config_test.exs
+++ b/test/beacon/config_test.exs
@@ -3,6 +3,33 @@ defmodule Beacon.ConfigTest do
 
   alias Beacon.Config
 
+  @site :my_site
+
+  describe "registry" do
+    test "returns the site config" do
+      assert %Beacon.Config{
+               css_compiler: Beacon.TailwindCompiler,
+               authorization_source: Beacon.BeaconTest.BeaconAuthorizationSource,
+               live_socket_path: "/custom_live",
+               safe_code_check: false,
+               site: :my_site,
+               tailwind_config: tailwind_config
+             } = Config.fetch!(@site)
+
+      assert tailwind_config =~ "tailwind.config.templates.js.eex"
+    end
+
+    test "raises for non existing site" do
+      assert_raise RuntimeError, ~r/site :invalid was not found/, fn ->
+        Config.fetch!(:invalid)
+      end
+    end
+
+    test "updates key from config" do
+      assert %Config{live_socket_path: "/new_live"} = Config.update_value(:boot_test, :live_socket_path, "/new_live")
+    end
+  end
+
   describe "template_formats" do
     test "preserve default config" do
       assert %{

--- a/test/beacon/content_test.exs
+++ b/test/beacon/content_test.exs
@@ -20,7 +20,7 @@ defmodule Beacon.ContentTest do
 
   describe "layouts" do
     test "broadcasts published event" do
-      %{site: site, id: id} = layout = layout_fixture()
+      %{site: site, id: id} = layout = layout_fixture(site: "booted")
       :ok = Beacon.PubSub.subscribe_to_layouts(site)
       Content.publish_layout(layout)
       assert_receive {:layout_published, %{site: ^site, id: ^id}}
@@ -100,21 +100,21 @@ defmodule Beacon.ContentTest do
 
   describe "pages" do
     test "broadcasts published event" do
-      %{site: site, id: id} = page = page_fixture()
+      %{site: site, id: id} = page = page_fixture(site: "booted")
       :ok = Beacon.PubSub.subscribe_to_pages(site)
       Content.publish_page(page)
       assert_receive {:page_published, %{site: ^site, id: ^id}}
     end
 
     test "broadcasts loaded event" do
-      %{site: site, id: id, path: path} = published_page_fixture()
+      %{site: site, id: id, path: path} = published_page_fixture(site: "booted")
       :ok = Beacon.PubSub.subscribe_to_page(site, path)
       Beacon.Loader.reload_page_module(site, id)
       assert_receive {:page_loaded, %{site: ^site, id: ^id}}
     end
 
     test "broadcasts unpublished event" do
-      %{site: site, id: id, path: path} = page = published_page_fixture()
+      %{site: site, id: id, path: path} = page = published_page_fixture(site: "booted")
       :ok = Beacon.PubSub.subscribe_to_pages(site)
       assert {:ok, _} = Content.unpublish_page(page)
       assert_receive {:page_unpublished, %{site: ^site, id: ^id, path: ^path}}
@@ -353,13 +353,13 @@ defmodule Beacon.ContentTest do
 
   describe "stylesheets" do
     test "create broadcasts updated content event" do
-      :ok = Beacon.PubSub.subscribe_to_content(:my_site)
-      %{site: site} = stylesheet_fixture()
+      :ok = Beacon.PubSub.subscribe_to_content(:booted)
+      %{site: site} = stylesheet_fixture(site: "booted")
       assert_receive {:content_updated, :stylesheet, %{site: ^site}}
     end
 
     test "update broadcasts updated content event" do
-      %{site: site} = stylesheet = stylesheet_fixture()
+      %{site: site} = stylesheet = stylesheet_fixture(site: "booted")
       :ok = Beacon.PubSub.subscribe_to_content(site)
       Content.update_stylesheet(stylesheet, %{body: "/* test */"})
       assert_receive {:content_updated, :stylesheet, %{site: ^site}}
@@ -368,8 +368,8 @@ defmodule Beacon.ContentTest do
 
   describe "snippets" do
     test "create broadcasts updated content event" do
-      :ok = Beacon.PubSub.subscribe_to_content(:my_site)
-      %{site: site} = snippet_helper_fixture()
+      :ok = Beacon.PubSub.subscribe_to_content(:booted)
+      %{site: site} = snippet_helper_fixture(site: "booted")
       assert_receive {:content_updated, :snippet_helper, %{site: ^site}}
     end
 
@@ -557,13 +557,13 @@ defmodule Beacon.ContentTest do
 
   describe "error_pages" do
     test "create broadcasts updated content event" do
-      :ok = Beacon.PubSub.subscribe_to_content(:my_site)
-      %{site: site} = error_page_fixture()
+      :ok = Beacon.PubSub.subscribe_to_content(:booted)
+      %{site: site} = error_page_fixture(site: "booted")
       assert_receive {:content_updated, :error_page, %{site: ^site}}
     end
 
     test "update broadcasts updated content event" do
-      %{site: site} = error_page = error_page_fixture()
+      %{site: site} = error_page = error_page_fixture(site: "booted")
       :ok = Beacon.PubSub.subscribe_to_content(site)
       Content.update_error_page(error_page, %{template: "test"})
       assert_receive {:content_updated, :error_page, %{site: ^site}}
@@ -605,13 +605,13 @@ defmodule Beacon.ContentTest do
 
   describe "components" do
     test "create broadcasts updated content event" do
-      :ok = Beacon.PubSub.subscribe_to_content(:my_site)
-      %{site: site} = component_fixture()
+      :ok = Beacon.PubSub.subscribe_to_content(:booted)
+      %{site: site} = component_fixture(site: "booted")
       assert_receive {:content_updated, :component, %{site: ^site}}
     end
 
     test "update broadcasts updated content event" do
-      %{site: site} = component = component_fixture()
+      %{site: site} = component = component_fixture(site: "booted")
       :ok = Beacon.PubSub.subscribe_to_content(site)
       Content.update_component(component, %{body: "<div>test</div>"})
       assert_receive {:content_updated, :component, %{site: ^site}}
@@ -651,8 +651,8 @@ defmodule Beacon.ContentTest do
 
   describe "live data" do
     test "create broadcasts updated content event" do
-      :ok = Beacon.PubSub.subscribe_to_content(:my_site)
-      %{site: site} = live_data_fixture()
+      :ok = Beacon.PubSub.subscribe_to_content(:booted)
+      %{site: site} = live_data_fixture(site: "booted")
       assert_receive {:content_updated, :live_data, %{site: ^site}}
     end
 
@@ -687,7 +687,7 @@ defmodule Beacon.ContentTest do
     test "live_data_for_site/1" do
       live_data_1 = live_data_fixture(site: :my_site, path: "/foo")
       live_data_2 = live_data_fixture(site: :my_site, path: "/bar")
-      live_data_3 = live_data_fixture(site: :other_site, path: "/baz")
+      live_data_3 = live_data_fixture(site: :not_booted, path: "/baz")
 
       results = Content.live_data_for_site(:my_site)
 

--- a/test/beacon/registry_test.exs
+++ b/test/beacon/registry_test.exs
@@ -3,38 +3,15 @@ defmodule Beacon.RegistryTest do
 
   test "running_sites" do
     running_sites = Beacon.Registry.running_sites()
-    assert Enum.sort(running_sites) == [:data_source_test, :default_meta_tags_test, :lifecycle_test, :lifecycle_test_fail, :my_site, :s3_site]
-  end
 
-  test "update_config" do
-    # register a config in the test process to make Registry.update_value/3 work
-    assert %Beacon.Config{live_socket_path: "/custom_live"} = config = Beacon.Registry.config!(:my_site)
-    Registry.register(Beacon.Registry, {:site, :test_update_config}, config)
-
-    assert %Beacon.Config{live_socket_path: "/test_update_config"} =
-             Beacon.Registry.update_config(:test_update_config, fn config ->
-               %{config | live_socket_path: "/test_update_config"}
-             end)
-  end
-
-  describe "config!" do
-    test "return site config for existing sites" do
-      assert %Beacon.Config{
-               css_compiler: Beacon.TailwindCompiler,
-               authorization_source: Beacon.BeaconTest.BeaconAuthorizationSource,
-               live_socket_path: "/custom_live",
-               safe_code_check: false,
-               site: :my_site,
-               tailwind_config: tailwind_config
-             } = Beacon.Registry.config!(:my_site)
-
-      assert tailwind_config =~ "tailwind.config.templates.js.eex"
-    end
-
-    test "raise when not found" do
-      assert_raise RuntimeError, ~r/site :invalid was not found/, fn ->
-        Beacon.Registry.config!(:invalid)
-      end
-    end
+    assert Enum.sort(running_sites) == [
+             :boot_test,
+             :data_source_test,
+             :default_meta_tags_test,
+             :lifecycle_test,
+             :lifecycle_test_fail,
+             :my_site,
+             :s3_site
+           ]
   end
 end

--- a/test/beacon/registry_test.exs
+++ b/test/beacon/registry_test.exs
@@ -5,12 +5,13 @@ defmodule Beacon.RegistryTest do
     running_sites = Beacon.Registry.running_sites()
 
     assert Enum.sort(running_sites) == [
-             :boot_test,
+             :booted,
              :data_source_test,
              :default_meta_tags_test,
              :lifecycle_test,
              :lifecycle_test_fail,
              :my_site,
+             :not_booted,
              :s3_site
            ]
   end

--- a/test/support/beacon_web.ex
+++ b/test/support/beacon_web.ex
@@ -1,4 +1,4 @@
-defmodule Beacon.BeaconTest do
+defmodule Beacon.BeaconWebTest do
   defmacro __using__(which) when is_atom(which) do
     apply(__MODULE__, which, [])
   end
@@ -37,11 +37,11 @@ defmodule Beacon.BeaconTest do
 end
 
 defmodule Beacon.BeaconTest.LayoutView do
-  use Beacon.BeaconTest, :view
+  use Beacon.BeaconWebTest, :view
 end
 
 defmodule Beacon.BeaconTest.ErrorView do
-  use Beacon.BeaconTest, :view
+  use Beacon.BeaconWebTest, :view
 
   def render(_template, _assigns), do: "Error"
 end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -1,5 +1,5 @@
 defmodule Beacon.BeaconTest.Router do
-  use Beacon.BeaconTest, :router
+  use Beacon.BeaconWebTest, :router
   use Beacon.Router
 
   pipeline :browser do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -37,8 +37,13 @@ Supervisor.start_link(
          ]
        ],
        [
-         site: :boot_test,
+         site: :not_booted,
          skip_boot?: true,
+         endpoint: Beacon.BeaconTest.Endpoint
+       ],
+       [
+         site: :booted,
+         skip_boot?: false,
          endpoint: Beacon.BeaconTest.Endpoint
        ],
        [
@@ -126,6 +131,11 @@ Supervisor.start_link(
   ],
   strategy: :one_for_one
 )
+
+# TODO: better control :booted default data
+Beacon.Repo.delete_all(Beacon.Content.Component)
+Beacon.Repo.delete_all(Beacon.Content.ErrorPage)
+Beacon.Repo.delete_all(Beacon.Content.Layout)
 
 ExUnit.start(exclude: [:skip])
 Ecto.Adapters.SQL.Sandbox.mode(Beacon.Repo, :manual)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -16,6 +16,7 @@ Supervisor.start_link(
        [
          site: :my_site,
          endpoint: Beacon.BeaconTest.Endpoint,
+         skip_boot?: true,
          tailwind_config: Path.join([File.cwd!(), "test", "support", "tailwind.config.templates.js.eex"]),
          live_socket_path: "/custom_live",
          extra_page_fields: [Beacon.BeaconTest.PageFields.TagsField],
@@ -36,8 +37,14 @@ Supervisor.start_link(
          ]
        ],
        [
+         site: :boot_test,
+         skip_boot?: true,
+         endpoint: Beacon.BeaconTest.Endpoint
+       ],
+       [
          site: :s3_site,
          endpoint: Beacon.BeaconTest.Endpoint,
+         skip_boot?: true,
          assets: [
            {"image/*", [backends: [Beacon.MediaLibrary.Backend.S3, Beacon.MediaLibrary.Backend.Repo], validations: []]}
          ],
@@ -45,10 +52,12 @@ Supervisor.start_link(
        ],
        [
          site: :data_source_test,
+         skip_boot?: true,
          endpoint: Beacon.BeaconTest.Endpoint
        ],
        [
          site: :default_meta_tags_test,
+         skip_boot?: true,
          endpoint: Beacon.BeaconTest.Endpoint,
          default_meta_tags: [
            %{"name" => "foo", "content" => "bar"}
@@ -57,6 +66,7 @@ Supervisor.start_link(
        [
          site: :lifecycle_test,
          endpoint: Beacon.BeaconTest.Endpoint,
+         skip_boot?: true,
          lifecycle: [
            load_template: [
              {:markdown,
@@ -103,6 +113,7 @@ Supervisor.start_link(
        [
          site: :lifecycle_test_fail,
          endpoint: Beacon.BeaconTest.Endpoint,
+         skip_boot?: true,
          lifecycle: [
            render_template: [
              {:markdown, [assigns: fn template, _metadata -> {:cont, template} end]}

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -132,7 +132,7 @@ Supervisor.start_link(
   strategy: :one_for_one
 )
 
-# TODO: better control :booted default data
+# TODO: better control :booted default data when we introduce Beacon.Test functions
 Beacon.Repo.delete_all(Beacon.Content.Component)
 Beacon.Repo.delete_all(Beacon.Content.ErrorPage)
 Beacon.Repo.delete_all(Beacon.Content.Layout)


### PR DESCRIPTION
Disabling site boot will skip the following steps:
- Loading default data
- Loading modules
- Broadcasting events

That's necessary to run tests without conflicts and to seed initial data.

Beacon.Repo and all the other necessary servers are started as usual.