### PR TITLE
Update content docs

### DIFF
--- a/lib/beacon/authorization/policy.ex
+++ b/lib/beacon/authorization/policy.ex
@@ -7,7 +7,7 @@ defmodule Beacon.Authorization.Policy do
       defmodule MyApp.Beacon.AuthzPolicy do
         @behaviour Beacon.Authorization.Policy
 
-        def get_agent(%{"session_id" => session_id}}) do
+        def get_agent(%{"session_id" => session_id}) do
           MyApp.Identity.find_by_session_id!(session_id) # returns %{user_id: 1, role: :admin}
         end
 

--- a/lib/beacon/beacon.ex
+++ b/lib/beacon/beacon.ex
@@ -21,9 +21,12 @@ defmodule Beacon do
 
   """
 
+  @doc false
   use Supervisor
-  require Logger
+
   alias Beacon.Config
+
+  require Logger
 
   @doc """
   Start `Beacon` and a supervisor for each site, which will load all layouts, pages, components, and so on.

--- a/lib/beacon/config.ex
+++ b/lib/beacon/config.ex
@@ -9,6 +9,7 @@ defmodule Beacon.Config do
 
   """
 
+  @doc false
   use GenServer
 
   alias Beacon.Content
@@ -349,7 +350,7 @@ defmodule Beacon.Config do
         media_types: ["image/jpeg", "image/gif", "image/png", "image/webp"],
         assets:[
           {"image/*", [backends: [Beacon.MediaLibrary.Backend.Repo], validations: [&SomeModule.some_function/2]]},
-        ]
+        ],
         lifecycle: [
           load_template: [
             heex: [],
@@ -455,7 +456,7 @@ defmodule Beacon.Config do
   end
 
   @doc """
-  Returns a `t:media_type_config/0` which contains the configuration for backends, processors and validations.
+  From a `Beacon.Config`, fetch the asset config for a given media type, raising when unsuccessful.
 
   ## Example
 
@@ -498,6 +499,25 @@ defmodule Beacon.Config do
     """
   end
 
+  @doc """
+  Searches a config option for the given media type.
+
+  For config options based on media type, such as `:assets` and `:extra_asset_fields`,
+  this function will check for the presence of `media_type`, returning the config for
+  that specific type, or `nil` if the type is not present.
+
+  ## Examples
+
+      iex> beacon_config = Beacon.Config.fetch!(:some_site)
+      iex> jpeg_config = config_for_media_type(beacon_config.assets, "image/jpeg")
+
+      iex> beacon_config = Beacon.Config.fetch!(:some_site)
+      iex> webp_config = config_for_media_type(beacon_config.extra_asset_fields, "image/webp")
+
+      iex> beacon_config = Beacon.Config.fetch!(:some_site)
+      iex> nil = config_for_media_type(beacon_config.assets, "invalid/foo")
+
+  """
   @spec get_media_type_config(media_type_configs(), String.t()) :: media_type_config() | nil
   @spec get_media_type_config(extra_asset_fields(), String.t()) :: extra_asset_field() | nil
   def get_media_type_config(configs, media_type) do

--- a/lib/beacon/content.ex
+++ b/lib/beacon/content.ex
@@ -187,11 +187,14 @@ defmodule Beacon.Content do
     GenServer.call(name(layout.site), {:publish_layout, layout})
   end
 
+  @doc """
+  Same as `publish_layout/2` but accepts a `site` and `layout_id` with which to lookup the layout.
+  """
   @doc type: :layouts
   @spec publish_layout(Site.t(), UUID.t()) :: {:ok, Layout.t()} | any()
-  def publish_layout(site, id) when is_atom(site) and is_binary(id) do
+  def publish_layout(site, layout_id) when is_atom(site) and is_binary(layout_id) do
     site
-    |> get_layout(id)
+    |> get_layout(layout_id)
     |> publish_layout()
   end
 
@@ -1114,13 +1117,13 @@ defmodule Beacon.Content do
   end
 
   @doc """
-  Creates a stylesheet.
+  Creates a stylesheet, raising an error if unsuccessful.
 
-  Returns the new stylesheet if successful, otherwise raises an error.
+  Returns the new stylesheet if successful, otherwise raises a `RuntimeError`.
 
   ## Example
 
