### PR TITLE
Validate ComponentAttr/SlotAttr Name

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -19,4 +19,6 @@ if Mix.env() == :dev do
     cdn_min: esbuild.(~w(--format=iife --target=es2016 --global-name=Beacon --minify --outfile=../priv/static/beacon.min.js))
 end
 
+config :tailwind, version: "3.4.4"
+
 if config_env() == :test, do: import_config("test.exs")

--- a/lib/beacon/content.ex
+++ b/lib/beacon/content.ex
@@ -1544,8 +1544,23 @@ defmodule Beacon.Content do
     clauses = Keyword.put(clauses, :site, site)
     preloads = Keyword.get(opts, :preloads, [])
 
+    preloads =
+      Enum.reduce(preloads, [], fn
+        :attrs, acc ->
+          attrs_query = from ca in ComponentAttr, order_by: [asc: ca.name]
+          [{:attrs, attrs_query} | acc]
+
+        :slots, acc ->
+          slots_query = from ca in ComponentSlot, order_by: [asc: ca.name]
+          [{:slots, slots_query} | acc]
+
+        {:slots, :attrs}, acc ->
+          slots_query = from ca in ComponentSlot, order_by: [asc: ca.name]
+          [{:slots, {slots_query, [:attrs]}} | acc]
+      end)
+
     Component
-    |> repo(site).get_by(clauses, opts)
+    |> repo(site).get_by(clauses)
     |> repo(site).preload(preloads)
   end
 

--- a/lib/beacon/content.ex
+++ b/lib/beacon/content.ex
@@ -1664,11 +1664,14 @@ defmodule Beacon.Content do
       iex> change_component_attr(component_attr, %{name: "Header"})
       %Ecto.Changeset{data: %ComponentAttr{}}
 
+      iex> change_component_attr(component_attr, %{name: "Header"}, ["sites", ["pages"]])
+      %Ecto.Changeset{data: %ComponentAttr{}}
+
   """
   @doc type: :components
-  @spec change_component_attr(ComponentAttr.t(), map()) :: Changeset.t()
-  def change_component_attr(%ComponentAttr{} = component_attr, attrs \\ %{}) do
-    ComponentAttr.changeset(component_attr, attrs)
+  @spec change_component_attr(ComponentAttr.t(), map(), list(String.t())) :: Changeset.t()
+  def change_component_attr(%ComponentAttr{} = component_attr, attrs, component_attr_names) do
+    ComponentAttr.changeset(component_attr, attrs, component_attr_names)
   end
 
   # COMPONENT SLOTS
@@ -1678,14 +1681,14 @@ defmodule Beacon.Content do
 
   ## Example
 
-      iex> change_component_slot(component_slot, %{name: "Slot A"})
+      iex> change_component_slot(component_slot, %{name: "slot_a"}, ["slot_name_1])
       %Ecto.Changeset{data: %ComponentSlot{}}
 
   """
   @doc type: :components
-  @spec change_component_slot(ComponentSlot.t(), map()) :: Changeset.t()
-  def change_component_slot(%ComponentSlot{} = slot, attrs \\ %{}) do
-    ComponentSlot.changeset(slot, attrs)
+  @spec change_component_slot(ComponentSlot.t(), map(), list(String.t())) :: Changeset.t()
+  def change_component_slot(%ComponentSlot{} = slot, attrs, component_slots_names) do
+    ComponentSlot.changeset(slot, attrs, component_slots_names)
   end
 
   @doc """
@@ -1710,9 +1713,9 @@ defmodule Beacon.Content do
   Updates a component slot and returns the component with updated `:slots` association.
   """
   @doc type: :components
-  @spec update_slot_for_component(Component.t(), ComponentSlot.t(), map()) :: {:ok, Component.t()} | {:error, Changeset.t()}
-  def update_slot_for_component(component, slot, attrs) do
-    changeset = ComponentSlot.changeset(slot, attrs)
+  @spec update_slot_for_component(Component.t(), ComponentSlot.t(), map(), list(String.t())) :: {:ok, Component.t()} | {:error, Changeset.t()}
+  def update_slot_for_component(component, slot, attrs, component_slots_names) do
+    changeset = ComponentSlot.changeset(slot, attrs, component_slots_names)
 
     with {:ok, %ComponentSlot{}} <- repo(component).update(changeset),
          %Component{} = component <- repo(component).preload(component, [slots: [:attrs]], force: true) do
