### PR TITLE
Allow to patch (navigate patching the content) to another site

### DIFF
--- a/lib/beacon/private.ex
+++ b/lib/beacon/private.ex
@@ -1,0 +1,35 @@
+defmodule Beacon.Private do
+  @moduledoc false
+
+  # Concentrate calls to private APIs so it's easier to track breaking changes and document them
+  # in case we need to make changes.
+  # Should be avoided as much as possible.
+
+  @doc """
+  On page navigation, the request might actually hit a different site than the one defined by the current session.
+
+  That's the case for a live path to a full URL, for eg:
+
+  User is in https://sitea.com/page1 and clicks on a link to https://siteb.com/page2 through a `<.link patch` component,
+  and since LV allows such navigation, we must fetch the session defined for the requested URL and update the state accordingly.
+
+  We use the private function `Phoenix.LiveView.Route.live_link_info/3` in order to keep the same behavior as LV.
+  """
+  def site_from_session(endpoint, router, url, view) do
+    case Phoenix.LiveView.Route.live_link_info(endpoint, router, url) do
+      {_,
+       %{
+         view: ^view,
+         live_session: %{
+           extra: %{
+             session: %{"beacon_site" => site}
+           }
+         }
+       }} ->
+        site
+
+      _ ->
+        nil
+    end
+  end
+end

--- a/lib/beacon/private.ex
+++ b/lib/beacon/private.ex
@@ -13,6 +13,8 @@ defmodule Beacon.Private do
   User is in https://sitea.com/page1 and clicks on a link to https://siteb.com/page2 through a `<.link patch` component,
   and since LV allows such navigation, we must fetch the session defined for the requested URL and update the state accordingly.
 
+  Relative paths are not supported because there's no safe way to know if a /relative path belongs to site A or B.
+
   We use the private function `Phoenix.LiveView.Route.live_link_info/3` in order to keep the same behavior as LV.
   """
   def site_from_session(endpoint, router, url, view) do

--- a/lib/beacon/private.ex
+++ b/lib/beacon/private.ex
@@ -1,19 +1,21 @@
 defmodule Beacon.Private do
   @moduledoc false
 
-  # Concentrate calls to private APIs so it's easier to track breaking changes and document them
-  # in case we need to make changes.
+  # Concentrate calls to private APIs so it's easier to track breaking changes and document them,
+  # in case we need to make changes or understand why we had to call such APIs.
+
   # Should be avoided as much as possible.
 
   @doc """
   On page navigation, the request might actually hit a different site than the one defined by the current session.
 
-  That's the case for a live path to a full URL, for eg:
+  That's the case for a live patch to a full URL, for eg:
 
-  User is in https://sitea.com/page1 and clicks on a link to https://siteb.com/page2 through a `<.link patch` component,
-  and since LV allows such navigation, we must fetch the session defined for the requested URL and update the state accordingly.
+  User is in https://sitea.com/page1 and clicks on a link to https://siteb.com/page2 through a `<.link patch={...}>` component,
+  and since LV allows such navigation, we must do it as well but we need fetch the session defined for the requested URL and update the state accordingly,
+  otherwise the page will either not be found or worse could render the wrong content.
 
-  Relative paths are not supported because there's no safe way to know if a /relative path belongs to site A or B.
+  Relative paths are not supported because there's no safe way to know if a `/relative` path belongs to site A or B, that's a LV contraint.
 
   We use the private function `Phoenix.LiveView.Route.live_link_info/3` in order to keep the same behavior as LV.
   """

--- a/lib/beacon/pub_sub.ex
+++ b/lib/beacon/pub_sub.ex
@@ -56,6 +56,10 @@ defmodule Beacon.PubSub do
     Phoenix.PubSub.subscribe(@pubsub, topic_page(site, path))
   end
 
+  def unsubscribe_to_page(site, path) do
+    Phoenix.PubSub.unsubscribe(@pubsub, topic_page(site, path))
+  end
+
   def page_loaded(%Content.Page{} = page) do
     page.site
     |> topic_page(page.path)

--- a/test/beacon_web/live/page_live_test.exs
+++ b/test/beacon_web/live/page_live_test.exs
@@ -68,6 +68,7 @@ defmodule Beacon.Web.Live.PageLiveTest do
           @beacon.query_params=<%= @beacon.query_params["query"] %>
 
           <.page_link path="/about">go_to_about_page</.page_link>
+          <.link patch={"#{Beacon.BeaconTest.Endpoint.url()}/other"}>go_to_other_site</.link>
 
           <.form :let={f} for={%{}} as={:greeting} phx-submit="hello">
             Name: <%= text_input f, :name %>
@@ -131,6 +132,14 @@ defmodule Beacon.Web.Live.PageLiveTest do
         meta_tags: nil
       )
 
+    beacon_published_page_fixture(
+      site: :not_booted,
+      path: "/",
+      template: """
+      <h1><%= @beacon.site %></h1>
+      """
+    )
+
     [layout: layout]
   end
 
@@ -155,6 +164,16 @@ defmodule Beacon.Web.Live.PageLiveTest do
     assert view
            |> element("a", "go_to_about_page")
            |> render_click() =~ "about_page"
+  end
+
+  test "patch to another site resets site data", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/home/hello")
+
+    view
+    |> element("a", "go_to_other_site")
+    |> render_click()
+
+    assert has_element?(view, "h1", "not_booted")
   end
 
   describe "meta tags" do

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -17,6 +17,7 @@ defmodule Beacon.BeaconTest.Router do
 
   scope "/" do
     pipe_through :browser
+    beacon_site "/other", site: :not_booted
     beacon_site "/", site: :my_site
   end
 end


### PR DESCRIPTION
Suppose the following routes:

```elixir
scope "/", host: "sitea.com" do
  pipe_through [:browser]
  beacon_site "/sitea", site: :site_a
end

scope "/", host: "siteb.com" do
  pipe_through [:browser]
  beacon_site "/siteb", site: :site_b
end
```

Given you're in any page of site_a and there's a link to another site such as http://siteb.com:4000/other

This change will allow Beacon to patch the contents of the page and display the /other page from site_b

That's very powerful because it allows to navigate between sites without requiring full refreshes. For instance LiveView does allow this kind of navigation too.

Note that patching to relative paths is not supported by LV and won't be supported by Beacon either. For eg a patch link to /other will raise.

Thanks to @APB9785 for the discussion on this issue.