-      iex >create_stylesheet(%{
+      iex >create_stylesheet!(%{
         site: :my_site,
         name: "override",
         content: ~S|
@@ -1136,7 +1139,7 @@ defmodule Beacon.Content do
   Note that escape characters must be preserved, so you should use `~S` to avoid issues.
   """
   @doc type: :stylesheets
-  @spec create_stylesheet(map()) :: Stylesheet.t()
+  @spec create_stylesheet!(map()) :: Stylesheet.t()
   def create_stylesheet!(attrs \\ %{}) do
     case create_stylesheet(attrs) do
       {:ok, stylesheet} -> stylesheet
@@ -1757,9 +1760,9 @@ defmodule Beacon.Content do
   end
 
   @doc """
-  Creates a component.
+  Creates a component, raising an error if unsuccessful.
 
-  Returns the new component if successful, otherwise raises an error.
+  Returns the new component if successful, otherwise raises a `RuntimeError`.
   """
   @doc type: :components
   @spec create_component!(map()) :: Component.t()
@@ -2119,9 +2122,9 @@ defmodule Beacon.Content do
   end
 
   @doc """
-  Creates a snippet helper.
+  Creates a snippet helper, raising an error if unsuccessful.
 
-  Returns the new helper if successful, otherwise raises an error.
+  Returns the new helper if successful, otherwise raises a `RuntimeError`.
   """
   @doc type: :snippets
   @spec create_snippet_helper!(map()) :: Snippets.Helper.t()
@@ -2293,6 +2296,12 @@ defmodule Beacon.Content do
     |> repo(site).all()
   end
 
+  @doc """
+  Lists all error pages for a given site, filtered by `clauses`.
+
+  Currently the only acceptable clause is `:layout_id`.
+  See `list_error_pages/2` for a list of acceptable `opts`.
+  """
   @doc type: :error_pages
   @spec list_error_pages_by(Site.t(), keyword(), keyword()) :: Layout.t() | nil
   def list_error_pages_by(site, clauses, opts \\ []) when is_atom(site) and is_list(clauses) do
@@ -2572,7 +2581,7 @@ defmodule Beacon.Content do
   end
 
   @doc """
-  Deletes a page variant and returns the page with updated variants association.
+  Deletes a page variant and returns the page with updated `:variants` association.
   """
   @doc type: :page_variants
   @spec delete_variant_from_page(Page.t(), PageVariant.t()) :: {:ok, Page.t()} | {:error, Changeset.t()}
@@ -2640,9 +2649,9 @@ defmodule Beacon.Content do
   end
 
   @doc """
-  Creates a new LiveData for scoping live data to pages.
+  Creates a new LiveData for scoping live data to pages, raising an error if unsuccessful.
 
-  Returns the new LiveData if successful, otherwise raises an error.
+  Returns the new LiveData if successful, otherwise raises a `RuntimeError`.
   """
   @doc type: :live_data
   @spec create_live_data!(map()) :: LiveData.t()

--- a/lib/beacon/content.ex
+++ b/lib/beacon/content.ex
@@ -23,6 +23,8 @@ defmodule Beacon.Content do
     * Page - only applies to the specific page.
 
   """
+
+  @doc false
   use GenServer
 
   import Ecto.Query
@@ -88,20 +90,6 @@ defmodule Beacon.Content do
 
   defp maybe_broadcast_updated_content_event({:ok, %{site: site}}, resource_type), do: Beacon.PubSub.content_updated(site, resource_type)
   defp maybe_broadcast_updated_content_event({:error, _}, _resource_type), do: :skip
-
-  @doc """
-  Returns the list of meta tags that are applied to all pages by default.
-
-  These meta tags can be overwritten or extended on a Layout or Page level.
-  """
-  @spec default_site_meta_tags() :: [map()]
-  def default_site_meta_tags do
-    [
-      %{"charset" => "utf-8"},
-      %{"http-equiv" => "X-UA-Compatible", "content" => "IE=edge"},
-      %{"name" => "viewport", "content" => "width=device-width, initial-scale=1"}
-    ]
-  end
 
   @doc """
   Returns an `%Ecto.Changeset{}` for tracking layout changes.
@@ -1072,6 +1060,21 @@ defmodule Beacon.Content do
     page
     |> Changeset.cast(attrs, [:extra])
     |> repo(page).update()
+  end
+
+  @doc """
+  Returns the list of meta tags that are applied to all pages by default.
+
+  These meta tags can be overwritten or extended on a Layout or Page level.
+  """
+  @spec default_site_meta_tags() :: [map()]
+  @doc type: :pages
+  def default_site_meta_tags do
+    [
+      %{"charset" => "utf-8"},
+      %{"http-equiv" => "X-UA-Compatible", "content" => "IE=edge"},
+      %{"name" => "viewport", "content" => "width=device-width, initial-scale=1"}
+    ]
   end
 
   # STYLESHEETS

--- a/lib/beacon/content/component_attr.ex
+++ b/lib/beacon/content/component_attr.ex
@@ -1,6 +1,14 @@
 defmodule Beacon.Content.ComponentAttr do
   @moduledoc """
-  TODO: doc
+  Component attr schema.
+
+  > #### Do not create or edit component attrs manually {: .warning}
+  >
+  > Use the public functions in `Beacon.Content` instead.
+  > The functions in that module guarantee that all dependencies
+  > are created correctly and all processes are updated.
+  > Manipulating data manually will most likely result
+  > in inconsistent behavior and crashes.
   """
 
   use Beacon.Schema

--- a/lib/beacon/content/component_slot.ex
+++ b/lib/beacon/content/component_slot.ex
@@ -1,6 +1,14 @@
 defmodule Beacon.Content.ComponentSlot do
   @moduledoc """
-  TODO: doc
+  Component slot schema.
+
+  > #### Do not create or edit component slots manually {: .warning}
+  >
+  > Use the public functions in `Beacon.Content` instead.
+  > The functions in that module guarantee that all dependencies
+  > are created correctly and all processes are updated.
+  > Manipulating data manually will most likely result
+  > in inconsistent behavior and crashes.
   """
 
   use Beacon.Schema

--- a/lib/beacon/content/component_slot_attr.ex
+++ b/lib/beacon/content/component_slot_attr.ex
@@ -1,6 +1,14 @@
 defmodule Beacon.Content.ComponentSlotAttr do
   @moduledoc """
-  TODO: doc
+  Component slot attr schema.
+
+  > #### Do not create or edit component slot attrs manually {: .warning}
+  >
+  > Use the public functions in `Beacon.Content` instead.
+  > The functions in that module guarantee that all dependencies
+  > are created correctly and all processes are updated.
+  > Manipulating data manually will most likely result
+  > in inconsistent behavior and crashes.
   """
 
   use Beacon.Schema

--- a/lib/beacon/content/page.ex
+++ b/lib/beacon/content/page.ex
@@ -46,11 +46,7 @@ defmodule Beacon.Content.Page do
     has_many :variants, Content.PageVariant
     has_many :event_handlers, Content.PageEventHandler
 
-    embeds_many :helpers, Helper do
-      field :name, :string
-      field :args, :string
-      field :code, :string
-    end
+    embeds_many :helpers, Helper
 
     timestamps()
   end

--- a/lib/beacon/content/page.ex
+++ b/lib/beacon/content/page.ex
@@ -24,6 +24,7 @@ defmodule Beacon.Content.Page do
 
   alias Beacon.Content
   alias Beacon.Template.HEEx.HEExDecoder
+  alias Beacon.Content.Page.Helper
 
   @version 3
 

--- a/lib/beacon/content/page/helper.ex
+++ b/lib/beacon/content/page/helper.ex
@@ -1,0 +1,10 @@
+defmodule Beacon.Content.Page.Helper do
+  @moduledoc false
+  use Ecto.Schema
+
+  embedded_schema do
+    field :name, :string
+    field :args, :string
+    field :code, :string
+  end
+end

--- a/lib/beacon/migration.ex
+++ b/lib/beacon/migration.ex
@@ -1,15 +1,51 @@
 defmodule Beacon.Migration do
   @moduledoc """
   Functions which can be called in an Ecto migration for Beacon installation and upgrades.
+
+  ## Usage
+
+  To install Beacon, you'll need to generate an `Ecto.Migration` that wraps calls to `Beacon.Migration`:
+
+  ```
+  mix ecto.gen.migration create_beacon_tables
+  ```
+
+  Open the generated migration in your editor and either call or delegate to `up/0` and `down/0`:
+
+  ```elixir
+  defmodule MyApp.Repo.Migrations.CreateBeaconTables do
+    use Ecto.Migration
+
+    # Approach A: delegate
+    defdelegate up, to: Beacon.Migration
+    defdelegate down, to: Beacon.Migration
+
+    # Approach B: function call
+    def up, do: Beacon.Migration.up()
+    def down, do: Beacon.Migration.down()
+  end
+  ```
+
+  Then, run the migrations for your app to create the necessary Beacon tables in your database:
+
+  ```
+  mix ecto.migrate
+  ```
   """
 
   # TODO: `up/1` should execute all migrations from v001 up to `@latest`
   @latest Beacon.Migrations.V001
 
+  @doc """
+  Run the `up` changes for all migrations between the initial version and the current version.
+  """
   def up do
     @latest.up()
   end
 
+  @doc """
+  Run the `down` changes for all migrations between the initial version and the current version.
+  """
   def down do
     @latest.down()
   end

--- a/lib/beacon/router.ex
+++ b/lib/beacon/router.ex
@@ -60,7 +60,7 @@ defmodule Beacon.Router do
       scope "/marketing", MyAppWeb do
         pipe_through :browser_analytics
         beacon_site "/super-campaign", site: :marketing_super_campaign
-        beacon_site "/, site: :marketing
+        beacon_site "/", site: :marketing
       end
 
   Note in the last example that `/super-campaign` is defined _before_ `/` and there's an important reason for that: router precedence.

--- a/lib/beacon/runtime_css.ex
+++ b/lib/beacon/runtime_css.ex
@@ -4,8 +4,8 @@ defmodule Beacon.RuntimeCSS do
 
   Beacon supports Tailwind by default implemented by `Beacon.RuntimeCSS.TailwindCompiler`,
   you can use that module as template to implement any ther CSS engine as needed.
-
   """
+  alias Beacon.Types.Site
 
   @doc """
   Returns the CSS compiler config.
@@ -13,12 +13,12 @@ defmodule Beacon.RuntimeCSS do
   For Tailwind that would be the content of the tailwind config file,
   or return an empty string `""` if the provided engine doesn't have a config file.
   """
-  @callback config(Beacon.Types.Site.t()) :: String.t()
+  @callback config(site :: Site.t()) :: String.t()
 
   @doc """
   Executes the compilation to generate the CSS for the site using the provided `:css_compiler` in `Beacon.Config`.
   """
-  @callback compile(Beacon.Types.Site.t()) :: {:ok, String.t()} | {:error, any()}
+  @callback compile(site :: Site.t()) :: {:ok, String.t()} | {:error, any()}
 
   @doc false
   # TODO: compress and fetch from ETS
@@ -29,6 +29,7 @@ defmodule Beacon.RuntimeCSS do
   @doc """
   Returns the URL to fetch the CSS config used to generate the site stylesheet.
   """
+  @spec asset_url(Site.t()) :: String.t()
   def asset_url(site) do
     %{endpoint: endpoint, router: router} = Beacon.Config.fetch!(site)
     prefix = router.__beacon_scoped_prefix_for_site__(site)

--- a/lib/beacon/tailwind_compiler.ex
+++ b/lib/beacon/tailwind_compiler.ex
@@ -114,6 +114,7 @@ defmodule Beacon.RuntimeCSS.TailwindCompiler do
   # Run tailwind-cli returning the output and exit code
   # Note that `:cd` is the root dir for regular and umbrella projects so the paths have to be defined accordingly.
   # https://github.com/phoenixframework/tailwind/blob/8cf9810474bf37c1b1dd821503d756885534d2ba/lib/tailwind.ex#L192
+  @doc false
   def run_cli(profile, extra_args) when is_atom(profile) and is_list(extra_args) do
     version =
       case Tailwind.bin_version() do

--- a/lib/beacon_web/beacon_assigns.ex
+++ b/lib/beacon_web/beacon_assigns.ex
@@ -30,6 +30,7 @@ defmodule BeaconWeb.BeaconAssigns do
     %__MODULE__{site: site, private: %{components_module: components_module}}
   end
 
+  @doc false
   def new(site, %Beacon.Content.Page{} = page) do
     components_module = Beacon.Loader.Components.module_name(site)
     page_module = Beacon.Loader.Page.module_name(site, page.id)

--- a/lib/errors.ex
+++ b/lib/errors.ex
@@ -1,6 +1,9 @@
 defmodule Beacon.ConfigError do
   @moduledoc """
-  TODO: doc
+  Raised when some option in `Beacon.Config` is invalid.
+
+  If you are seeing this error, check `application.ex` where your site's config is defined.
+  Description and examples of each allowed configuration option can be found in `Beacon.Config.new/1`
   """
 
   defexception message: "error in Beacon.Config"
@@ -8,7 +11,11 @@ end
 
 defmodule Beacon.LoaderError do
   @moduledoc """
-  TODO: doc
+  Raised when Beacon attempts to load content into memory unsuccessfully.
+
+  There are several causes that can lead to this error, so if you're seeing it, be sure to read the
+  full error message for any additional information or steps to take.  If a LoaderError is crashing
+  your app on startup, it could indicate a problem in your `Beacon.Config`
   """
 
   defexception message: "error in Beacon.Loader", plug_status: 404
@@ -16,7 +23,12 @@ end
 
 defmodule Beacon.RuntimeError do
   @moduledoc """
-  TODO: doc
+  Raised when Beacon attempts to read content from memory unsuccessfully.
+
+  If you see this error consistently, check the message to see if `handle_event` is mentioned.
+  If so, this can indicate that pages on your site are sending events (e.g. button clicks,
+  form submissions) to an event handler which hasn't been implemented, or that the event name
+  does not match your handler.
   """
 
   defexception message: "runtime error in Beacon", plug_status: 404
@@ -24,7 +36,11 @@ end
 
 defmodule Beacon.AuthorizationError do
   @moduledoc """
-  TODO: doc
+  Raised when there is an error in the `get_agent/1` or `authorized?/3` callbacks of
+  a `Beacon.Authorization.Policy`.
+
+  If you're seeing this error, and have implemented a custom `Beacon.Authorization.Policy`,
+  check the logic in your policy module.
   """
 
   defexception message: "error in Beacon.Authorization"
@@ -32,7 +48,11 @@ end
 
 defmodule Beacon.ParserError do
   @moduledoc """
-  TODO: doc
+  Raised when Beacon's Markdown engine attempts to convert Markdown to HTML unsuccessfully.
+
+  This error can be triggered by layouts, pages, and any other resource that display HTML.
+  If you're seeing it, ensure that your template formats are correct. The full error message
+  will have details on where to look.
   """
 
   defexception message: "error parsing template"
@@ -40,7 +60,9 @@ end
 
 defmodule Beacon.SnippetError do
   @moduledoc """
-  TODO: doc
+  Raised when Beacon attempts to render a `Beacon.Content.Snippets.Helper` unsuccessfully.
+
+  If you're seeing this error, check for typos in your helpers' `:body`.
   """
 
   defexception [:message]
@@ -61,7 +83,11 @@ end
 
 defmodule BeaconWeb.NotFoundError do
   @moduledoc """
-  TODO: doc
+  Raised when Beacon attempts to serve a page or asset on an invalid path.
+
+  If you're seeing this error, it means some of your users are using the wrong URL.
+  To some extent, this is unavoidable, but consistently seeing this error with the same path
+  can indicate that somewhere in your page content, you are creating invalid links.
   """
 
   defexception [:message, plug_status: 404]
@@ -69,7 +95,10 @@ end
 
 defmodule BeaconWeb.ServerError do
   @moduledoc """
-  TODO: doc
+  Raised when a `Beacon.Content.PageEventHandler` returns an invalid response.
+
+  If you're seeing this error, check the code in your site's event handlers, and
+  ensure that each one returns `{:noreply, socket}`.
   """
 
   defexception [:message, plug_status: 500]

--- a/mix.exs
+++ b/mix.exs
@@ -113,6 +113,9 @@ defmodule Beacon.MixProject do
         Content: [
           Beacon.Content,
           Beacon.Content.Component,
+          Beacon.Content.ComponentAttr,
+          Beacon.Content.ComponentSlot,
+          Beacon.Content.ComponentSlotAttr,
           Beacon.Content.ErrorPage,
           Beacon.Content.Layout,
           Beacon.Content.LayoutEvent,
@@ -172,7 +175,9 @@ defmodule Beacon.MixProject do
           Beacon.Registry,
           Beacon.RuntimeCSS,
           Beacon.RuntimeJS,
-          Beacon.RuntimeCSS.TailwindCompiler
+          Beacon.RuntimeCSS.TailwindCompiler,
+          BeaconWeb.BeaconAssigns,
+          Beacon.Migration
         ],
         Types: [
           Beacon.Types.Atom,
@@ -185,10 +190,13 @@ defmodule Beacon.MixProject do
           Beacon.AuthorizationError,
           Beacon.ParserError,
           Beacon.SnippetError,
-          BeaconWeb.NotFoundError
+          BeaconWeb.NotFoundError,
+          BeaconWeb.ServerError,
+          Beacon.RuntimeError,
+          Beacon.ConfigError
         ]
       ],
-      groups_for_functions: [
+      groups_for_docs: [
         "Functions: Layouts": &(&1[:type] == :layouts),
         "Functions: Pages": &(&1[:type] == :pages),
         "Functions: Page Variants": &(&1[:type] == :page_variants),


### PR DESCRIPTION
* Adds some basic moduledoc to replace TODOs
* Group content functions which were missing group
* Move embedded schema Page.Helper into its own module so it can be undocumented
* Replace deprecated `groups_for_functions` with `groups_for_docs`
* Remove injected `child_spec` (from GenServer/Supervisor) from docs