@@ -1763,14 +1766,14 @@ defmodule Beacon.Content do
 
   ## Example
 
-      iex> change_slot_attr(slot_attr, %{name: "Header"})
+      iex> change_slot_attr(slot_attr, %{name: "Header"}, [])
       %Ecto.Changeset{data: %ComponentSlotAttr{}}
 
   """
   @doc type: :components
-  @spec change_slot_attr(ComponentSlotAttr.t(), map()) :: Changeset.t()
-  def change_slot_attr(%ComponentSlotAttr{} = slot_attr, attrs \\ %{}) do
-    ComponentSlotAttr.changeset(slot_attr, attrs)
+  @spec change_slot_attr(ComponentSlotAttr.t(), map(), list(String.t())) :: Changeset.t()
+  def change_slot_attr(%ComponentSlotAttr{} = slot_attr, attrs, slot_attr_names) do
+    ComponentSlotAttr.changeset(slot_attr, attrs, slot_attr_names)
   end
 
   @doc """
@@ -1782,11 +1785,11 @@ defmodule Beacon.Content do
       {:ok, %ComponentSlotAttr{}}
 
   """
-  @spec create_slot_attr(Site.t(), map()) :: {:ok, ComponentSlotAttr.t()} | {:error, Changeset.t()}
+  @spec create_slot_attr(Site.t(), map(), list(String.t())) :: {:ok, ComponentSlotAttr.t()} | {:error, Changeset.t()}
   @doc type: :components
-  def create_slot_attr(site, attrs \\ %{}) do
+  def create_slot_attr(site, attrs, slot_attr_names) do
     %ComponentSlotAttr{}
-    |> ComponentSlotAttr.changeset(attrs)
+    |> ComponentSlotAttr.changeset(attrs, slot_attr_names)
     |> repo(site).insert()
   end
 
@@ -1798,10 +1801,10 @@ defmodule Beacon.Content do
 
   """
   @doc type: :components
-  @spec update_slot_attr(Site.t(), ComponentSlotAttr.t(), map()) :: {:ok, ComponentAttr.t()} | {:error, Changeset.t()}
-  def update_slot_attr(site, %ComponentSlotAttr{} = slot_attr, attrs) do
+  @spec update_slot_attr(Site.t(), ComponentSlotAttr.t(), map(), list(String.t())) :: {:ok, ComponentAttr.t()} | {:error, Changeset.t()}
+  def update_slot_attr(site, %ComponentSlotAttr{} = slot_attr, attrs, slot_attr_names) do
     slot_attr
-    |> ComponentSlotAttr.changeset(attrs)
+    |> ComponentSlotAttr.changeset(attrs, slot_attr_names)
     |> repo(site).update()
   end
 

--- a/lib/beacon/content/component.ex
+++ b/lib/beacon/content/component.ex
@@ -13,6 +13,7 @@ defmodule Beacon.Content.Component do
 
   use Beacon.Schema
 
+  alias Beacon.Content
   alias Beacon.Content.ComponentAttr
   alias Beacon.Content.ComponentSlot
 
@@ -50,4 +51,141 @@ defmodule Beacon.Content.Component do
   end
 
   def categories, do: @categories
