### PR TITLE
fix: serve media library assets inside aliased scopes

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -79,7 +79,7 @@ defmodule DemoWeb.Router do
     plug :put_secure_browser_headers
   end
 
-  scope "/" do
+  scope "/", DemoWeb do
     pipe_through :browser
     beacon_site "/dev", site: :dev
     beacon_site "/dy", site: :dy

--- a/lib/beacon/content.ex
+++ b/lib/beacon/content.ex
@@ -1706,7 +1706,7 @@ defmodule Beacon.Content do
           %{name: "class", type: "string", opts: [default: nil]},
           %{name: "rest", type: "global"}
         ],
-        template: ~S|<img src={beacon_asset_url(@name)} class={@class} {@rest} />|,
+        template: ~S|<img src={beacon_media_url(@name)} class={@class} {@rest} />|,
         example: ~S|<.image site={@beacon.site} name="beacon.webp" alt="logo" />|,
         category: :media
       },

--- a/lib/beacon/loader/routes.ex
+++ b/lib/beacon/loader/routes.ex
@@ -15,10 +15,12 @@ defmodule Beacon.Loader.Routes do
 
     config.site
     |> module_name()
-    |> render(config.site, config.endpoint, config.router)
+    |> render(config)
   end
 
-  defp render(routes_module, site, endpoint, router) do
+  defp render(routes_module, config) do
+    %{site: site, endpoint: endpoint, router: router} = config
+
     quote do
       defmodule unquote(routes_module) do
         Module.put_attribute(__MODULE__, :site, unquote(site))
@@ -28,7 +30,8 @@ defmodule Beacon.Loader.Routes do
         # TODO: secure cross site assets
         # TODO: asset_path sigil
         def beacon_asset_path(file_name) when is_binary(file_name) do
-          sanitize_path("/__beacon_assets__/#{unquote(site)}/#{file_name}")
+          prefix = @router.__beacon_scoped_prefix_for_site__(@site)
+          sanitize_path("#{prefix}/__beacon_assets__/#{file_name}")
         end
 
         # TODO: asset_url sigil

--- a/lib/beacon/loader/routes.ex
+++ b/lib/beacon/loader/routes.ex
@@ -27,16 +27,26 @@ defmodule Beacon.Loader.Routes do
         Module.put_attribute(__MODULE__, :endpoint, unquote(endpoint))
         Module.put_attribute(__MODULE__, :router, unquote(router))
 
-        # TODO: secure cross site assets
-        # TODO: asset_path sigil
+        @deprecated "use beacon_media_path/1 instead"
         def beacon_asset_path(file_name) when is_binary(file_name) do
-          prefix = @router.__beacon_scoped_prefix_for_site__(@site)
-          sanitize_path("#{prefix}/__beacon_assets__/#{file_name}")
+          beacon_media_path(file_name)
         end
 
-        # TODO: asset_url sigil
+        @deprecated "use beacon_media_url/1 instead"
         def beacon_asset_url(file_name) when is_binary(file_name) do
-          @endpoint.url() <> beacon_asset_path(file_name)
+          beacon_media_url(file_name)
+        end
+
+        # TODO: secure cross site assets
+        # TODO: media_path sigil
+        def beacon_media_path(file_name) when is_binary(file_name) do
+          prefix = @router.__beacon_scoped_prefix_for_site__(@site)
+          sanitize_path("#{prefix}/__beacon_media__/#{file_name}")
+        end
+
+        # TODO: media_url sigil
+        def beacon_media_url(file_name) when is_binary(file_name) do
+          @endpoint.url() <> beacon_media_path(file_name)
         end
 
         defp sanitize_path(path) do

--- a/lib/beacon/media_library/provider/repo.ex
+++ b/lib/beacon/media_library/provider/repo.ex
@@ -37,7 +37,7 @@ defmodule Beacon.MediaLibrary.Provider.Repo do
   @doc false
   def url_for(asset) do
     routes = Beacon.Loader.fetch_routes_module(asset.site)
