### PR TITLE
Content/Component - validate attr opts and slot opts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           - otp: "27"
             elixir: "1.17"
             phoenix: "~> 1.7"
-            phoenix-live-view: "1.0.0-rc.7"
+            phoenix-live-view: "~> 1.0.0-rc.7"
             postgres: '16.4-alpine'
 
     env:
@@ -98,7 +98,7 @@ jobs:
           - otp: "27"
             elixir: "1.17"
             phoenix: "~> 1.7"
-            phoenix-live-view: "1.0.0-rc.7"
+            phoenix-live-view: "~> 1.0.0-rc.7"
 
     env:
       MIX_ENV: dev

--- a/lib/beacon/content.ex
+++ b/lib/beacon/content.ex
@@ -2948,7 +2948,14 @@ defmodule Beacon.Content do
         component
 
       {:error, changeset} ->
-        raise "failed to create component: #{inspect(changeset.errors)}"
+        errors =
+          Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+            Regex.replace(~r"%{(\w+)}", msg, fn _, key ->
+              opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+            end)
+          end)
+
+        raise "failed to create component: #{inspect(errors)}"
     end
   end
 

--- a/lib/beacon/content/component.ex
+++ b/lib/beacon/content/component.ex
@@ -130,12 +130,17 @@ defmodule Beacon.Content.Component do
   @doc false
   def validate_equivalent_options(changeset) do
     opts = get_field(changeset, :opts) |> maybe_binary_to_term()
+    type = get_field(changeset, :type)
     required_opts = get_field_from_opts(changeset, :required)
-
     values_opts = get_field_from_opts(changeset, :values)
     examples_opts = get_field_from_opts(changeset, :examples)
+    not_allowed = Keyword.keys(opts) -- [:required, :default, :examples, :values, :doc]
 
     cond do
+      Enum.count(not_allowed) > 0 and type != "global" ->
+        name = get_field(changeset, :name)
+        add_error(changeset, :opts, "invalid opts for attribute #{inspect(name)}: #{inspect(not_allowed)}")
+
       not is_nil(required_opts) and :default in Keyword.keys(opts) ->
         add_error(changeset, :opts_default, "only one of 'Required' or 'Default' attribute must be given")
 

--- a/lib/beacon/content/component_slot.ex
+++ b/lib/beacon/content/component_slot.ex
@@ -56,13 +56,11 @@ defmodule Beacon.Content.ComponentSlot do
     opts = get_field(changeset, :opts) |> maybe_binary_to_term()
     not_allowed = Keyword.keys(opts) -- [:required, :validate_attrs, :doc]
 
-    cond do
-      Enum.count(not_allowed) > 0 ->
-        name = get_field(changeset, :name)
-        add_error(changeset, :opts, "invalid opts for slot #{inspect(name)}: #{inspect(not_allowed)}")
-
-      true ->
-        changeset
+    if Enum.count(not_allowed) > 0 do
+      name = get_field(changeset, :name)
+      add_error(changeset, :opts, "invalid opts for slot #{inspect(name)}: #{inspect(not_allowed)}")
+    else
+      changeset
     end
   end
 

--- a/lib/beacon/loader/components.ex
+++ b/lib/beacon/loader/components.ex
@@ -99,8 +99,8 @@ defmodule Beacon.Loader.Components do
           quote do
             attr.(
               unquote(String.to_atom(component_attr.name)),
-              unquote(att_type_to_atom(component_attr.type, component_attr.struct_name)),
-              unquote(Macro.escape(component_attr.opts))
+              unquote(attr_type_to_atom(component_attr.type, component_attr.struct_name)),
+              unquote(Macro.escape(ignore_invalid_attr_opts(component_attr.opts)))
             )
           end
         end