+
+  def validate_if_struct_name_required(changeset) do
+    type = get_field(changeset, :type)
+    struct_name = get_field(changeset, :struct_name)
+
+    if type == "struct" and is_nil(struct_name) do
+      add_error(changeset, :struct_name, "is required when type is 'struct'")
+    else
+      changeset
+    end
+  end
+
+  def validate_struct_name(changeset) do
+    struct_name = get_field(changeset, :struct_name)
+
+    if struct_name do
+      struct = Module.concat([struct_name])
+
+      try do
+        Code.eval_string("%#{struct}{}")
+        changeset
+      rescue
+        _ -> add_error(changeset, :struct_name, "the struct #{struct_name} is undefined")
+      end
+    else
+      changeset
+    end
+  end
+
+  def validate_non_empty_examples_opts(changeset) do
+    opts = get_field(changeset, :opts) |> maybe_binary_to_term()
+
+    if :examples in Keyword.keys(opts) do
+      case Keyword.get(opts, :examples) do
+        [_ | _] -> changeset
+        _ -> add_error(changeset, :opts_examples, "if provided, examples must be a non-empty list")
+      end
+    else
+      changeset
+    end
+  end
+
+  def validate_non_empty_values_opts(changeset) do
+    opts = get_field(changeset, :opts) |> maybe_binary_to_term()
+
+    if :values in Keyword.keys(opts) do
+      case Keyword.get(opts, :values) do
+        [_ | _] -> changeset
+        _ -> add_error(changeset, :opts_values, "if provided, :values must be a non-empty list")
+      end
+    else
+      changeset
+    end
+  end
+
+  def validate_equivalent_options(changeset) do
+    opts = get_field(changeset, :opts) |> maybe_binary_to_term()
+    required_opts = get_field_from_opts(changeset, :required)
+
+    values_opts = get_field_from_opts(changeset, :values)
+    examples_opts = get_field_from_opts(changeset, :examples)
+
+    cond do
+      not is_nil(required_opts) and :default in Keyword.keys(opts) ->
+        add_error(changeset, :opts_default, "only one of 'Required' or 'Default' attribute must be given")
+
+      not is_nil(values_opts) and not is_nil(examples_opts) ->
+        add_error(changeset, :opts_examples, "only one of 'Accepted values' or 'Examples' must be given")
+
+      true ->
+        changeset
+    end
+  end
+
+  def validate_default_opts_is_in_values_opts(%Changeset{valid?: false} = changeset), do: changeset
+
+  def validate_default_opts_is_in_values_opts(%Changeset{valid?: true} = changeset) do
+    opts = get_field(changeset, :opts) |> maybe_binary_to_term()
+    values_opts = get_field_from_opts(changeset, :values)
+    default_opts = get_field_from_opts(changeset, :default)
+
+    cond do
+      :default not in Keyword.keys(opts) or is_nil(values_opts) -> changeset
+      default_opts in values_opts -> changeset
+      true -> add_error(changeset, :opts_default, "expected the default value to be one of the Accepted Values list")
+    end
+  end
+
+  def validate_type_and_default_opts(changeset) do
+    type = get_field(changeset, :type)
+    default_opts = get_field_from_opts(changeset, :default)
+
+    Content.validate_if_value_matches_type(changeset, type, default_opts, :opts_default)
+  end
+
+  def validate_struct_name_and_default_opts(%Changeset{valid?: false} = changeset), do: changeset
+
+  def validate_struct_name_and_default_opts(%Changeset{valid?: true} = changeset) do
+    struct_name = get_field(changeset, :struct_name)
+    default_opts = get_field_from_opts(changeset, :default)
+
+    if is_nil(struct_name) or is_nil(default_opts) do
+      changeset
+    else
+      struct = Module.concat([struct_name])
+
+      case struct(struct) == default_opts do
+        true -> changeset
+        _ -> add_error(changeset, :opts_default, "expected the default value to be a #{struct_name} struct")
+      end
+    end
+  end
+
+  def validate_type_and_examples_opts(%Changeset{valid?: false} = changeset), do: changeset
+
+  def validate_type_and_examples_opts(%Changeset{valid?: true} = changeset) do
+    type = get_field(changeset, :type)
+    examples_opts = get_field(changeset, :opts) |> maybe_binary_to_term() |> Keyword.get(:examples, [])
+
+    Enum.reduce(examples_opts, changeset, fn value, changeset -> Content.validate_if_value_matches_type(changeset, type, value, :opts_examples) end)
+  end
+
+  def validate_type_and_values_opts(%Changeset{valid?: false} = changeset), do: changeset
+
+  def validate_type_and_values_opts(%Changeset{valid?: true} = changeset) do
+    type = get_field(changeset, :type)
+    values_opts = get_field(changeset, :opts) |> maybe_binary_to_term() |> Keyword.get(:values, [])
+
+    Enum.reduce(values_opts, changeset, fn value, changeset -> Content.validate_if_value_matches_type(changeset, type, value, :opts_values) end)
+  end
+
+  defp get_field_from_opts(changeset, field) do
+    get_field(changeset, :opts) |> maybe_binary_to_term() |> Keyword.get(field)
+  end
+
+  defp maybe_binary_to_term(opts) when is_binary(opts), do: :erlang.binary_to_term(opts)
+  defp maybe_binary_to_term(opts), do: opts
 end

--- a/lib/beacon/content/component.ex
+++ b/lib/beacon/content/component.ex
@@ -46,12 +46,30 @@ defmodule Beacon.Content.Component do
     |> validate_required([:site, :name, :template, :example, :category])
     |> validate_format(:name, ~r/^[a-z0-9_!]+$/, message: "can only contain lowercase letters, numbers, and underscores")
     |> validate_exclusion(:name, reserved_names)