-    Beacon.apply_mfa(routes, :beacon_asset_url, [asset.file_name])
+    Beacon.apply_mfa(routes, :beacon_media_url, [asset.file_name])
   end
 
   @doc false

--- a/lib/beacon/router.ex
+++ b/lib/beacon/router.ex
@@ -133,13 +133,15 @@ defmodule Beacon.Router do
       {site, session_name, session_opts} = Beacon.Router.__options__(opts)
 
       scope prefix, alias: false, as: false do
-        get "/__beacon_assets__/:file_name", Beacon.Web.MediaLibraryController, :show, assigns: %{site: opts[:site]}
-
         live_session session_name, session_opts do
+          get "/__beacon_media__/:file_name", Beacon.Web.MediaLibraryController, :show, assigns: %{site: opts[:site]}
+
           # TODO: css_config-:md5 caching
-          get "/__beacon_assets__/css_config", Beacon.Web.AssetsController, :css_config, as: :asset, assigns: %{site: opts[:site]}
-          get "/__beacon_assets__/css-:md5", Beacon.Web.AssetsController, :css, as: :asset, assigns: %{site: opts[:site]}
-          get "/__beacon_assets__/js-:md5", Beacon.Web.AssetsController, :js, as: :asset, assigns: %{site: opts[:site]}
+          get "/__beacon_assets__/css_config", Beacon.Web.AssetsController, :css_config, assigns: %{site: opts[:site]}
+
+          get "/__beacon_assets__/css-:md5", Beacon.Web.AssetsController, :css, assigns: %{site: opts[:site]}
+          get "/__beacon_assets__/js-:md5", Beacon.Web.AssetsController, :js, assigns: %{site: opts[:site]}
+
           live "/*path", Beacon.Web.PageLive, :path
         end
       end
@@ -200,13 +202,17 @@ defmodule Beacon.Router do
   end
 
   @doc false
+  @deprecated "use Routes.beacon_media_path/1 instead"
   def beacon_asset_path(site, file_name) when is_atom(site) and is_binary(file_name) do
-    sanitize_path("/__beacon_assets__/#{site}/#{file_name}")
+    routes = Beacon.Loader.fetch_routes_module(site)
+    routes.beacon_media_path(file_name)
   end
 
   @doc false
+  @deprecated "use Routes.beacon_media_path/1 instead"
   def beacon_asset_url(site, file_name) when is_atom(site) and is_binary(file_name) do
-    Beacon.Config.fetch!(site).endpoint.url() <> beacon_asset_path(site, file_name)
+    routes = Beacon.Loader.fetch_routes_module(site)
+    routes.beacon_media_url(file_name)
   end
 
   @doc false

--- a/lib/beacon/router.ex
+++ b/lib/beacon/router.ex
@@ -120,7 +120,7 @@ defmodule Beacon.Router do
   ## Options
 
     * `:site` (required) `t:Beacon.Types.Site.t/0` - register your site with a unique name.
