### PR TITLE
Introduce `@beacon` and deprecate `@beacon_*` assigns

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -256,12 +256,12 @@ dev_seeds = fn ->
         </div>
 
         <div>
-          <BeaconWeb.Components.image_set asset={@beacon_live_data[:img1]} sources={["480w"]} width="200px" />
+          <BeaconWeb.Components.image_set asset={@img1} sources={["480w"]} width="200px" />
         </div>
 
         <div>
           <p>From data source:</p>
-          <%= @beacon_live_data[:year] %>
+          <%= @year %>
         </div>
 
         <div>

--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -268,7 +268,7 @@ For more info on site options, check out `Beacon.start_link/1`.
       <main>
         <h2>Some Values:</h2>
         <ul>
-          <%= for val <- @beacon_live_data[:vals] do %>
+          <%= for val <- @vals do %>
             <%= my_component("sample_component", val: val) %>
           <% end %>
         </ul>
@@ -317,8 +317,8 @@ For more info on site options, check out `Beacon.start_link/1`.
       <main>
         <h2>A blog</h2>
         <ul>
-          <li>Path Params Blog Slug: <%= @beacon_path_params["blog_slug"] %></li>
-          <li>Live Data blog_slug_uppercase: <%= @beacon_live_data.blog_slug_uppercase %></li>
+          <li>Path Params Blog Slug: <%= @beacon.path_params["blog_slug"] %></li>
+          <li>Live Data blog_slug_uppercase: <%= @blog_slug_uppercase %></li>
         </ul>
       </main>
       """

--- a/lib/beacon/beacon.ex
+++ b/lib/beacon/beacon.ex
@@ -194,8 +194,6 @@ defmodule Beacon do
 
     #{context}
 
-    Make sure you have created a page for this path.
-    See Pages.create_page!/2 for more info.
     """
   end
 

--- a/lib/beacon/lifecycle/template.ex
+++ b/lib/beacon/lifecycle/template.ex
@@ -102,7 +102,7 @@ defmodule Beacon.Lifecycle.Template do
   @spec render_template(Beacon.Content.Page.t(), map(), Macro.Env.t()) :: Beacon.Template.t()
   def render_template(page, assigns, env) do
     page_module = Beacon.Loader.fetch_page_module(page.site, page.id)
-    template = Beacon.Template.render(page_module, assigns)
+    template = Beacon.Template.render_page(page_module, assigns)
     context = [path: page.path, assigns: assigns, env: env]
     lifecycle = Lifecycle.execute(__MODULE__, page.site, :render_template, template, sub_key: page.format, context: context)
     lifecycle.output

--- a/lib/beacon/lifecycle/template.ex
+++ b/lib/beacon/lifecycle/template.ex
@@ -102,7 +102,7 @@ defmodule Beacon.Lifecycle.Template do
   @spec render_template(Beacon.Content.Page.t(), map(), Macro.Env.t()) :: Beacon.Template.t()
   def render_template(page, assigns, env) do
     page_module = Beacon.Loader.fetch_page_module(page.site, page.id)
-    template = Beacon.Template.render_page(page_module, assigns)
+    template = page_module.render(assigns)
     context = [path: page.path, assigns: assigns, env: env]
     lifecycle = Lifecycle.execute(__MODULE__, page.site, :render_template, template, sub_key: page.format, context: context)
     lifecycle.output

--- a/lib/beacon/loader/components.ex
+++ b/lib/beacon/loader/components.ex
@@ -26,7 +26,8 @@ defmodule Beacon.Loader.Components do
         use PhoenixHTMLHelpers
         import Phoenix.HTML
         import Phoenix.HTML.Form
-        import Phoenix.Component
+        import Phoenix.Component, except: [assign: 2, assign: 3, assign_new: 3]
+        import BeaconWeb, only: [assign: 2, assign: 3, assign_new: 3]
 
         def my_component(name, assigns \\ []) do
           Beacon.apply_mfa(__MODULE__, :render, [name, Enum.into(assigns, %{})])
@@ -41,7 +42,8 @@ defmodule Beacon.Loader.Components do
         use PhoenixHTMLHelpers
         import Phoenix.HTML
         import Phoenix.HTML.Form
-        import Phoenix.Component
+        import Phoenix.Component, except: [assign: 2, assign: 3, assign_new: 3]
+        import BeaconWeb, only: [assign: 2, assign: 3, assign_new: 3]
 
         def my_component(name, assigns \\ []) do
           Beacon.apply_mfa(__MODULE__, :render, [name, Enum.into(assigns, %{})])

--- a/lib/beacon/loader/error_page.ex
+++ b/lib/beacon/loader/error_page.ex
@@ -17,7 +17,8 @@ defmodule Beacon.Loader.ErrorPage do
         use PhoenixHTMLHelpers
         import Phoenix.HTML
         import Phoenix.HTML.Form
-        import Phoenix.Component
+        import Phoenix.Component, except: [assign: 2, assign: 3, assign_new: 3]
+        import BeaconWeb, only: [assign: 2, assign: 3, assign_new: 3]
 
         unquote_splicing(layout_functions)
         unquote_splicing(render_functions)

--- a/lib/beacon/loader/layout.ex
+++ b/lib/beacon/loader/layout.ex
@@ -18,7 +18,8 @@ defmodule Beacon.Loader.Layout do
         use PhoenixHTMLHelpers
         import Phoenix.HTML
         import Phoenix.HTML.Form
-        import Phoenix.Component
+        import Phoenix.Component, except: [assign: 2, assign: 3, assign_new: 3]
+        import BeaconWeb, only: [assign: 2, assign: 3, assign_new: 3]
         import unquote(components_module), only: [my_component: 2]
 
         unquote(render_function)

--- a/lib/beacon/loader/live_data.ex
+++ b/lib/beacon/loader/live_data.ex
@@ -16,7 +16,7 @@ defmodule Beacon.Loader.LiveData do
         unquote_splicing(live_data_functions)
 
         def live_data(path, params) do
-          Logger.warning("live data not found for site #{unquote(site)} with path #{inspect(path)} and params #{inspect(params)}")
+          Logger.debug("live data not found for site #{unquote(site)} with path #{inspect(path)} and params #{inspect(params)}")
           %{}
         end
       end

--- a/lib/beacon/loader/page.ex
+++ b/lib/beacon/loader/page.ex
@@ -32,7 +32,8 @@ defmodule Beacon.Loader.Page do
         use PhoenixHTMLHelpers
         import Phoenix.HTML
         import Phoenix.HTML.Form
-        import Phoenix.Component
+        import Phoenix.Component, except: [assign: 2, assign: 3, assign_new: 3]
+        import BeaconWeb, only: [assign: 2, assign: 3, assign_new: 3]
         import unquote(components_module), only: [my_component: 2]
 
         unquote_splicing(functions)

--- a/lib/beacon/template.ex
+++ b/lib/beacon/template.ex
@@ -47,6 +47,7 @@ defmodule Beacon.Template do
   @doc false
   # this function is used only for debugging HEEx templates
   # it is NOT supposed to be used to render templates
+  # TODO: keep this function?
   def __render__(site, path_list) when is_list(path_list) do
     raise_not_found = fn -> raise BeaconWeb.NotFoundError, "could not find page #{inspect(path_list)} for site #{site}" end
 
@@ -60,7 +61,12 @@ defmodule Beacon.Template do
 
         components_module = Beacon.Loader.fetch_components_module(site)
         page_module = Beacon.Loader.fetch_page_module(site, page_id)