+    |> validate_unique_attr_name(attrs)
     |> cast_assoc(:attrs, with: &ComponentAttr.changeset/2)
     |> cast_assoc(:slots, with: &ComponentSlot.changeset/2)
   end
 
+  defp validate_unique_attr_name(changeset, attrs) do
+    component_attrs = attrs["attrs"] || []
+
+    attr_names =
+      Enum.map(component_attrs, fn
+        %{name: name} -> name
+        {_index, attr} -> attr["name"]
+      end)
+
+    if Enum.uniq(attr_names) == attr_names do
+      changeset
+    else
+      add_error(changeset, :attrs, "component attribute list contains duplicate names")
+    end
+  end
+
   def categories, do: @categories
 
+  @doc false
   def validate_if_struct_name_required(changeset) do
     type = get_field(changeset, :type)
     struct_name = get_field(changeset, :struct_name)
@@ -63,6 +81,7 @@ defmodule Beacon.Content.Component do
     end
   end
 
+  @doc false
   def validate_struct_name(changeset) do
     struct_name = get_field(changeset, :struct_name)
 
@@ -80,6 +99,7 @@ defmodule Beacon.Content.Component do
     end
   end
 
+  @doc false
   def validate_non_empty_examples_opts(changeset) do
     opts = get_field(changeset, :opts) |> maybe_binary_to_term()
 
@@ -93,6 +113,7 @@ defmodule Beacon.Content.Component do
     end
   end
 
+  @doc false
   def validate_non_empty_values_opts(changeset) do
     opts = get_field(changeset, :opts) |> maybe_binary_to_term()
 
@@ -106,6 +127,7 @@ defmodule Beacon.Content.Component do
     end
   end
 
+  @doc false
   def validate_equivalent_options(changeset) do
     opts = get_field(changeset, :opts) |> maybe_binary_to_term()
     required_opts = get_field_from_opts(changeset, :required)
@@ -125,6 +147,7 @@ defmodule Beacon.Content.Component do
     end
   end
 
+  @doc false
   def validate_default_opts_is_in_values_opts(%Changeset{valid?: false} = changeset), do: changeset
 
   def validate_default_opts_is_in_values_opts(%Changeset{valid?: true} = changeset) do
@@ -139,6 +162,7 @@ defmodule Beacon.Content.Component do
     end
   end
 
+  @doc false
   def validate_type_and_default_opts(changeset) do
     type = get_field(changeset, :type)
     default_opts = get_field_from_opts(changeset, :default)
@@ -146,6 +170,7 @@ defmodule Beacon.Content.Component do
     Content.validate_if_value_matches_type(changeset, type, default_opts, :opts_default)
   end
 
+  @doc false
   def validate_struct_name_and_default_opts(%Changeset{valid?: false} = changeset), do: changeset
 
   def validate_struct_name_and_default_opts(%Changeset{valid?: true} = changeset) do
@@ -164,6 +189,7 @@ defmodule Beacon.Content.Component do
     end
   end
 
+  @doc false
   def validate_type_and_examples_opts(%Changeset{valid?: false} = changeset), do: changeset
 
   def validate_type_and_examples_opts(%Changeset{valid?: true} = changeset) do
@@ -173,6 +199,7 @@ defmodule Beacon.Content.Component do
     Enum.reduce(examples_opts, changeset, fn value, changeset -> Content.validate_if_value_matches_type(changeset, type, value, :opts_examples) end)
   end
 
+  @doc false
   def validate_type_and_values_opts(%Changeset{valid?: false} = changeset), do: changeset
 
   def validate_type_and_values_opts(%Changeset{valid?: true} = changeset) do

--- a/lib/beacon/content/component_attr.ex
+++ b/lib/beacon/content/component_attr.ex
@@ -3,9 +3,7 @@ defmodule Beacon.Content.ComponentAttr do
 
   use Beacon.Schema
 
-  alias Beacon.Content
   alias Beacon.Content.Component
-  alias Ecto.Changeset
 
   @type t :: %__MODULE__{}
 
@@ -26,152 +24,15 @@ defmodule Beacon.Content.ComponentAttr do
     |> cast(attrs, [:id, :name, :type, :struct_name, :opts, :component_id])
     |> validate_required([:name, :type])
     |> validate_format(:name, ~r/^[a-zA-Z0-9_!?]+$/, message: "can only contain letters, numbers, and underscores")