@@ -109,15 +109,15 @@ defmodule Beacon.Loader.Components do
       unquote_splicing(
         for component_slot <- component.slots do
           quote do
-            slot.(unquote(String.to_atom(component_slot.name)), unquote(component_slot.opts),
+            slot.(unquote(String.to_atom(component_slot.name)), unquote(ignore_invalid_slot_opts(component_slot.opts)),
               do:
                 unquote_splicing(
                   for slot_attr <- component_slot.attrs do
                     quote do
                       attr.(
                         unquote(String.to_atom(slot_attr.name)),
-                        unquote(att_type_to_atom(slot_attr.type, slot_attr.struct_name)),
-                        unquote(Macro.escape(slot_attr.opts))
+                        unquote(attr_type_to_atom(slot_attr.type, slot_attr.struct_name)),
+                        unquote(Macro.escape(ignore_invalid_attr_opts(slot_attr.opts)))
                       )
                     end
                   end
@@ -134,12 +134,22 @@ defmodule Beacon.Loader.Components do
     end
   end
 
-  def att_type_to_atom(component_type, struct_name) when component_type == "struct" do
+  defp attr_type_to_atom(component_type, struct_name) when component_type == "struct" do
     Module.concat([struct_name])
   end
 
-  def att_type_to_atom(component_type, _struct_name) when component_type in @supported_attr_types do
+  defp attr_type_to_atom(component_type, _struct_name) when component_type in @supported_attr_types do
     String.to_atom(component_type)
+  end
+
+  # https://hexdocs.pm/phoenix_live_view/1.0.0-rc.5/Phoenix.Component.html#attr/3
+  defp ignore_invalid_attr_opts(opts) do
+    Keyword.take(opts, [:required, :default, :examples, :values, :doc])
+  end
+
+  # https://hexdocs.pm/phoenix_live_view/1.0.0-rc.7/Phoenix.Component.html#slot/3
+  defp ignore_invalid_slot_opts(opts) do
+    Keyword.take(opts, [:required, :validate_attrs, :doc])
   end
 
   # TODO: remove render_component/1 along with my_component/2

--- a/test/beacon/content_test.exs
+++ b/test/beacon/content_test.exs
@@ -776,6 +776,44 @@ defmodule Beacon.ContentTest do
                Content.create_component(%{site: :my_site, name: "my_component$", template: "test", example: "test"})
     end
 
+    test "validate allowed attrs opts" do
+      assert {
+               :error,
+               %Ecto.Changeset{
+                 changes: %{attrs: [%{errors: [opts: {"invalid opts for attribute \"name\": [:other]", []}]}]},
+                 valid?: false
+               }
+             } =
+               Content.create_component(%{
+                 site: :my_site,
+                 name: "my_component",
+                 template: "test",
+                 example: "test",
+                 attrs: [
+                   %{name: "name", type: "string", opts: [required: true, other: nil]}
+                 ]
+               })
+    end
+
+    test "validate allowed slot opts" do
+      assert {
+               :error,
+               %Ecto.Changeset{
+                 changes: %{slots: [%{errors: [opts: {"invalid opts for slot \"inner_block\": [:default]", []}]}]},
+                 valid?: false
+               }
+             } =
+               Content.create_component(%{
+                 site: :my_site,
+                 name: "my_component",
+                 template: "test",
+                 example: "test",
+                 slots: [
+                   %{name: "inner_block", opts: [default: nil]}
+                 ]
+               })
+    end
+
     test "list components" do
       beacon_component_fixture(site: "my_site", name: "component_a")
       beacon_component_fixture(site: "my_site", name: "component_b")


### PR DESCRIPTION
Fixes the error `[error] failed to compile module Elixir.Beacon.Web.LiveRenderer.a0bcc01f27e792cd27ed89d15303a9da.Page94f2b1db-1900-4654-a402-986bcb0f27f9`

One of the built-in components were created incorrectly with an invalid slot opt which was causing the `Components` module to fail. This change validates attr opts and slot opts to avoid invalid state and also ignore invalid opts when loading the Components module.