-        assigns = %{__changed__: %{}, __live_path__: [], __beacon_page_module__: page_module, __beacon_component_module__: components_module}
+
+        assigns = %{
+          __changed__: %{},
+          beacon: %BeaconWeb.BeaconAssigns{private: %{live_path: [], page_module: page_module, components_module: components_module}}
+        }
+
         Beacon.Lifecycle.Template.render_template(page, assigns, BeaconWeb.PageLive.make_env())
 
       _ ->
@@ -70,7 +76,7 @@ defmodule Beacon.Template do
 
   @doc false
   def render(page_module, assigns \\ %{}) when is_atom(page_module) and is_map(assigns) do
-    %{__changed__: %{}, __live_path__: [], beacon_path_params: %{}, beacon_live_data: %{}}
+    %{__changed__: %{}, beacon: %BeaconWeb.BeaconAssigns{private: %{live_path: []}}, beacon_path_params: %{}, beacon_live_data: %{}}
     |> Map.merge(assigns)
     |> page_module.render()
   end

--- a/lib/beacon/template.ex
+++ b/lib/beacon/template.ex
@@ -76,7 +76,7 @@ defmodule Beacon.Template do
 
   @doc false
   def render(page_module, assigns \\ %{}) when is_atom(page_module) and is_map(assigns) do
-    %{__changed__: %{}, beacon: %BeaconWeb.BeaconAssigns{private: %{live_path: []}}, beacon_path_params: %{}, beacon_live_data: %{}}
+    %{__changed__: %{}, beacon: %BeaconWeb.BeaconAssigns{}}
     |> Map.merge(assigns)
     |> page_module.render()
   end

--- a/lib/beacon/template.ex
+++ b/lib/beacon/template.ex
@@ -60,13 +60,6 @@ defmodule Beacon.Template do
   end
 
   @doc false
-  def render_page(page_module, assigns \\ %{}) when is_atom(page_module) and is_map(assigns) do
-    %{__changed__: %{}, beacon: %BeaconWeb.BeaconAssigns{}}
-    |> Map.merge(assigns)
-    |> page_module.render()
-  end
-
-  @doc false
   def choose_template([primary]), do: primary
   def choose_template([primary | variants]), do: choose_template(variants, Enum.random(1..100), primary)
 

--- a/lib/beacon/template.ex
+++ b/lib/beacon/template.ex
@@ -37,6 +37,8 @@ defmodule Beacon.Template do
   Template engines that do not support dynamic content can make use of the `:static` field to store its contents.
   """
 
+  alias BeaconWeb.BeaconAssigns
+
   @typedoc """
   The AST representation of a `t:Phoenix.LiveView.Rendered.t/0` struct.
   """
@@ -45,37 +47,20 @@ defmodule Beacon.Template do
   @type t :: Phoenix.LiveView.Rendered.t() | ast()
 
   @doc false
-  # this function is used only for debugging HEEx templates
-  # it is NOT supposed to be used to render templates
-  # TODO: keep this function?
-  def __render__(site, path_list) when is_list(path_list) do
-    raise_not_found = fn -> raise BeaconWeb.NotFoundError, "could not find page #{inspect(path_list)} for site #{site}" end
+  def render_path(site, path_info, query_params \\ %{}) when is_atom(site) and is_list(path_info) and is_map(query_params) do
+    beacon_assigns =
+      site
+      |> BeaconAssigns.build()
+      |> BeaconAssigns.build(path_info, query_params)
 
-    case Beacon.RouterServer.lookup_path(site, path_list) do
-      {_path, page_id} ->
-        page =
-          case Beacon.Content.get_published_page(site, page_id) do
-            nil -> raise_not_found.()
-            page -> page
-          end
+    page = Beacon.RouterServer.lookup_page!(site, path_info)
+    live_data = BeaconWeb.DataSource.live_data(site, path_info)
 
-        components_module = Beacon.Loader.fetch_components_module(site)
-        page_module = Beacon.Loader.fetch_page_module(site, page_id)
-
-        assigns = %{
-          __changed__: %{},
-          beacon: %BeaconWeb.BeaconAssigns{private: %{live_path: [], page_module: page_module, components_module: components_module}}
-        }
-
-        Beacon.Lifecycle.Template.render_template(page, assigns, BeaconWeb.PageLive.make_env())
-
-      _ ->
-        raise_not_found.()
-    end
+    Beacon.Lifecycle.Template.render_template(page, Map.put(live_data, :beacon, beacon_assigns), BeaconWeb.PageLive.make_env())
   end
 
   @doc false
-  def render(page_module, assigns \\ %{}) when is_atom(page_module) and is_map(assigns) do
+  def render_page(page_module, assigns \\ %{}) when is_atom(page_module) and is_map(assigns) do
     %{__changed__: %{}, beacon: %BeaconWeb.BeaconAssigns{}}
     |> Map.merge(assigns)
     |> page_module.render()

--- a/lib/beacon_web.ex
+++ b/lib/beacon_web.ex
@@ -1,6 +1,41 @@
 defmodule BeaconWeb do
-  @moduledoc false
+  @non_assignables [:beacon]
 
+  @doc """
+  Same as `Phoenix.Component.assign/2` but raises an error if the `key` is a reserved assign by Beacon.
+  """
+  def assign(socket_or_assigns, keyword_or_map) when is_map(keyword_or_map) or is_list(keyword_or_map) do
+    Enum.each(keyword_or_map, fn {key, _value} ->
+      validate_assign_key!(key)
+    end)
+
+    Phoenix.Component.assign(socket_or_assigns, keyword_or_map)
+  end
+
+  @doc """
+  Same as `Phoenix.Component.assign/3` but raises an error if the `key` is a reserved assign by Beacon.
+  """
+  def assign(socket_or_assigns, key, value) do
+    validate_assign_key!(key)
+    Phoenix.Component.assign(socket_or_assigns, key, value)
+  end
+
+  @doc """
+  Same as `Phoenix.Component.assign_new/3` but raises an error if the `key` is a reserved assign by Beacon.
+  """
+  def assign_new(socket_or_assigns, key, fun) do
+    validate_assign_key!(key)
+    Phoenix.Component.assign_new(socket_or_assigns, key, fun)
+  end
+
+  defp validate_assign_key!(assign) when assign in @non_assignables do
+    raise ArgumentError, "#{inspect(assign)} is a reserved assign by Beacon and it cannot be set directly"
+  end
+
+  # we let LiveView perform the other validations
+  defp validate_assign_key!(_key), do: :ok
+
+  @doc false
   def controller do
     quote do
       use Phoenix.Controller,
@@ -13,6 +48,7 @@ defmodule BeaconWeb do
     end
   end
 
+  @doc false
   def live_view do
     quote do
       use Phoenix.LiveView,
@@ -22,6 +58,7 @@ defmodule BeaconWeb do
     end
   end
 
+  @doc false
   def live_component do
     quote do
       use Phoenix.LiveComponent
@@ -30,6 +67,7 @@ defmodule BeaconWeb do
     end
   end
 
+  @doc false
   def html do
     quote do
       use Phoenix.Component
@@ -43,6 +81,7 @@ defmodule BeaconWeb do
     end
   end
 
+  @doc false
   defp html_helpers do
     quote do
       # HTML helpers and components

--- a/lib/beacon_web.ex
+++ b/lib/beacon_web.ex
@@ -2,7 +2,7 @@ defmodule BeaconWeb do
   @non_assignables [:beacon]
 
   @doc """