-    |> validate_if_struct_name_required()
-    |> validate_struct_name()
-    |> validate_non_empty_examples_opts()
-    |> validate_non_empty_values_opts()
-    |> validate_equivalent_options()
-    |> validate_default_opts_is_in_values_opts()
-    |> validate_type_and_values_opts()
-    |> validate_type_and_default_opts()
-    |> validate_struct_name_and_default_opts()
-    |> validate_type_and_examples_opts()
+    |> Component.validate_if_struct_name_required()
+    |> Component.validate_struct_name()
+    |> Component.validate_non_empty_examples_opts()
+    |> Component.validate_non_empty_values_opts()
+    |> Component.validate_equivalent_options()
+    |> Component.validate_default_opts_is_in_values_opts()
+    |> Component.validate_type_and_values_opts()
+    |> Component.validate_type_and_default_opts()
+    |> Component.validate_struct_name_and_default_opts()
+    |> Component.validate_type_and_examples_opts()
   end
-
-  def validate_if_struct_name_required(changeset) do
-    type = get_field(changeset, :type)
-    struct_name = get_field(changeset, :struct_name)
-
-    if type == "struct" and is_nil(struct_name) do
-      add_error(changeset, :struct_name, "is required when type is 'struct'")
-    else
-      changeset
-    end
-  end
-
-  def validate_struct_name(changeset) do
-    struct_name = get_field(changeset, :struct_name)
-
-    if struct_name do
-      struct = Module.concat([struct_name])
-
-      try do
-        Code.eval_string("%#{struct}{}")
-        changeset
-      rescue
-        _ -> add_error(changeset, :struct_name, "the struct #{struct_name} is undefined")
-      end
-    else
-      changeset
-    end
-  end
-
-  def validate_non_empty_examples_opts(changeset) do
-    opts = get_field(changeset, :opts) |> maybe_binary_to_term()
-
-    if :examples in Keyword.keys(opts) do
-      case Keyword.get(opts, :examples) do
-        [_ | _] -> changeset
-        _ -> add_error(changeset, :opts_examples, "if provided, examples must be a non-empty list")
-      end
-    else
-      changeset
-    end
-  end
-
-  def validate_non_empty_values_opts(changeset) do
-    opts = get_field(changeset, :opts) |> maybe_binary_to_term()
-
-    if :values in Keyword.keys(opts) do
-      case Keyword.get(opts, :values) do
-        [_ | _] -> changeset
-        _ -> add_error(changeset, :opts_values, "if provided, :values must be a non-empty list")
-      end
-    else
-      changeset
-    end
-  end
-
-  def validate_equivalent_options(changeset) do
-    opts = get_field(changeset, :opts) |> maybe_binary_to_term()
-    required_opts = get_field_from_opts(changeset, :required)
-
-    values_opts = get_field_from_opts(changeset, :values)
-    examples_opts = get_field_from_opts(changeset, :examples)
-
-    cond do
-      not is_nil(required_opts) and :default in Keyword.keys(opts) ->
-        add_error(changeset, :opts_default, "only one of 'Required' or 'Default' attribute must be given")
-
-      not is_nil(values_opts) and not is_nil(examples_opts) ->
-        add_error(changeset, :opts_examples, "only one of 'Accepted values' or 'Examples' must be given")
-
-      true ->
-        changeset
-    end
-  end
-
-  def validate_default_opts_is_in_values_opts(%Changeset{valid?: false} = changeset), do: changeset
-
-  def validate_default_opts_is_in_values_opts(%Changeset{valid?: true} = changeset) do
-    opts = get_field(changeset, :opts) |> maybe_binary_to_term()
-    values_opts = get_field_from_opts(changeset, :values)
-    default_opts = get_field_from_opts(changeset, :default)
-
-    cond do
-      :default not in Keyword.keys(opts) or is_nil(values_opts) -> changeset
-      default_opts in values_opts -> changeset
-      true -> add_error(changeset, :opts_default, "expected the default value to be one of the Accepted Values list")
-    end
-  end
-
-  def validate_type_and_default_opts(changeset) do
-    type = get_field(changeset, :type)
-    default_opts = get_field_from_opts(changeset, :default)
-
-    Content.validate_if_value_matches_type(changeset, type, default_opts, :opts_default)
-  end
-
-  def validate_struct_name_and_default_opts(%Changeset{valid?: false} = changeset), do: changeset
-
-  def validate_struct_name_and_default_opts(%Changeset{valid?: true} = changeset) do
-    struct_name = get_field(changeset, :struct_name)
-    default_opts = get_field_from_opts(changeset, :default)
-
-    if is_nil(struct_name) or is_nil(default_opts) do
-      changeset
-    else
-      struct = Module.concat([struct_name])
-
-      case struct(struct) == default_opts do
-        true -> changeset
-        _ -> add_error(changeset, :opts_default, "expected the default value to be a #{struct_name} struct")
-      end
-    end
-  end
-
-  def validate_type_and_examples_opts(%Changeset{valid?: false} = changeset), do: changeset
-
-  def validate_type_and_examples_opts(%Changeset{valid?: true} = changeset) do
-    type = get_field(changeset, :type)
-    examples_opts = get_field(changeset, :opts) |> maybe_binary_to_term() |> Keyword.get(:examples, [])
-
-    Enum.reduce(examples_opts, changeset, fn value, changeset -> Content.validate_if_value_matches_type(changeset, type, value, :opts_examples) end)
-  end
-
-  def validate_type_and_values_opts(%Changeset{valid?: false} = changeset), do: changeset
-
-  def validate_type_and_values_opts(%Changeset{valid?: true} = changeset) do
-    type = get_field(changeset, :type)
-    values_opts = get_field(changeset, :opts) |> maybe_binary_to_term() |> Keyword.get(:values, [])
-
-    Enum.reduce(values_opts, changeset, fn value, changeset -> Content.validate_if_value_matches_type(changeset, type, value, :opts_values) end)
-  end
-
-  defp get_field_from_opts(changeset, field) do
-    get_field(changeset, :opts) |> maybe_binary_to_term() |> Keyword.get(field)
-  end
-
-  defp maybe_binary_to_term(opts) when is_binary(opts), do: :erlang.binary_to_term(opts)
-  defp maybe_binary_to_term(opts), do: opts
 end

