### PR TITLE
Validate variants and live_data on create

### DIFF
--- a/lib/beacon/content.ex
+++ b/lib/beacon/content.ex
@@ -2255,6 +2255,7 @@ defmodule Beacon.Content do
     changeset =
       live_data
       |> Ecto.build_assoc(:assigns)
+      |> Map.put(:live_data, live_data)
       |> LiveDataAssign.changeset(attrs)
       |> validate_live_data_code()
 

--- a/lib/beacon/content.ex
+++ b/lib/beacon/content.ex
@@ -2111,6 +2111,7 @@ defmodule Beacon.Content do
       page
       |> Ecto.build_assoc(:variants)
       |> PageVariant.changeset(attrs)
+      |> validate_variant(page)
 
     Repo.transact(fn ->
       with {:ok, %PageVariant{}} <- Repo.insert(changeset),
@@ -2255,6 +2256,7 @@ defmodule Beacon.Content do
       live_data
       |> Ecto.build_assoc(:assigns)
       |> LiveDataAssign.changeset(attrs)
+      |> validate_live_data_code()
 
     case Repo.insert(changeset) do
       {:ok, %LiveDataAssign{}} ->


### PR DESCRIPTION
PageVariants and LiveDataAssigns are being validated on update, but not on create.  It might be that creation does not involve user inputted data so validation on create has not been necessary yet.  But we should probably add this anyway