-  Same as `Phoenix.Component.assign/2` but raises an error if the `key` is a reserved assign by Beacon.
+  Same as `Phoenix.Component.assign/2` but raises an error if the key is a reserved assign by Beacon.
   """
   def assign(socket_or_assigns, keyword_or_map) when is_map(keyword_or_map) or is_list(keyword_or_map) do
     Enum.each(keyword_or_map, fn {key, _value} ->
@@ -101,9 +101,7 @@ defmodule BeaconWeb do
     end
   end
 
-  @doc """
-  When used, dispatch to the appropriate controller/view/etc.
-  """
+  @doc false
   defmacro __using__(which) when is_atom(which) do
     apply(__MODULE__, which, [])
   end

--- a/lib/beacon_web/beacon_assigns.ex
+++ b/lib/beacon_web/beacon_assigns.ex
@@ -28,6 +28,33 @@ defmodule BeaconWeb.BeaconAssigns do
             }
 
   @doc false
+  def build(site) when is_atom(site), do: %__MODULE__{site: site}
+
+  def build(beacon_assigns = %__MODULE__{}, path_info, query_params) when is_list(path_info) and is_map(query_params) do
+    site = beacon_assigns.site
+    %{site: ^site} = page = Beacon.RouterServer.lookup_page!(beacon_assigns.site, path_info)
+    components_module = Beacon.Loader.Components.module_name(site)
+    page_module = Beacon.Loader.Page.module_name(site, page.id)
+    live_data = BeaconWeb.DataSource.live_data(site, path_info, Map.drop(query_params, ["path"]))
+    page_title = BeaconWeb.DataSource.page_title(site, page.id, live_data)
+
+    %{
+      beacon_assigns
+      | query_params: query_params,
+        page: %{path: page.path, title: page_title},
+        private: %{
+          live_data_keys: Map.keys(live_data),
+          live_path: path_info,
+          layout_id: page.layout_id,
+          page_id: page.id,
+          page_updated_at: DateTime.utc_now(),
+          page_module: page_module,
+          components_module: components_module
+        }
+    }
+  end
+
+  @doc false
   def update(_socket_or_assigns, _key, _value)
 
   def update(%{assigns: %{beacon: _beacon}} = socket, key, value) do

--- a/lib/beacon_web/beacon_assigns.ex
+++ b/lib/beacon_web/beacon_assigns.ex
@@ -1,0 +1,46 @@
+defmodule BeaconWeb.BeaconAssigns do
+  @moduledoc """
+  TODO
+  """
+
+  @derive {Inspect, only: [:site, :path_params, :query_params, :page]}
+
+  defstruct site: nil,
+            path_params: nil,
+            query_params: nil,
+            page: %{title: nil},
+            private: %{
+              live_path: nil,
+              layout_id: nil,
+              page_id: nil,
+              page_updated_at: nil,
+              page_module: nil,
+              components_module: nil
+            }
+
+  @doc false
+  def update(_socket_or_assigns, _key, _value)
+
+  def update(%{assigns: %{beacon: _beacon}} = socket, key, value) do
+    do_update_socket_or_assigns(socket, key, value)
+  end
+
+  def update(%{beacon: _beacon} = assigns, key, value) do
+    do_update_socket_or_assigns(assigns, key, value)
+  end
+
+  def update(_socket_or_assigns, _key, _value), do: raise("expected :beacon assign in socket but none found")
+
+  defp do_update_socket_or_assigns(socket_or_assigns, key, value) do
+    Phoenix.Component.update(socket_or_assigns, :beacon, fn beacon ->
+      Map.put(beacon, key, value)
+    end)
+  end
+
+  @doc false
+  def update_private(%{assigns: %{beacon: _beacon}} = socket, key, value) do
+    Phoenix.Component.update(socket, :beacon, fn beacon ->
+      put_in(beacon, [Access.key(:private), Access.key(key)], value)
+    end)
+  end
+end

--- a/lib/beacon_web/beacon_assigns.ex
+++ b/lib/beacon_web/beacon_assigns.ex
@@ -1,6 +1,14 @@
 defmodule BeaconWeb.BeaconAssigns do
   @moduledoc """