--- a/lib/beacon/content/component_attr.ex
+++ b/lib/beacon/content/component_attr.ex
@@ -19,11 +19,15 @@ defmodule Beacon.Content.ComponentAttr do
   end
 
   @doc false
-  def changeset(component, attrs) do
-    component
+  def changeset(component_attr, attrs, component_attr_names \\ []) do
+    reserved_names = ["inner_block"]
+
+    component_attr
     |> cast(attrs, [:id, :name, :type, :struct_name, :opts, :component_id])
     |> validate_required([:name, :type])
     |> validate_format(:name, ~r/^[a-zA-Z0-9_!?]+$/, message: "can only contain letters, numbers, and underscores")
+    |> validate_exclusion(:name, reserved_names)
+    |> validate_unique_component_attr_names(component_attr_names)
     |> Component.validate_if_struct_name_required()
     |> Component.validate_struct_name()
     |> Component.validate_non_empty_examples_opts()
@@ -34,5 +38,16 @@ defmodule Beacon.Content.ComponentAttr do
     |> Component.validate_type_and_default_opts()
     |> Component.validate_struct_name_and_default_opts()
     |> Component.validate_type_and_examples_opts()
+  end
+
+  @doc false
+  def validate_unique_component_attr_names(changeset, component_attr_names) do
+    name = get_field(changeset, :name)
+
+    if name in component_attr_names do
+      add_error(changeset, :name, "a duplicate attribute with name '#{name}' already exists")
+    else
+      changeset
+    end
   end
 end

--- a/lib/beacon/content/component_slot.ex
+++ b/lib/beacon/content/component_slot.ex
@@ -19,10 +19,22 @@ defmodule Beacon.Content.ComponentSlot do
   end
 
   @doc false
-  def changeset(component, attrs) do
+  def changeset(component, attrs, component_slots_names \\ []) do
     component
     |> cast(attrs, [:name, :opts])
     |> validate_required([:name])
+    |> validate_unique_component_slot_names(component_slots_names)
     |> cast_assoc(:attrs, with: &ComponentSlotAttr.changeset/2)
+  end
+
+  @doc false
+  def validate_unique_component_slot_names(changeset, component_slots_names) do
+    name = get_field(changeset, :name)
+
+    if name in component_slots_names do
+      add_error(changeset, :name, "a duplicate slot with name '#{name}' already exists")
+    else
+      changeset
+    end
   end
 end

--- a/lib/beacon/content/component_slot_attr.ex
+++ b/lib/beacon/content/component_slot_attr.ex
@@ -20,11 +20,15 @@ defmodule Beacon.Content.ComponentSlotAttr do
   end
 
   @doc false