-      Note that the name has to match the one used in your site configuration in `application.ex`.
+      Note that the name has to match the one used in your site configuration.
       See the module doc and `Beacon.Config` for more info.
 
   """
@@ -132,15 +132,14 @@ defmodule Beacon.Router do
 
       {site, session_name, session_opts} = Beacon.Router.__options__(opts)
 
-      get "/__beacon_assets__/#{site}/:file_name", Beacon.Web.MediaLibraryController, :show
-
       scope prefix, alias: false, as: false do
+        get "/__beacon_assets__/:file_name", Beacon.Web.MediaLibraryController, :show, assigns: %{site: opts[:site]}
+
         live_session session_name, session_opts do
           # TODO: css_config-:md5 caching
-          get "/__beacon_assets__/css_config", Beacon.Web.AssetsController, :css_config, as: :beacon_asset, assigns: %{site: opts[:site]}
-          get "/__beacon_assets__/css-:md5", Beacon.Web.AssetsController, :css, as: :beacon_asset, assigns: %{site: opts[:site]}
-          get "/__beacon_assets__/js-:md5", Beacon.Web.AssetsController, :js, as: :beacon_asset, assigns: %{site: opts[:site]}
-          get "/__beacon_assets__/:file_name", Beacon.Web.MediaLibraryController, :show
+          get "/__beacon_assets__/css_config", Beacon.Web.AssetsController, :css_config, as: :asset, assigns: %{site: opts[:site]}
+          get "/__beacon_assets__/css-:md5", Beacon.Web.AssetsController, :css, as: :asset, assigns: %{site: opts[:site]}
+          get "/__beacon_assets__/js-:md5", Beacon.Web.AssetsController, :js, as: :asset, assigns: %{site: opts[:site]}
           live "/*path", Beacon.Web.PageLive, :path
         end
       end

--- a/lib/beacon/web/controllers/media_library_controller.ex
+++ b/lib/beacon/web/controllers/media_library_controller.ex
@@ -6,15 +6,7 @@ defmodule Beacon.Web.MediaLibraryController do
   alias Beacon.MediaLibrary
   alias Beacon.MediaLibrary.Asset
 
-  def show(conn, %{"file_name" => file_name}) do
-    site =
-      case conn.path_info do
-        ["__beacon_assets__", site | _] -> String.to_existing_atom(site)
-        _ -> nil
-      end
-
-    site || raise Beacon.Web.NotFoundError, "failed to serve asset #{file_name}"
-
+  def show(%{assigns: %{site: site}} = conn, %{"file_name" => file_name}) when is_atom(site) do
     case MediaLibrary.get_asset_by(site, file_name: file_name) do
       %Asset{} = asset ->
         Beacon.Web.Cache.when_stale(conn, asset, fn conn ->
@@ -27,6 +19,10 @@ defmodule Beacon.Web.MediaLibraryController do
       _ ->
         raise Beacon.Web.NotFoundError, "asset #{inspect(file_name)} not found"
     end
+  end
+
+  def show(_conn, %{"file_name" => file_name}) do
+    raise Beacon.Web.NotFoundError, "failed to serve asset #{file_name}"
   end
 
   def show(_conn, _params) do

--- a/test/beacon/loader/routes_test.exs
+++ b/test/beacon/loader/routes_test.exs
@@ -6,11 +6,11 @@ defmodule Beacon.Loader.RoutesTest do
   import :"Elixir.Beacon.Web.LiveRenderer.c55c9d9db8d6d8c4d34b4f249c20ed4e.Routes"
 
   test "beacon_asset_path" do
-    assert beacon_asset_path("logo.webp") == "/__beacon_assets__/s3_site/logo.webp"
+    assert beacon_asset_path("logo.webp") == "/nested/media/__beacon_assets__/logo.webp"
   end
 
   test "beacon_asset_url" do
-    assert beacon_asset_url("logo.webp") == "http://localhost:4000/__beacon_assets__/s3_site/logo.webp"
+    assert beacon_asset_url("logo.webp") == "http://localhost:4000/nested/media/__beacon_assets__/logo.webp"
   end
 
   describe "sigil_p" do

--- a/test/beacon/loader/routes_test.exs
+++ b/test/beacon/loader/routes_test.exs
@@ -5,12 +5,12 @@ defmodule Beacon.Loader.RoutesTest do
   # Beacon.Loader.fetch_routes_module(:s3_site)
   import :"Elixir.Beacon.Web.LiveRenderer.c55c9d9db8d6d8c4d34b4f249c20ed4e.Routes"
 
-  test "beacon_asset_path" do
-    assert beacon_asset_path("logo.webp") == "/nested/media/__beacon_assets__/logo.webp"
+  test "beacon_media_path" do
+    assert beacon_media_path("logo.webp") == "/nested/media/__beacon_media__/logo.webp"
   end
 
-  test "beacon_asset_url" do
-    assert beacon_asset_url("logo.webp") == "http://localhost:4000/nested/media/__beacon_assets__/logo.webp"
+  test "beacon_media_url" do
+    assert beacon_media_url("logo.webp") == "http://localhost:4000/nested/media/__beacon_media__/logo.webp"
   end
 
   describe "sigil_p" do

--- a/test/beacon/media_library_test.exs
+++ b/test/beacon/media_library_test.exs
@@ -38,7 +38,7 @@ defmodule Beacon.MediaLibraryTest do
     test "upload asset, converts to webp by default, repo store" do
       metadata = beacon_upload_metadata_fixture(file_name: "image.png")
       assert %Asset{file_name: "image.webp", media_type: "image/webp"} = asset = MediaLibrary.upload(metadata)
-      assert "http://localhost:4000/__beacon_assets__/image.webp" = MediaLibrary.url_for(asset)
+      assert "http://localhost:4000/__beacon_media__/image.webp" = MediaLibrary.url_for(asset)
     end
   end
 

--- a/test/beacon/media_library_test.exs
+++ b/test/beacon/media_library_test.exs
@@ -38,7 +38,7 @@ defmodule Beacon.MediaLibraryTest do
     test "upload asset, converts to webp by default, repo store" do
       metadata = beacon_upload_metadata_fixture(file_name: "image.png")
       assert %Asset{file_name: "image.webp", media_type: "image/webp"} = asset = MediaLibrary.upload(metadata)
-      assert "http://localhost:4000/__beacon_assets__/my_site/image.webp" = MediaLibrary.url_for(asset)
+      assert "http://localhost:4000/__beacon_assets__/image.webp" = MediaLibrary.url_for(asset)
     end
   end
 

--- a/test/beacon_web/controllers/media_library_controller_test.exs
+++ b/test/beacon_web/controllers/media_library_controller_test.exs
@@ -4,7 +4,7 @@ defmodule Beacon.Web.Controllers.MediaLibraryControllerTest do
   test "show", %{conn: conn} do
     %{file_name: file_name} = Beacon.Test.Fixtures.beacon_media_library_asset_fixture(site: :my_site)
     routes = Beacon.Loader.fetch_routes_module(:my_site)
-    path = Beacon.apply_mfa(routes, :beacon_asset_path, [file_name])
+    path = Beacon.apply_mfa(routes, :beacon_media_path, [file_name])
 
     conn = get(conn, path)
 

--- a/test/support/beacon_web.ex
+++ b/test/support/beacon_web.ex
@@ -1,4 +1,4 @@
-defmodule Beacon.Beacon.WebTest do
+defmodule Beacon.BeaconTest.Web do
   defmacro __using__(which) when is_atom(which) do
     apply(__MODULE__, which, [])
   end
@@ -41,11 +41,11 @@ defmodule Beacon.Beacon.WebTest do
 end
 
 defmodule Beacon.BeaconTest.LayoutView do
-  use Beacon.Beacon.WebTest, :view
+  use Beacon.BeaconTest.Web, :view
 end
 
 defmodule Beacon.BeaconTest.ErrorView do
-  use Beacon.Beacon.WebTest, :view
+  use Beacon.BeaconTest.Web, :view
 
   def render(_template, _assigns), do: "Error"
 end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -1,5 +1,5 @@
 defmodule Beacon.BeaconTest.Router do
-  use Beacon.Beacon.WebTest, :router
+  use Beacon.BeaconTest.Web, :router
   use Beacon.Router
 
   pipeline :browser do
@@ -16,7 +16,8 @@ defmodule Beacon.BeaconTest.Router do
     beacon_site "/media", site: :s3_site
   end
 
-  scope "/" do
+  # `alias` is not really used but is present here to verify that `beacon_site` has no conflicts with custom aliases
+  scope path: "/", alias: AnyAlias do
     pipe_through :browser
     beacon_site "/other", site: :not_booted
     beacon_site "/", site: :my_site


### PR DESCRIPTION
Close #642

Now it allows to use `beacon_site` inside aliased scopes and also doesn't expose the site name.