-  TODO
+  Container of Beacon assigns related to the current page.
+
+  These assigns can be used in page template or Elixir code, for example in in an event handler,
+  and  they are made available as `@beacon`:
+
+  ## Example
+
+      <h1><%= @beacon.site %></h1>
+
   """
 
   @derive {Inspect, only: [:site, :path_params, :query_params, :page]}
@@ -8,7 +16,6 @@ defmodule BeaconWeb.BeaconAssigns do
   defstruct site: nil,
             path_params: nil,
             query_params: nil,
-            page: %{title: nil},
             private: %{
               live_path: nil,
               layout_id: nil,

--- a/lib/beacon_web/beacon_assigns.ex
+++ b/lib/beacon_web/beacon_assigns.ex
@@ -14,11 +14,12 @@ defmodule BeaconWeb.BeaconAssigns do
   @derive {Inspect, only: [:site, :path_params, :query_params, :page]}
 
   defstruct site: nil,
-            path_params: nil,
-            query_params: nil,
+            path_params: %{},
+            query_params: %{},
             page: %{title: nil},
             private: %{
-              live_path: nil,
+              live_data_keys: [],
+              live_path: [],
               layout_id: nil,
               page_id: nil,
               page_updated_at: nil,

--- a/lib/beacon_web/beacon_assigns.ex
+++ b/lib/beacon_web/beacon_assigns.ex
@@ -16,6 +16,7 @@ defmodule BeaconWeb.BeaconAssigns do
   defstruct site: nil,
             path_params: nil,
             query_params: nil,
+            page: %{title: nil},
             private: %{
               live_path: nil,
               layout_id: nil,

--- a/lib/beacon_web/beacon_assigns.ex
+++ b/lib/beacon_web/beacon_assigns.ex
@@ -16,7 +16,7 @@ defmodule BeaconWeb.BeaconAssigns do
   defstruct site: nil,
             path_params: %{},
             query_params: %{},
-            page: %{title: nil},
+            page: %{path: nil, title: nil},
             private: %{
               live_data_keys: [],
               live_path: [],
@@ -36,11 +36,13 @@ defmodule BeaconWeb.BeaconAssigns do
     components_module = Beacon.Loader.Components.module_name(site)
     page_module = Beacon.Loader.Page.module_name(site, page.id)
     live_data = BeaconWeb.DataSource.live_data(site, path_info, Map.drop(query_params, ["path"]))
+    path_params = Beacon.Router.path_params(page.path, path_info)
     page_title = BeaconWeb.DataSource.page_title(site, page.id, live_data)
 
     %{
       beacon_assigns
-      | query_params: query_params,
+      | path_params: path_params,
+        query_params: query_params,
         page: %{path: page.path, title: page_title},
         private: %{
           live_data_keys: Map.keys(live_data),

--- a/lib/beacon_web/beacon_assigns.ex
+++ b/lib/beacon_web/beacon_assigns.ex
@@ -32,7 +32,7 @@ defmodule BeaconWeb.BeaconAssigns do
 
   def build(beacon_assigns = %__MODULE__{}, path_info, query_params) when is_list(path_info) and is_map(query_params) do
     site = beacon_assigns.site
-    %{site: ^site} = page = Beacon.RouterServer.lookup_page!(beacon_assigns.site, path_info)
+    %{site: ^site} = page = Beacon.RouterServer.lookup_page!(site, path_info)
     components_module = Beacon.Loader.Components.module_name(site)
     page_module = Beacon.Loader.Page.module_name(site, page.id)
     live_data = BeaconWeb.DataSource.live_data(site, path_info, Map.drop(query_params, ["path"]))
@@ -70,13 +70,6 @@ defmodule BeaconWeb.BeaconAssigns do
   defp do_update_socket_or_assigns(socket_or_assigns, key, value) do
     Phoenix.Component.update(socket_or_assigns, :beacon, fn beacon ->
       Map.put(beacon, key, value)
-    end)
-  end
-
-  @doc false
-  def update_private(%{assigns: %{beacon: _beacon}} = socket, key, value) do
-    Phoenix.Component.update(socket, :beacon, fn beacon ->
-      put_in(beacon, [Access.key(:private), Access.key(key)], value)
     end)
   end
 end

--- a/lib/beacon_web/components/layouts.ex
+++ b/lib/beacon_web/components/layouts.ex
@@ -7,7 +7,8 @@ defmodule BeaconWeb.Layouts do
   embed_templates "layouts/*"
 
   # TODO: style nonce
-  def asset_path(%{assigns: %{beacon: %{site: site}}} = conn, asset) when asset in [:css, :js] do
+  def asset_path(conn, asset) when asset in [:css, :js] do
+    %{assigns: %{beacon: %{site: site}}} = conn
     prefix = router(conn).__beacon_scoped_prefix_for_site__(site)
 
     hash =

--- a/lib/beacon_web/components/layouts.ex
+++ b/lib/beacon_web/components/layouts.ex
@@ -23,13 +23,16 @@ defmodule BeaconWeb.Layouts do
   defp router(%Plug.Conn{private: %{phoenix_router: router}}), do: router
   defp router(%Phoenix.LiveView.Socket{router: router}), do: router
 
-  def render_dynamic_layout(%{beacon: %{site: site, private: %{layout_id: layout_id}}} = assigns) do
+  def render_dynamic_layout(assigns) do
+    %{beacon: %{site: site, private: %{layout_id: layout_id}}} = assigns
+
     site
     |> Beacon.Loader.fetch_layout_module(layout_id)
     |> Beacon.apply_mfa(:render, [assigns])
   end
 
-  def live_socket_path(%{beacon: %{site: site}}) do
+  def live_socket_path(assigns) do
+    %{beacon: %{site: site}} = assigns
     Beacon.Config.fetch!(site).live_socket_path
   end
 
@@ -45,7 +48,8 @@ defmodule BeaconWeb.Layouts do
     |> Beacon.apply_mfa(:layout_assigns, [])
   end
 
-  def render_page_title(%{beacon: %{site: site, private: %{page_id: page_id, live_data_keys: live_data_keys}}} = assigns) do
+  def render_page_title(assigns) do
+    %{beacon: %{site: site, private: %{page_id: page_id, live_data_keys: live_data_keys}}} = assigns
     live_data = Map.take(assigns, live_data_keys)
     BeaconWeb.DataSource.page_title(site, page_id, live_data)
   end
@@ -77,7 +81,8 @@ defmodule BeaconWeb.Layouts do
     compiled_page_meta_tags(assigns)
   end
 
-  defp compiled_page_meta_tags(%{beacon: %{site: site, private: %{page_id: page_id}}}) do
+  defp compiled_page_meta_tags(assigns) do
+    %{beacon: %{site: site, private: %{page_id: page_id}}} = assigns
     %{meta_tags: meta_tags} = compiled_page_assigns(site, page_id)
     meta_tags
   end
@@ -92,12 +97,14 @@ defmodule BeaconWeb.Layouts do
     compiled_layout_meta_tags(assigns)
   end
 
-  defp compiled_layout_meta_tags(%{beacon: %{site: site, private: %{layout_id: layout_id}}}) do
+  defp compiled_layout_meta_tags(assigns) do
+    %{beacon: %{site: site, private: %{layout_id: layout_id}}} = assigns
     %{meta_tags: meta_tags} = compiled_layout_assigns(site, layout_id)
     meta_tags
   end
 
-  defp render_schema(%{beacon: %{site: site, private: %{page_id: page_id}}} = assigns) do
+  defp render_schema(assigns) do
+    %{beacon: %{site: site, private: %{page_id: page_id}}} = assigns
     %{raw_schema: raw_schema} = compiled_page_assigns(site, page_id)
 
     is_empty = fn raw_schema ->
@@ -138,7 +145,8 @@ defmodule BeaconWeb.Layouts do
     compiled_layout_resource_links(assigns)
   end
 
-  defp compiled_layout_resource_links(%{beacon: %{site: site, private: %{layout_id: layout_id}}}) do
+  defp compiled_layout_resource_links(assigns) do
+    %{beacon: %{site: site, private: %{layout_id: layout_id}}} = assigns
     %{resource_links: resource_links} = compiled_layout_assigns(site, layout_id)
     resource_links
   end

--- a/lib/beacon_web/components/layouts.ex
+++ b/lib/beacon_web/components/layouts.ex
@@ -7,8 +7,7 @@ defmodule BeaconWeb.Layouts do
   embed_templates "layouts/*"
 
   # TODO: style nonce
-  def asset_path(conn, asset) when asset in [:css, :js] do
-    %{assigns: %{__site__: site}} = conn
+  def asset_path(%{assigns: %{beacon: %{site: site}}} = conn, asset) when asset in [:css, :js] do
     prefix = router(conn).__beacon_scoped_prefix_for_site__(site)
 
     hash =
@@ -24,16 +23,13 @@ defmodule BeaconWeb.Layouts do
   defp router(%Plug.Conn{private: %{phoenix_router: router}}), do: router
   defp router(%Phoenix.LiveView.Socket{router: router}), do: router
 
-  def dynamic_layout?(%{__dynamic_layout_id__: _}), do: true
-  def dynamic_layout?(_), do: false
-
-  def render_dynamic_layout(%{__site__: site, __dynamic_layout_id__: layout_id} = assigns) do
+  def render_dynamic_layout(%{beacon: %{site: site, private: %{layout_id: layout_id}}} = assigns) do
     site
     |> Beacon.Loader.fetch_layout_module(layout_id)
     |> Beacon.apply_mfa(:render, [assigns])
   end
 
-  def live_socket_path(%{__site__: site}) do
+  def live_socket_path(%{beacon: %{site: site}}) do
     Beacon.Config.fetch!(site).live_socket_path
   end
 
@@ -49,8 +45,7 @@ defmodule BeaconWeb.Layouts do
     |> Beacon.apply_mfa(:layout_assigns, [])
   end
 
-  def render_page_title(assigns) do
-    %{__site__: site, __dynamic_page_id__: page_id, beacon_live_data: beacon_live_data} = assigns
+  def render_page_title(%{beacon_live_data: beacon_live_data, beacon: %{site: site, private: %{page_id: page_id}}}) do
     BeaconWeb.DataSource.page_title(site, page_id, beacon_live_data)
   end
 
@@ -81,7 +76,7 @@ defmodule BeaconWeb.Layouts do
     compiled_page_meta_tags(assigns)
   end
 
-  defp compiled_page_meta_tags(%{__site__: site, __dynamic_page_id__: page_id}) do
+  defp compiled_page_meta_tags(%{beacon: %{site: site, private: %{page_id: page_id}}}) do
     %{meta_tags: meta_tags} = compiled_page_assigns(site, page_id)
     meta_tags
   end
@@ -96,13 +91,13 @@ defmodule BeaconWeb.Layouts do
     compiled_layout_meta_tags(assigns)
   end
 
-  defp compiled_layout_meta_tags(%{__site__: site, __dynamic_layout_id__: layout_id}) do
+  defp compiled_layout_meta_tags(%{beacon: %{site: site, private: %{layout_id: layout_id}}}) do
     %{meta_tags: meta_tags} = compiled_layout_assigns(site, layout_id)
     meta_tags
   end
 
-  def render_schema(assigns) do
-    %{raw_schema: raw_schema} = compiled_page_assigns(assigns.__site__, assigns.__dynamic_page_id__)
+  defp render_schema(%{beacon: %{site: site, private: %{page_id: page_id}}} = assigns) do
+    %{raw_schema: raw_schema} = compiled_page_assigns(site, page_id)
 
     is_empty = fn raw_schema ->
       raw_schema |> Enum.map(&Map.values/1) |> List.flatten() == []
@@ -121,7 +116,7 @@ defmodule BeaconWeb.Layouts do
     end
   end
 
-  def render_resource_links(%{__dynamic_layout_id__: _, __site__: _} = assigns) do
+  def render_resource_links(assigns) do
     resource_links = layout_resource_links(assigns) || []
     assigns = assign(assigns, :resource_links, resource_links)
 
@@ -131,8 +126,6 @@ defmodule BeaconWeb.Layouts do
     <% end %>
     """
   end