-  def changeset(component, attrs) do
-    component
+  def changeset(component_slot_attr, attrs, component_slot_attr_names \\ []) do
+    reserved_names = ["inner_block"]
+
+    component_slot_attr
     |> cast(attrs, [:name, :type, :struct_name, :opts, :slot_id])
     |> validate_required([:name, :type])
     |> validate_format(:name, ~r/^[a-zA-Z0-9_!?]+$/, message: "can only contain letters, numbers, and underscores")
+    |> validate_exclusion(:name, reserved_names)
+    |> validate_unique_component_slot_attr_names(component_slot_attr_names)
     |> Component.validate_if_struct_name_required()
     |> Component.validate_struct_name()
     |> Component.validate_non_empty_examples_opts()
@@ -35,5 +39,16 @@ defmodule Beacon.Content.ComponentSlotAttr do
     |> Component.validate_type_and_default_opts()
     |> Component.validate_struct_name_and_default_opts()
     |> Component.validate_type_and_examples_opts()
+  end
+
+  @doc false
+  def validate_unique_component_slot_attr_names(changeset, component_slot_attr_names) do
+    name = get_field(changeset, :name)
+
+    if name in component_slot_attr_names do
+      add_error(changeset, :name, "a duplicate slot attr with name '#{name}' already exists")
+    else
+      changeset
+    end
   end
 end

--- a/lib/beacon/content/component_slot_attr.ex
+++ b/lib/beacon/content/component_slot_attr.ex
@@ -3,9 +3,8 @@ defmodule Beacon.Content.ComponentSlotAttr do
 
   use Beacon.Schema
 
-  alias Beacon.Content
+  alias Beacon.Content.Component
   alias Beacon.Content.ComponentSlot
-  alias Ecto.Changeset
 
   @type t :: %__MODULE__{}
 
@@ -26,152 +25,15 @@ defmodule Beacon.Content.ComponentSlotAttr do
     |> cast(attrs, [:name, :type, :struct_name, :opts, :slot_id])
     |> validate_required([:name, :type])
     |> validate_format(:name, ~r/^[a-zA-Z0-9_!?]+$/, message: "can only contain letters, numbers, and underscores")
-    |> validate_if_struct_name_required()
-    |> validate_struct_name()
-    |> validate_non_empty_examples_opts()
-    |> validate_non_empty_values_opts()
-    |> validate_equivalent_options()
-    |> validate_default_opts_is_in_values_opts()
-    |> validate_type_and_values_opts()
-    |> validate_type_and_default_opts()
-    |> validate_struct_name_and_default_opts()
-    |> validate_type_and_examples_opts()
+    |> Component.validate_if_struct_name_required()
+    |> Component.validate_struct_name()
+    |> Component.validate_non_empty_examples_opts()
+    |> Component.validate_non_empty_values_opts()
+    |> Component.validate_equivalent_options()
+    |> Component.validate_default_opts_is_in_values_opts()
+    |> Component.validate_type_and_values_opts()
+    |> Component.validate_type_and_default_opts()
+    |> Component.validate_struct_name_and_default_opts()
+    |> Component.validate_type_and_examples_opts()
   end
-
-  def validate_if_struct_name_required(changeset) do
-    type = get_field(changeset, :type)
-    struct_name = get_field(changeset, :struct_name)
-
-    if type == "struct" and is_nil(struct_name) do
-      add_error(changeset, :struct_name, "is required when type is 'struct'")
-    else
-      changeset
-    end
-  end
-
-  def validate_struct_name(changeset) do
-    struct_name = get_field(changeset, :struct_name)
-
-    if struct_name do
-      struct = Module.concat([struct_name])
-
-      try do
-        Code.eval_string("%#{struct}{}")
-        changeset
-      rescue
-        _ -> add_error(changeset, :struct_name, "the struct #{struct_name} is undefined")
-      end
-    else
-      changeset
-    end
-  end
-
-  def validate_non_empty_examples_opts(changeset) do
-    opts = get_field(changeset, :opts) |> maybe_binary_to_term()
-
-    if :examples in Keyword.keys(opts) do
-      case Keyword.get(opts, :examples) do
-        [_ | _] -> changeset
-        _ -> add_error(changeset, :opts_examples, "if provided, examples must be a non-empty list")
-      end
-    else
-      changeset
-    end
-  end
-
-  def validate_non_empty_values_opts(changeset) do
-    opts = get_field(changeset, :opts) |> maybe_binary_to_term()
-
-    if :values in Keyword.keys(opts) do
-      case Keyword.get(opts, :values) do
-        [_ | _] -> changeset
-        _ -> add_error(changeset, :opts_values, "if provided, :values must be a non-empty list")
-      end
-    else
-      changeset
-    end
-  end
-
-  def validate_equivalent_options(changeset) do
-    opts = get_field(changeset, :opts) |> maybe_binary_to_term()
-    required_opts = get_field_from_opts(changeset, :required)
-
-    values_opts = get_field_from_opts(changeset, :values)
-    examples_opts = get_field_from_opts(changeset, :examples)
-
-    cond do
-      not is_nil(required_opts) and :default in Keyword.keys(opts) ->
-        add_error(changeset, :opts_default, "only one of 'Required' or 'Default' attribute must be given")
-
-      not is_nil(values_opts) and not is_nil(examples_opts) ->
-        add_error(changeset, :opts_examples, "only one of 'Accepted values' or 'Examples' must be given")
-
-      true ->
-        changeset
-    end
-  end
-
-  def validate_default_opts_is_in_values_opts(%Changeset{valid?: false} = changeset), do: changeset
-
-  def validate_default_opts_is_in_values_opts(%Changeset{valid?: true} = changeset) do
-    opts = get_field(changeset, :opts) |> maybe_binary_to_term()
-    values_opts = get_field_from_opts(changeset, :values)
-    default_opts = get_field_from_opts(changeset, :default)
-
-    cond do
-      :default not in Keyword.keys(opts) or is_nil(values_opts) -> changeset
-      default_opts in values_opts -> changeset
-      true -> add_error(changeset, :opts_default, "expected the default value to be one of the Accepted Values list")
-    end
-  end
-
-  def validate_type_and_default_opts(changeset) do
-    type = get_field(changeset, :type)
-    default_opts = get_field_from_opts(changeset, :default)
-
-    Content.validate_if_value_matches_type(changeset, type, default_opts, :opts_default)
-  end
-
-  def validate_struct_name_and_default_opts(%Changeset{valid?: false} = changeset), do: changeset
-
-  def validate_struct_name_and_default_opts(%Changeset{valid?: true} = changeset) do
-    struct_name = get_field(changeset, :struct_name)
-    default_opts = get_field_from_opts(changeset, :default)
-
-    if is_nil(struct_name) or is_nil(default_opts) do
-      changeset
-    else
-      struct = Module.concat([struct_name])
-
-      case struct(struct) == default_opts do
-        true -> changeset
-        _ -> add_error(changeset, :opts_default, "expected the default value to be a #{struct_name} struct")
-      end
-    end
-  end
-
-  def validate_type_and_examples_opts(%Changeset{valid?: false} = changeset), do: changeset
-
-  def validate_type_and_examples_opts(%Changeset{valid?: true} = changeset) do
-    type = get_field(changeset, :type)
-    examples_opts = get_field(changeset, :opts) |> maybe_binary_to_term() |> Keyword.get(:examples, [])
-
-    Enum.reduce(examples_opts, changeset, fn value, changeset -> Content.validate_if_value_matches_type(changeset, type, value, :opts_examples) end)
-  end
-
-  def validate_type_and_values_opts(%Changeset{valid?: false} = changeset), do: changeset
-
-  def validate_type_and_values_opts(%Changeset{valid?: true} = changeset) do
-    type = get_field(changeset, :type)
-    values_opts = get_field(changeset, :opts) |> maybe_binary_to_term() |> Keyword.get(:values, [])
-
-    Enum.reduce(values_opts, changeset, fn value, changeset -> Content.validate_if_value_matches_type(changeset, type, value, :opts_values) end)
-  end
-
-  defp get_field_from_opts(changeset, field) do
-    get_field(changeset, :opts) |> maybe_binary_to_term() |> Keyword.get(field)
-  end
-
-  defp maybe_binary_to_term(opts) when is_binary(opts), do: :erlang.binary_to_term(opts)
-  defp maybe_binary_to_term(opts), do: opts
 end


### PR DESCRIPTION
- Move component_attr and slot_attr changeset validations to component.ex
- Add query to order Component preloads (`attrs` and `slots`) by name (if preloads are given)
- Add changeset validations - Unique name for ComponentAttr, ComponentSlot and ComponentSlotAttr