-
-  def render_resource_links(_assigns), do: []
 
   defp layout_resource_links(%{layout_assigns: %{resource_links: resource_links}} = assigns) do
     assigns
@@ -144,7 +137,7 @@ defmodule BeaconWeb.Layouts do
     compiled_layout_resource_links(assigns)
   end
 
-  defp compiled_layout_resource_links(%{__site__: site, __dynamic_layout_id__: layout_id}) do
+  defp compiled_layout_resource_links(%{beacon: %{site: site, private: %{layout_id: layout_id}}}) do
     %{resource_links: resource_links} = compiled_layout_assigns(site, layout_id)
     resource_links
   end

--- a/lib/beacon_web/components/layouts.ex
+++ b/lib/beacon_web/components/layouts.ex
@@ -45,8 +45,9 @@ defmodule BeaconWeb.Layouts do
     |> Beacon.apply_mfa(:layout_assigns, [])
   end
 
-  def render_page_title(%{beacon_live_data: beacon_live_data, beacon: %{site: site, private: %{page_id: page_id}}}) do
-    BeaconWeb.DataSource.page_title(site, page_id, beacon_live_data)
+  def render_page_title(%{beacon: %{site: site, private: %{page_id: page_id, live_data_keys: live_data_keys}}} = assigns) do
+    live_data = Map.take(assigns, live_data_keys)
+    BeaconWeb.DataSource.page_title(site, page_id, live_data)
   end
 
   def render_meta_tags(assigns) do

--- a/lib/beacon_web/controllers/api/page_json.ex
+++ b/lib/beacon_web/controllers/api/page_json.ex
@@ -36,7 +36,7 @@ defmodule BeaconWeb.API.PageJSON do
   end
 
   defp page_ast(page, live_data) do
-    case JSONEncoder.encode(page.site, page.template, %{beacon_live_data: live_data}) do
+    case JSONEncoder.encode(page.site, page.template, live_data) do
       {:ok, ast} -> ast
       _ -> []
     end
@@ -52,11 +52,13 @@ defmodule BeaconWeb.API.PageJSON do
     Map.put(data, :layout, layout)
   end
 
-  defp maybe_include_layout(data, _page, _beacon_live_data), do: data
+  defp maybe_include_layout(data, _page, _live_data), do: data
 
   # TODO: cache layout ast instead of recomputing for every page
   defp layout_ast(layout, page_template, live_data) do
-    case JSONEncoder.encode(layout.site, layout.template, %{inner_content: page_template, beacon_live_data: live_data}) do
+    assigns = Map.put(live_data, :inner_content, page_template)
+
+    case JSONEncoder.encode(layout.site, layout.template, assigns) do
       {:ok, ast} -> ast
       _ -> []
     end

--- a/lib/beacon_web/controllers/api/page_json.ex
+++ b/lib/beacon_web/controllers/api/page_json.ex
@@ -32,9 +32,6 @@ defmodule BeaconWeb.API.PageJSON do
 
     assigns = Map.put(live_data, :beacon, beacon_assigns)
 
-    dbg(assigns)
-    dbg(assigns.beacon.private)
-
     %{
       id: page.id,
       layout_id: page.layout_id,

--- a/lib/beacon_web/controllers/api/page_json.ex
+++ b/lib/beacon_web/controllers/api/page_json.ex
@@ -4,6 +4,7 @@ defmodule BeaconWeb.API.PageJSON do
   alias Beacon.Content.Layout
   alias Beacon.Content.Page
   alias Beacon.Template.HEEx.JSONEncoder
+  alias BeaconWeb.BeaconAssigns
 
   @doc """
   Renders a list of pages.
@@ -21,7 +22,18 @@ defmodule BeaconWeb.API.PageJSON do
 
   defp data(%Page{} = page) do
     path_info = for segment <- String.split(page.path, "/"), segment != "", do: segment
+
+    beacon_assigns =
+      page.site
+      |> BeaconAssigns.build()
+      |> BeaconAssigns.build(path_info, %{})
+
     live_data = BeaconWeb.DataSource.live_data(page.site, path_info, %{})
+
+    assigns = Map.put(live_data, :beacon, beacon_assigns)
+
+    dbg(assigns)
+    dbg(assigns.beacon.private)
 
     %{
       id: page.id,
@@ -30,33 +42,33 @@ defmodule BeaconWeb.API.PageJSON do
       site: page.site,
       template: page.template,
       format: page.format,
-      ast: page_ast(page, live_data)
+      ast: page_ast(page, assigns)
     }
-    |> maybe_include_layout(page, live_data)
+    |> maybe_include_layout(page, assigns)
   end
 
-  defp page_ast(page, live_data) do
-    case JSONEncoder.encode(page.site, page.template, live_data) do
+  defp page_ast(page, assigns) do
+    case JSONEncoder.encode(page.site, page.template, assigns) do
       {:ok, ast} -> ast
       _ -> []
     end
   end
 
-  defp maybe_include_layout(%{template: page_template} = data, %Page{layout: %Layout{} = layout}, live_data) do
+  defp maybe_include_layout(%{template: page_template} = data, %Page{layout: %Layout{} = layout}, assigns) do
     layout =
       layout
       |> Map.from_struct()
       |> Map.drop([:__meta__])
-      |> Map.put(:ast, layout_ast(layout, page_template, live_data))
+      |> Map.put(:ast, layout_ast(layout, page_template, assigns))
 
     Map.put(data, :layout, layout)
   end
 
-  defp maybe_include_layout(data, _page, _live_data), do: data
+  defp maybe_include_layout(data, _page, _assigns), do: data
 
   # TODO: cache layout ast instead of recomputing for every page
-  defp layout_ast(layout, page_template, live_data) do
-    assigns = Map.put(live_data, :inner_content, page_template)
+  defp layout_ast(layout, page_template, assigns) do
+    assigns = Map.put(assigns, :inner_content, page_template)
 
     case JSONEncoder.encode(layout.site, layout.template, assigns) do
       {:ok, ast} -> ast

--- a/lib/beacon_web/controllers/error_html.ex
+++ b/lib/beacon_web/controllers/error_html.ex
@@ -9,7 +9,7 @@ defmodule BeaconWeb.ErrorHTML do
     error_module = Beacon.Loader.fetch_error_page_module(site)
 
     conn
-    |> Plug.Conn.assign(:beacon, %BeaconWeb.BeaconAssigns{site: site})
+    |> Plug.Conn.assign(:beacon, BeaconWeb.BeaconAssigns.build(site))
     |> error_module.render(String.to_integer(status_code))
   rescue
     error ->

--- a/lib/beacon_web/controllers/error_html.ex
+++ b/lib/beacon_web/controllers/error_html.ex
@@ -7,8 +7,10 @@ defmodule BeaconWeb.ErrorHTML do
   def render(<<status_code::binary-size(3), _rest::binary>> = template, %{conn: conn}) do
     {_, _, %{extra: %{session: %{"beacon_site" => site}}}} = conn.private.phoenix_live_view
     error_module = Beacon.Loader.fetch_error_page_module(site)
-    conn = Plug.Conn.assign(conn, :__site__, site)
-    error_module.render(conn, String.to_integer(status_code))
+
+    conn
+    |> Plug.Conn.assign(:beacon, %BeaconWeb.BeaconAssigns{site: site})
+    |> error_module.render(String.to_integer(status_code))
   rescue
     error ->
       Logger.error("""

--- a/lib/beacon_web/data_source.ex
+++ b/lib/beacon_web/data_source.ex
@@ -34,7 +34,8 @@ defmodule BeaconWeb.DataSource do
     end
   end
 
-  def meta_tags(%{beacon: %{site: site, private: %{page_id: page_id, live_data_keys: live_data_keys}}} = assigns) do
+  def meta_tags(assigns) do
+    %{beacon: %{site: site, private: %{page_id: page_id, live_data_keys: live_data_keys}}} = assigns
     live_data = Map.take(assigns, live_data_keys)
 
     page =

--- a/lib/beacon_web/data_source.ex
+++ b/lib/beacon_web/data_source.ex
@@ -34,9 +34,7 @@ defmodule BeaconWeb.DataSource do
     end
   end
 
-  def meta_tags(assigns) do
-    %{__site__: site, __dynamic_page_id__: page_id} = assigns
-
+  def meta_tags(%{beacon: %{site: site, private: %{page_id: page_id}}} = assigns) do
     page =
       site
       |> Beacon.Loader.fetch_page_module(page_id)

--- a/lib/beacon_web/data_source.ex
+++ b/lib/beacon_web/data_source.ex
@@ -34,7 +34,9 @@ defmodule BeaconWeb.DataSource do
     end
   end
 
-  def meta_tags(%{beacon: %{site: site, private: %{page_id: page_id}}} = assigns) do
+  def meta_tags(%{beacon: %{site: site, private: %{page_id: page_id, live_data_keys: live_data_keys}}} = assigns) do
+    live_data = Map.take(assigns, live_data_keys)
+
     page =
       site
       |> Beacon.Loader.fetch_page_module(page_id)
@@ -43,7 +45,7 @@ defmodule BeaconWeb.DataSource do
     assigns
     |> BeaconWeb.Layouts.meta_tags()
     |> List.wrap()
-    |> Enum.map(&interpolate_meta_tag(&1, %{page: page, live_data: assigns.beacon_live_data}))
+    |> Enum.map(&interpolate_meta_tag(&1, %{page: page, live_data: live_data}))
   end
 
   defp interpolate_meta_tag(meta_tag, values) when is_map(meta_tag) do

--- a/lib/beacon_web/exceptions.ex
+++ b/lib/beacon_web/exceptions.ex
@@ -34,3 +34,7 @@ end
 defmodule BeaconWeb.NotFoundError do
   defexception [:message, plug_status: 404]
 end
+
+defmodule BeaconWeb.ServerError do
+  defexception [:message, plug_status: 500]
+end

--- a/lib/beacon_web/live/page_live.ex
+++ b/lib/beacon_web/live/page_live.ex
@@ -24,7 +24,6 @@ defmodule BeaconWeb.PageLive do
   def render(assigns) do
     site = assigns.beacon.site
     live_path = assigns.beacon.private.live_path
-
     page = RouterServer.lookup_page!(site, live_path)
     path_params = Beacon.Router.path_params(page.path, live_path)
 

--- a/lib/beacon_web/live/page_live.ex
+++ b/lib/beacon_web/live/page_live.ex
@@ -100,8 +100,11 @@ defmodule BeaconWeb.PageLive do
 
     socket =
       socket
-      |> Component.assign(:beacon_live_data, live_data)
       |> Component.assign(:page_title, page_title)
+      # TODO: remove deprecated @beacon_live_data
+      |> Component.assign(:beacon_live_data, live_data)
+      |> Component.assign(live_data)
+      |> BeaconAssigns.update_private(:live_data_keys, Map.keys(live_data))
       |> BeaconAssigns.update_private(:live_path, path)
       |> BeaconAssigns.update_private(:layout_id, page.layout_id)
       |> BeaconAssigns.update_private(:page_id, page.id)

--- a/lib/beacon_web/live/page_live.ex
+++ b/lib/beacon_web/live/page_live.ex
@@ -16,13 +16,8 @@ defmodule BeaconWeb.PageLive do
     %{"path" => path} = params
     %{"beacon_site" => site} = session
 
-    socket =
-      socket
-      |> Component.assign(:beacon, %BeaconAssigns{})
-      |> BeaconAssigns.update(:site, site)
-
+    socket = Component.assign(socket, :beacon, BeaconAssigns.build(site))
     if connected?(socket), do: :ok = Beacon.PubSub.subscribe_to_page(site, path)
-
     {:ok, socket, layout: {BeaconWeb.Layouts, :dynamic}}
   end
 
@@ -86,35 +81,22 @@ defmodule BeaconWeb.PageLive do
   end
 
   def handle_params(params, _url, socket) do
-    %{"path" => path} = params
-    site = socket.assigns.beacon.site
-
-    page = RouterServer.lookup_page!(site, path)
-    live_data = BeaconWeb.DataSource.live_data(site, path, Map.drop(params, ["path"]))
-    components_module = Beacon.Loader.Components.module_name(site)
-    page_module = Beacon.Loader.Page.module_name(site, page.id)
-    page_title = BeaconWeb.DataSource.page_title(site, page.id, live_data)
+    %{"path" => path_info} = params
+    %{site: site, page: page, query_params: query_params} = beacon_assigns = BeaconAssigns.build(socket.assigns.beacon, path_info, params)
+    live_data = BeaconWeb.DataSource.live_data(site, path_info, Map.drop(params, ["path"]))
 
     Process.put(:__beacon_site__, site)
     Process.put(:__beacon_page_path__, page.path)
 
     socket =
       socket
-      |> Component.assign(:page_title, page_title)
+      |> Component.assign(:page_title, page.title)
+      |> Component.assign(live_data)
       # TODO: remove deprecated @beacon_live_data
       |> Component.assign(:beacon_live_data, live_data)
-      |> Component.assign(live_data)
-      |> BeaconAssigns.update_private(:live_data_keys, Map.keys(live_data))
-      |> BeaconAssigns.update_private(:live_path, path)
-      |> BeaconAssigns.update_private(:layout_id, page.layout_id)
-      |> BeaconAssigns.update_private(:page_id, page.id)
-      |> BeaconAssigns.update_private(:page_updated_at, DateTime.utc_now())
-      |> BeaconAssigns.update_private(:page_module, page_module)
-      |> BeaconAssigns.update_private(:components_module, components_module)
-      |> BeaconAssigns.update(:query_params, params)
-      |> BeaconAssigns.update(:page, %{title: page_title})
       # TODO: remove deprecated @beacon_query_params
-      |> Component.assign(:beacon_query_params, params)
+      |> Component.assign(:beacon_query_params, query_params)
+      |> Component.assign(:beacon, beacon_assigns)
 
     {:noreply, push_event(socket, "beacon:page-updated", %{meta_tags: BeaconWeb.DataSource.meta_tags(socket.assigns)})}
   end

--- a/priv/templates/install/seeds.exs
+++ b/priv/templates/install/seeds.exs
@@ -48,7 +48,7 @@ page =
     <main>
       <h2>Some Values:</h2>
       <ul>
-        <%%= for val <- @beacon_live_data[:vals] do %>
+        <%%= for val <- @vals do %>
           <%%= my_component("sample_component", val: val) %>
         <%% end %>
       </ul>
@@ -99,7 +99,7 @@ Content.create_assign_for_live_data(home_live_data, %{format: :elixir, key: "val
     <h2>A blog</h2>
     <ul>
       <li>Path Params Blog Slug: <%%= @beacon_path_params["blog_slug"] %></li>
-      <li>Live Data blog_slug_uppercase: <%%= @beacon_live_data[:blog_slug_uppercase] %></li>
+      <li>Live Data blog_slug_uppercase: <%%= @blog_slug_uppercase %></li>
     </ul>
   </main>
   """

--- a/test/beacon/loader/error_page_test.exs
+++ b/test/beacon/loader/error_page_test.exs
@@ -6,7 +6,7 @@ defmodule Beacon.Loader.ErrorPageTest do
 
   defp build_conn(conn) do
     conn
-    |> Plug.Conn.assign(:__site__, @site)
+    |> Plug.Conn.assign(:beacon, %BeaconWeb.BeaconAssigns{site: @site})
     |> Plug.Conn.put_private(:phoenix_router, Beacon.BeaconTest.Router)
   end
 

--- a/test/beacon/tailwind_compiler_test.exs
+++ b/test/beacon/tailwind_compiler_test.exs
@@ -32,7 +32,7 @@ defmodule Beacon.RuntimeCSS.TailwindCompilerTest do
       template: """
       <main>
         <h2 class="text-gray-200">Some Values:</h2>
-        <%= for val <- @beacon_live_data[:vals] do %>
+        <%= for val <- @vals do %>
           <%= my_component("sample_component", val: val) %>
         <% end %>
       </main>
@@ -45,7 +45,7 @@ defmodule Beacon.RuntimeCSS.TailwindCompilerTest do
       template: """
       <main>
         <h2 class="text-gray-200">Some Values:</h2>
-        <%= for val <- @beacon_live_data[:vals] do %>
+        <%= for val <- @vals do %>
           <%= my_component("sample_component", val: val) %>
         <% end %>
       </main>

--- a/test/beacon/template/heex/heex_decoder_test.exs
+++ b/test/beacon/template/heex/heex_decoder_test.exs
@@ -56,11 +56,11 @@ defmodule Beacon.Template.HEEx.HEExDecoderTest do
 
     assert_equal(
       ~S"""
-      <%= for val <- @beacon_live_data[:vals] do %>
+      <%= for val <- @vals do %>
         <%= val %>
       <% end %>
       """,
-      %{beacon_live_data: %{vals: [1]}}
+      %{vals: [1]}
     )
 
     assert_equal(~S"""
@@ -85,6 +85,6 @@ defmodule Beacon.Template.HEEx.HEExDecoderTest do
   end
 
   test "live data assigns" do
-    assert_equal(~S|<%= @beacon_live_data[:name] %>|, %{beacon_live_data: %{name: "Beacon"}})
+    assert_equal(~S|<%= @name %>|, %{name: "Beacon"})
   end
 end

--- a/test/beacon/template/heex/json_encoder_test.exs
+++ b/test/beacon/template/heex/json_encoder_test.exs
@@ -60,25 +60,25 @@ defmodule Beacon.Template.HEEx.JSONEncoderTest do
     assert_output(
       ~S|
       <img
-        alt={@beacon_live_data.person.bio}
-        src={@beacon_live_data.person.picture}
+        alt={@person.bio}
+        src={@person.picture}
         class="w-full h-auto max-w-full"
       />
       |,
       [
         %{
           "attrs" => %{
-            "alt" => "{@beacon_live_data.person.bio}",
+            "alt" => "{@person.bio}",
             "class" => "w-full h-auto max-w-full",
             "self_close" => true,
-            "src" => "{@beacon_live_data.person.picture}"
+            "src" => "{@person.picture}"
           },
           "content" => [],
           "rendered_html" => "<img alt=\"person bio\" src=\"profile.jpg\" class=\"w-full h-auto max-w-full\">",
           "tag" => "img"
         }
       ],
-      %{beacon_live_data: %{person: %{bio: "person bio", picture: "profile.jpg"}}}
+      %{person: %{bio: "person bio", picture: "profile.jpg"}}
     )
   end
 
@@ -190,11 +190,11 @@ defmodule Beacon.Template.HEEx.JSONEncoderTest do
 
   test "comprehensions" do
     template = ~S|
-        <%= for employee <- @beacon_live_data[:employees] do %>
+        <%= for employee <- @employees do %>
           <!-- regular <!-- comment --> -->
           <%= employee.position %>
           <div>
-            <%= for person <- @beacon_live_data[:persons] do %>
+            <%= for person <- @persons do %>
               <%= if person.id == employee.id do %>
                 <span><%= person.name %></span>
                 <img src={if person.picture , do: person.picture, else: "default.jpg"} width="200" />
@@ -207,7 +207,7 @@ defmodule Beacon.Template.HEEx.JSONEncoderTest do
     assert {:ok,
             [
               %{
-                "arg" => "for employee <- @beacon_live_data[:employees] do",
+                "arg" => "for employee <- @employees do",
                 "tag" => "eex_block",
                 "rendered_html" =>
                   "\n<!-- regular <!-- comment --> -->\nCEO\n          <div>\n\n\n                <span>José</span>\n                <img width=\"200\" src=\"profile.jpg\">\n\n\n\n\n          </div>\n\n<!-- regular <!-- comment --> -->\nManager\n          <div>\n\n\n\n\n                <span>Chris</span>\n                <img width=\"200\" src=\"default.jpg\">\n\n\n          </div>\n",
@@ -215,10 +215,8 @@ defmodule Beacon.Template.HEEx.JSONEncoderTest do
               }
             ]} =
              JSONEncoder.encode(:my_site, template, %{
-               beacon_live_data: %{
-                 employees: [%{id: 1, position: "CEO"}, %{id: 2, position: "Manager"}],
-                 persons: [%{id: 1, name: "José", picture: "profile.jpg"}, %{id: 2, name: "Chris", picture: nil}]
-               }
+               employees: [%{id: 1, position: "CEO"}, %{id: 2, position: "Manager"}],
+               persons: [%{id: 1, name: "José", picture: "profile.jpg"}, %{id: 2, name: "Chris", picture: nil}]
              })
 
     assert is_binary(ast)
@@ -226,17 +224,17 @@ defmodule Beacon.Template.HEEx.JSONEncoderTest do
 
   test "live data" do
     assert_output(
-      "<%= inspect(@beacon_live_data[:vals]) %>",
+      "<%= inspect(@vals) %>",
       [
         %{
           "attrs" => %{},
-          "content" => ["inspect(@beacon_live_data[:vals])"],
+          "content" => ["inspect(@vals)"],
           "metadata" => %{"opt" => ~c"="},
           "rendered_html" => "[1, 2, 3]",
           "tag" => "eex"
         }
       ],
-      %{beacon_live_data: %{vals: [1, 2, 3]}}
+      %{vals: [1, 2, 3]}
     )
   end
 

--- a/test/beacon/template/heex/tokenizer_test.exs
+++ b/test/beacon/template/heex/tokenizer_test.exs
@@ -37,11 +37,11 @@ defmodule Beacon.Template.HEEx.TokenizerTest do
 
   test "comprehension" do
     assert Tokenizer.tokenize(~S|
-      <%= for employee <- @beacon_live_data[:employees] do %>
+      <%= for employee <- @employees do %>
         <!-- regular <!-- comment --> -->
         <%= employee.position %>
         <div>
-          <%= for person <- @beacon_live_data[:persons] do %>
+          <%= for person <- @persons do %>
             <%= if person.id == employee.id do %>
               <span><%= person.name %></span>
               <img src={if person.picture , do: person.picture, else: "default.jpg"} width="200" />
@@ -54,7 +54,7 @@ defmodule Beacon.Template.HEEx.TokenizerTest do
              [
                {
                  :eex_block,
-                 "for employee <- @beacon_live_data[:employees] do",
+                 "for employee <- @employees do",
                  [
                    {
                      [
@@ -67,7 +67,7 @@ defmodule Beacon.Template.HEEx.TokenizerTest do
                          [],
                          [
                            {:text, "\n          ", %{newlines: 1}},
-                           {:eex_block, "for person <- @beacon_live_data[:persons] do",
+                           {:eex_block, "for person <- @persons do",
                             [
                               {[
                                  {:text, "\n            ", %{newlines: 1}},

--- a/test/beacon/template/heex_test.exs
+++ b/test/beacon/template/heex_test.exs
@@ -21,11 +21,11 @@ defmodule Beacon.Template.HEExTest do
       assert HEEx.render(
                :my_site,
                ~S|
-                  <%= for val <- @beacon_live_data[:vals] do %>
+                  <%= for val <- @vals do %>
                     <%= val %>
                   <% end %>
                 |,
-               %{beacon_live_data: %{vals: [1, 2]}}
+               %{vals: [1, 2]}
              ) == "\n1\n\n2\n"
     end
 

--- a/test/beacon_web/beacon_assigns_test.exs
+++ b/test/beacon_web/beacon_assigns_test.exs
@@ -10,9 +10,4 @@ defmodule BeaconWeb.BeaconAssignsTest do
     assert %{assigns: %{beacon: %BeaconAssigns{site: "one"}}} = BeaconAssigns.update(socket, :site, "one")
     assert %{assigns: %{beacon: %BeaconAssigns{site: "two"}}} = BeaconAssigns.update(socket, :site, "two")
   end
-
-  test "update_private/3", %{socket: socket} do
-    assert %{assigns: %{beacon: %BeaconAssigns{private: %{page_id: 1}}}} = BeaconAssigns.update_private(socket, :page_id, 1)
-    assert %{assigns: %{beacon: %BeaconAssigns{private: %{page_id: 2}}}} = BeaconAssigns.update_private(socket, :page_id, 2)
-  end
 end

--- a/test/beacon_web/beacon_assigns_test.exs
+++ b/test/beacon_web/beacon_assigns_test.exs
@@ -1,0 +1,18 @@
+defmodule BeaconWeb.BeaconAssignsTest do
+  use ExUnit.Case, async: true
+  alias BeaconWeb.BeaconAssigns
+
+  setup do
+    [socket: %Phoenix.LiveView.Socket{assigns: %{__changed__: %{beacon: true}, beacon: %BeaconAssigns{}}}]
+  end
+
+  test "update/3", %{socket: socket} do
+    assert %{assigns: %{beacon: %BeaconAssigns{site: "one"}}} = BeaconAssigns.update(socket, :site, "one")
+    assert %{assigns: %{beacon: %BeaconAssigns{site: "two"}}} = BeaconAssigns.update(socket, :site, "two")
+  end
+
+  test "update_private/3", %{socket: socket} do
+    assert %{assigns: %{beacon: %BeaconAssigns{private: %{page_id: 1}}}} = BeaconAssigns.update_private(socket, :page_id, 1)
+    assert %{assigns: %{beacon: %BeaconAssigns{private: %{page_id: 2}}}} = BeaconAssigns.update_private(socket, :page_id, 2)
+  end
+end

--- a/test/beacon_web/controllers/error_html_test.exs
+++ b/test/beacon_web/controllers/error_html_test.exs
@@ -3,10 +3,12 @@ defmodule BeaconWeb.ErrorHTMLTest do
 
   alias BeaconWeb.ErrorHTML
 
+  @tag capture_log: true
   test "invalid status code" do
     assert ErrorHTML.render("invalid", %{conn: nil}) == "Internal Server Error"
   end
 
+  @tag capture_log: true
   test "invalid conn" do
     assert ErrorHTML.render("404.html", %{conn: nil}) == "Not Found"
   end

--- a/test/beacon_web/live/page_live_test.exs
+++ b/test/beacon_web/live/page_live_test.exs
@@ -35,7 +35,7 @@ defmodule BeaconWeb.Live.PageLiveTest do
         template: """
         <main>
           <h2>Some Values:</h2>
-          <%= for value <- @beacon_live_data[:values] do %>
+          <%= for value <- @values do %>
             <%= my_component("sample_component", val: value) %>
           <% end %>
 

--- a/test/beacon_web_test.exs
+++ b/test/beacon_web_test.exs
@@ -1,0 +1,22 @@
+defmodule BeaconWebTest do
+  use ExUnit.Case, async: true
+
+  describe "assign/2" do
+    test "do not allow assigning reserved :beacon key" do
+      assert_raise ArgumentError, fn -> BeaconWeb.assign(%{}, beacon: nil) end
+      assert_raise ArgumentError, fn -> BeaconWeb.assign(%{}, %{beacon: nil}) end
+    end
+  end
+
+  describe "assign/3" do
+    test "do not allow assigning reserved :beacon key" do
+      assert_raise ArgumentError, fn -> BeaconWeb.assign(%{}, :beacon, nil) end
+    end
+  end
+
+  describe "assign_new/3" do
+    test "do not allow assigning reserved :beacon key" do
+      assert_raise ArgumentError, fn -> BeaconWeb.assign_new(%{}, :beacon, fn -> nil end) end
+    end
+  end
+end

--- a/test/support/beacon_web.ex
+++ b/test/support/beacon_web.ex
@@ -28,7 +28,8 @@ defmodule Beacon.BeaconWebTest do
       use PhoenixHTMLHelpers
       import Phoenix.HTML
       import Phoenix.HTML.Form
-      import Phoenix.Component
+      import Phoenix.Component, except: [assign: 2, assign: 3, assign_new: 3]
+      import BeaconWeb, only: [assign: 2, assign: 3, assign_new: 3]
       import Phoenix.View
 
       alias Beacon.BeaconTest.Router.Helpers, as: Routes


### PR DESCRIPTION
Close #369 

- `@beacon` assign is a container for public and private assigns, including path params, query params, and others that used to be defined on its own assigns as `@beacon_*` or as `__{name}__` 
- `@beacon_live_data` is deprecated if favor of accessing those values from `assigns` directly, ie: `@name` instead of `@beacon_live_data[:name]`
- Add custom `assign` functions to warn and block assigning the `:beacon` key, those functions are called in event handlers and any exposed code block in the page editor