### PR TITLE
Global lock, Take 2

### DIFF
--- a/lib/beacon/beacon.ex
+++ b/lib/beacon/beacon.ex
@@ -136,6 +136,8 @@ defmodule Beacon do
   rescue
     error ->
       context = Keyword.get(opts, :context, nil)
-      reraise Beacon.InvokeError, [error: error, args: args, context: context], __STACKTRACE__
+      mfa = Exception.format_mfa(module, function, length(args))
+      message = "error applying #{mfa}"
+      reraise Beacon.InvokeError, [message: message, error: error, args: args, context: context], __STACKTRACE__
   end
 end

--- a/lib/beacon/boot.ex
+++ b/lib/beacon/boot.ex
@@ -23,10 +23,10 @@ defmodule Beacon.Boot do
   def init(%{site: site, mode: :testing}) when is_atom(site) do
     Logger.debug("Beacon.Boot is disabled for site #{site} on testing mode")
 
-    # reload modules that are expected to be available, even empty
-    Beacon.Loader.reload_routes_module(site)
-    Beacon.Loader.reload_components_module(site)
-    Beacon.Loader.reload_live_data_module(site)
+    # load modules that are expected to be available, even empty
+    Beacon.Loader.load_routes_module(site)
+    Beacon.Loader.load_components_module(site)
+    Beacon.Loader.load_live_data_module(site)
 
     :ignore
   end
@@ -35,7 +35,7 @@ defmodule Beacon.Boot do
     Logger.info("Beacon.Boot booting site #{site}")
     task_supervisor = Beacon.Registry.via({site, TaskSupervisor})
 
-    # temporary disable module reloading so we can populate data more efficiently
+    # temporary disable module loading so we can populate data more efficiently
     %{mode: :manual} = Beacon.Config.update_value(site, :mode, :manual)
     Beacon.Loader.populate_default_media(site)
     Beacon.Loader.populate_default_components(site)
@@ -46,12 +46,12 @@ defmodule Beacon.Boot do
     %{mode: :live} = Beacon.Config.update_value(site, :mode, :live)
 
     # still needed to test Beacon itself
-    Beacon.Loader.reload_routes_module(site)
-    Beacon.Loader.reload_components_module(site)
+    Beacon.Loader.load_routes_module(site)
+    Beacon.Loader.load_components_module(site)
 
     assets = [
-      Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_runtime_js(site) end),
-      Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.reload_runtime_css(site) end)
+      Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.load_runtime_js(site) end),
+      Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.load_runtime_css(site) end)
     ]
 
     # TODO: revisit this timeout after we upgrade to Tailwind v4

--- a/lib/beacon/boot.ex
+++ b/lib/beacon/boot.ex
@@ -15,19 +15,8 @@ defmodule Beacon.Boot do
     Beacon.Registry.via({site, __MODULE__})
   end
 
-  def init(%{site: site, mode: :manual}) when is_atom(site) do
-    Logger.debug("Beacon.Boot is disabled for site #{site} on manual mode")
-    :ignore
-  end
-
-  def init(%{site: site, mode: :testing}) when is_atom(site) do
-    Logger.debug("Beacon.Boot is disabled for site #{site} on testing mode")
-
-    # load modules that are expected to be available, even empty
-    # Beacon.Loader.load_routes_module(site)
-    # Beacon.Loader.load_components_module(site)
-    Beacon.Loader.load_live_data_module(site)
-
+  def init(%{site: site, mode: mode}) when is_atom(site) and mode in [:manual, :testing] do
+    Logger.debug("Beacon.Boot is disabled for site #{site} on #{mode} mode")
     :ignore
   end
 
@@ -44,10 +33,6 @@ defmodule Beacon.Boot do
     Beacon.Loader.populate_default_home_page(site)
 
     %{mode: :live} = Beacon.Config.update_value(site, :mode, :live)
-
-    # still needed to test Beacon itself
-    # Beacon.Loader.load_routes_module(site)
-    # Beacon.Loader.load_components_module(site)
 
     assets = [
       Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.load_runtime_js(site) end),

--- a/lib/beacon/boot.ex
+++ b/lib/beacon/boot.ex
@@ -24,8 +24,8 @@ defmodule Beacon.Boot do
     Logger.debug("Beacon.Boot is disabled for site #{site} on testing mode")
 
     # load modules that are expected to be available, even empty
-    Beacon.Loader.load_routes_module(site)
-    Beacon.Loader.load_components_module(site)
+    # Beacon.Loader.load_routes_module(site)
+    # Beacon.Loader.load_components_module(site)
     Beacon.Loader.load_live_data_module(site)
 
     :ignore
@@ -46,8 +46,8 @@ defmodule Beacon.Boot do
     %{mode: :live} = Beacon.Config.update_value(site, :mode, :live)
 
     # still needed to test Beacon itself
-    Beacon.Loader.load_routes_module(site)
-    Beacon.Loader.load_components_module(site)
+    # Beacon.Loader.load_routes_module(site)
+    # Beacon.Loader.load_components_module(site)
 
     assets = [
       Task.Supervisor.async(task_supervisor, fn -> Beacon.Loader.load_runtime_js(site) end),

--- a/lib/beacon/error_handler.ex
+++ b/lib/beacon/error_handler.ex
@@ -12,12 +12,12 @@ defmodule Beacon.ErrorHandler do
   alias Beacon.Loader
 
   def undefined_function(module, fun, args) do
-    ensure_loaded(module) or reload_resource(module)
+    ensure_loaded(module) or load_resource(module)
     :error_handler.undefined_function(module, fun, args)
   end
 
   def undefined_lambda(module, fun, args) do
-    ensure_loaded(module) or reload_resource(module)
+    ensure_loaded(module) or load_resource(module)
     :error_handler.undefined_lambda(module, fun, args)
   end
 
@@ -33,35 +33,35 @@ defmodule Beacon.ErrorHandler do
     end
   end
 
-  defp reload_resource(module) when is_atom(module) do
+  defp load_resource(module) when is_atom(module) do
     module
     |> Module.split()
-    |> reload_resource()
+    |> load_resource()
   rescue
     # ignore erlang modules
     _ -> false
   end
 
-  defp reload_resource(["Beacon", "Web", "LiveRenderer", _site_id, resource]) do
-    reload_beacon_resource(Process.get(:__beacon_site__), resource)
+  defp load_resource(["Beacon", "Web", "LiveRenderer", _site_id, resource]) do
+    load_beacon_resource(Process.get(:__beacon_site__), resource)
   end
 
-  defp reload_resource(_module), do: false
+  defp load_resource(_module), do: false
 
-  defp reload_beacon_resource(nil = _site, _resource), do: false
+  defp load_beacon_resource(nil = _site, _resource), do: false
 
-  defp reload_beacon_resource(site, resource) do
+  defp load_beacon_resource(site, resource) do
     case resource do
-      "Page" <> page_id -> Loader.reload_page_module(site, page_id)
-      "Layout" <> layout_id -> Loader.reload_layout_module(site, layout_id)
-      "Routes" -> Loader.reload_routes_module(site)
-      "Components" -> Loader.reload_components_module(site)
-      "LiveData" -> Loader.reload_live_data_module(site)
-      "Stylesheet" -> Loader.reload_stylesheet_module(site)
-      "Snippets" -> Loader.reload_snippets_module(site)
-      "ErrorPage" -> Loader.reload_error_page_module(site)
-      "EventHandlers" -> Loader.reload_event_handlers_module(site)
-      "InfoHandlers" -> Loader.reload_info_handlers_module(site)
+      "Page" <> page_id -> Loader.load_page_module(site, page_id)
+      "Layout" <> layout_id -> Loader.load_layout_module(site, layout_id)
+      "Routes" -> Loader.load_routes_module(site)
+      "Components" -> Loader.load_components_module(site)
+      "LiveData" -> Loader.load_live_data_module(site)
+      "Stylesheet" -> Loader.load_stylesheet_module(site)
+      "Snippets" -> Loader.load_snippets_module(site)
+      "ErrorPage" -> Loader.load_error_page_module(site)
+      "EventHandlers" -> Loader.load_event_handlers_module(site)
+      "InfoHandlers" -> Loader.load_info_handlers_module(site)
       _ -> false
     end
   end

--- a/lib/beacon/loader.ex
+++ b/lib/beacon/loader.ex
@@ -229,6 +229,11 @@ defmodule Beacon.Loader do
     GenServer.call(worker(site), {:unload_page_module, page_id}, @timeout)
   end
 
+  def ensure_loaded!(modules, site) do
+    Beacon.ErrorHandler.enable(site)
+    Enum.each(modules, & &1.__info__(:module))
+  end
+
   # Server
 
   def handle_continue(:async_init, config) do

--- a/lib/beacon/loader.ex
+++ b/lib/beacon/loader.ex
@@ -93,12 +93,12 @@ defmodule Beacon.Loader do
     GenServer.call(worker(site), :populate_default_home_page, @timeout)
   end
 
-  def reload_runtime_js(site) do
-    GenServer.call(worker(site), :reload_runtime_js, :timer.minutes(2))
+  def load_runtime_js(site) do
+    GenServer.call(worker(site), :load_runtime_js, :timer.minutes(2))
   end
 
-  def reload_runtime_css(site) do
-    GenServer.call(worker(site), :reload_runtime_css, :timer.minutes(2))
+  def load_runtime_css(site) do
+    GenServer.call(worker(site), :load_runtime_css, :timer.minutes(2))
   end
 
   def fetch_snippets_module(site) do
@@ -153,61 +153,62 @@ defmodule Beacon.Loader do
     Loader.InfoHandlers.module_name(site)
   end
 
-  def maybe_reload_page_module(site, page_id) do
-    maybe_reload(Loader.Page.module_name(site, page_id), fn -> reload_page_module(site, page_id) end)
+  def load_snippets_module(site) do
+    call_worker(site, :load_snippets_module, {:load_snippets_module, [site]})
   end
 
-  def reload_snippets_module(site) do
-    call_worker(site, :reload_snippets_module, {:reload_snippets_module, [site]})
+  def load_routes_module(site) do
+    call_worker(site, :load_routes_module, {:load_routes_module, [site]})
   end
 
-  def reload_routes_module(site) do
-    call_worker(site, :reload_routes_module, {:reload_routes_module, [site]})
+  def load_components_module(site) do
+    call_worker(site, :load_components_module, {:load_components_module, [site]})
   end
 
-  def reload_components_module(site) do
-    call_worker(site, :reload_components_module, {:reload_components_module, [site]})
+  def load_live_data_module(site) do
+    call_worker(site, :load_live_data_module, {:load_live_data_module, [site]})
   end
 
-  def reload_live_data_module(site) do
-    call_worker(site, :reload_live_data_module, {:reload_live_data_module, [site]})
+  def load_error_page_module(site) do
+    call_worker(site, :load_error_page_module, {:load_error_page_module, [site]})
   end
 
-  def reload_error_page_module(site) do
-    call_worker(site, :reload_error_page_module, {:reload_error_page_module, [site]})
+  def load_stylesheet_module(site) do
+    call_worker(site, :load_stylesheet_module, {:load_stylesheet_module, [site]})
   end
 
-  def reload_stylesheet_module(site) do
-    call_worker(site, :reload_stylesheet_module, {:reload_stylesheet_module, [site]})
+  def load_event_handlers_module(site) do
+    call_worker(site, :load_event_handlers_module, {:load_event_handlers_module, [site]})
   end
 
-  def reload_event_handlers_module(site) do
-    call_worker(site, :reload_event_handlers_module, {:reload_event_handlers_module, [site]})
+  def load_info_handlers_module(site) do
+    call_worker(site, :load_info_handlers_module, {:load_info_handlers_module, [site]})
   end
 
-  def reload_info_handlers_module(site) do
-    call_worker(site, :reload_info_handlers_module, {:reload_info_handlers_module, [site]})
+  def load_layouts_modules(site) do
+    site
+    |> Content.list_published_layouts()
+    |> Enum.map(&load_layout_module(&1.site, &1.id))
   end
 
-  def reload_layouts_modules(site) do
-    Enum.map(Content.list_published_layouts(site), &reload_layout_module(&1.site, &1.id))
+  def load_layout_module(site, layout_id) do
+    call_worker(site, {:load_layout_module, layout_id}, {:load_layout_module, [site, layout_id]})
   end
 
-  def reload_layout_module(site, layout_id) do
-    call_worker(site, {:reload_layout_module, layout_id}, {:reload_layout_module, [site, layout_id]})
-  end
-
-  def reload_pages_modules(site, opts \\ []) do
+  def load_pages_modules(site, opts \\ []) do
     per_page = Keyword.get(opts, :per_page, :infinity)
-    Enum.map(Content.list_published_pages(site, per_page: per_page), &reload_page_module(&1.site, &1.id))
+
+    site
+    |> Content.list_published_pages(per_page: per_page)
+    |> Enum.map(&load_page_module(&1.site, &1.id))
   end
 
-  def reload_page_module(site, page_id) do
-    call_worker(site, {:reload_page_module, page_id}, {:reload_page_module, [site, page_id]})
+  def load_page_module(site, page_id) do
+    call_worker(site, {:load_page_module, page_id}, {:load_page_module, [site, page_id]})
   end
 
   # call worker asyncly or syncly depending on the current site mode
-  # or skip if mode is manual so we don't reload modules
+  # or skip if mode is manual so we don't load modules
   defp call_worker(site, async_request, sync_request) do
     mode = Beacon.Config.fetch!(site).mode
 
@@ -226,14 +227,6 @@ defmodule Beacon.Loader do
 
   def unload_page_module(site, page_id) do
     GenServer.call(worker(site), {:unload_page_module, page_id}, @timeout)
-  end
-
-  defp maybe_reload(module, reload_fun) do
-    if :erlang.module_loaded(module) do
-      {:ok, module}
-    else
-      reload_fun.()
-    end
   end
 
   # Server
@@ -258,7 +251,7 @@ defmodule Beacon.Loader do
     |> Loader.Layout.module_name(id)
     |> unload()
 
-    reload_runtime_css(site)
+    load_runtime_css(site)
 
     {:noreply, config}
   end
@@ -270,7 +263,7 @@ defmodule Beacon.Loader do
     |> Loader.Page.module_name(id)
     |> unload()
 
-    reload_runtime_css(site)
+    load_runtime_css(site)
 
     {:noreply, config}
   end
@@ -284,7 +277,7 @@ defmodule Beacon.Loader do
       |> unload()
     end
 
-    reload_runtime_css(site)
+    load_runtime_css(site)
 
     {:noreply, config}
   end
@@ -300,7 +293,7 @@ defmodule Beacon.Loader do
     |> Loader.Stylesheet.module_name()
     |> unload()
 
-    reload_runtime_css(site)
+    load_runtime_css(site)
 
     {:noreply, config}
   end
@@ -310,7 +303,7 @@ defmodule Beacon.Loader do
     |> Loader.Snippets.module_name()
     |> unload()
 
-    reload_runtime_css(site)
+    load_runtime_css(site)
 
     {:noreply, config}
   end
@@ -320,7 +313,7 @@ defmodule Beacon.Loader do
     |> Loader.ErrorPage.module_name()
     |> unload()
 
-    reload_runtime_css(site)
+    load_runtime_css(site)
 
     {:noreply, config}
   end
@@ -330,7 +323,7 @@ defmodule Beacon.Loader do
     |> Loader.Components.module_name()
     |> unload()
 
-    reload_runtime_css(site)
+    load_runtime_css(site)
 
     {:noreply, config}
   end
@@ -340,7 +333,7 @@ defmodule Beacon.Loader do
     |> Loader.LiveData.module_name()
     |> unload()
 
-    reload_runtime_css(site)
+    load_runtime_css(site)
 
     {:noreply, config}
   end

--- a/lib/beacon/loader/components.ex
+++ b/lib/beacon/loader/components.ex
@@ -25,6 +25,10 @@ defmodule Beacon.Loader.Components do
     routes_module = Loader.Routes.module_name(site)
     render_functions = Enum.map(components, &render_component/1)
     function_components = Enum.map(components, &function_component/1)
+
+    # `import` modules won't be autoloaded
+    Loader.ensure_loaded!([routes_module], site)
+
     render(module, routes_module, render_functions, function_components)
   end
 

--- a/lib/beacon/loader/error_page.ex
+++ b/lib/beacon/loader/error_page.ex
@@ -11,6 +11,9 @@ defmodule Beacon.Loader.ErrorPage do
     layout_functions = Enum.map(error_pages, &build_layout_fn/1)
     render_functions = Enum.map(error_pages, &build_render_fn(&1, module))
 
+    # `import` modules won't be autoloaded
+    Loader.ensure_loaded!([routes_module], site)
+
     quote do
       defmodule unquote(module) do
         require Logger

--- a/lib/beacon/loader/layout.ex
+++ b/lib/beacon/loader/layout.ex
@@ -10,6 +10,10 @@ defmodule Beacon.Loader.Layout do
     routes_module = Loader.Routes.module_name(site)
     components_module = Loader.Components.module_name(site)
     render_function = render_layout(layout)
+
+    # `import` modules won't be autoloaded
+    Loader.ensure_loaded!([routes_module, components_module], site)
+
     render(module, routes_module, components_module, render_function)
   end
 

--- a/lib/beacon/loader/page.ex
+++ b/lib/beacon/loader/page.ex
@@ -23,6 +23,9 @@ defmodule Beacon.Loader.Page do
       dynamic_helper()
     ]
 
+    # `import` modules won't be autoloaded
+    Loader.ensure_loaded!([routes_module, components_module], site)
+
     ast = build(module, routes_module, components_module, functions)
 
     {module, ast}

--- a/lib/beacon/test/fixtures.ex
+++ b/lib/beacon/test/fixtures.ex
@@ -170,7 +170,7 @@ defmodule Beacon.Test.Fixtures do
       content: "body {cursor: zoom-in;}"
     })
     |> Content.create_stylesheet!()
-    |> tap(&Loader.reload_stylesheet_module(&1.site))
+    |> tap(&Loader.load_stylesheet_module(&1.site))
   end
 
   @doc """
@@ -195,7 +195,7 @@ defmodule Beacon.Test.Fixtures do
       example: ~S|<.sample_component project={%{id: 1, name: "Beacon"}} />|
     })
     |> Content.create_component!()
-    |> tap(&Loader.reload_components_module(&1.site))
+    |> tap(&Loader.load_components_module(&1.site))
   end
 
   @doc """
@@ -235,7 +235,7 @@ defmodule Beacon.Test.Fixtures do
       |> beacon_layout_fixture()
       |> Content.publish_layout()
 
-    Loader.reload_layout_module(layout.site, layout.id)
+    Loader.load_layout_module(layout.site, layout.id)
 
     layout
   end
@@ -288,8 +288,6 @@ defmodule Beacon.Test.Fixtures do
       |> beacon_page_fixture()
       |> Content.publish_page()
 
-    Loader.reload_page_module(page.site, page.id)
-
     page
   end
 
@@ -328,7 +326,7 @@ defmodule Beacon.Test.Fixtures do
       """
     })
     |> Content.create_snippet_helper!()
-    |> tap(&Loader.reload_snippets_module(&1.site))
+    |> tap(&Loader.load_snippets_module(&1.site))
   end
 
   @doc """
@@ -406,15 +404,10 @@ defmodule Beacon.Test.Fixtures do
         template: template_for(page)
       })
 
-    page_variant =
-      page
-      |> Ecto.build_assoc(:variants)
-      |> Content.PageVariant.changeset(attrs)
-      |> repo(page).insert!()
-
-    Loader.reload_page_module(page.site, page.id)
-
-    page_variant
+    page
+    |> Ecto.build_assoc(:variants)
+    |> Content.PageVariant.changeset(attrs)
+    |> repo(page).insert!()
   end
 
   defp template_for(%{format: :heex} = _page), do: "<div><h1>My Site</h1></div>"
@@ -442,7 +435,7 @@ defmodule Beacon.Test.Fixtures do
       code: "{:noreply, socket}"
     })
     |> Content.create_event_handler!()
-    |> tap(&Loader.reload_event_handlers_module(&1.site))
+    |> tap(&Loader.load_event_handlers_module(&1.site))
   end
 
   @doc """
@@ -466,7 +459,7 @@ defmodule Beacon.Test.Fixtures do
       layout_id: layout.id
     })
     |> Content.create_error_page!()
-    |> tap(&Loader.reload_error_page_module(&1.site))
+    |> tap(&Loader.load_error_page_module(&1.site))
   end
 
   @doc """
@@ -486,7 +479,7 @@ defmodule Beacon.Test.Fixtures do
       path: "/foo/bar"
     })
     |> Content.create_live_data!()
-    |> tap(&Loader.reload_live_data_module(&1.site))
+    |> tap(&Loader.load_live_data_module(&1.site))
   end
 
   @doc """
@@ -515,7 +508,7 @@ defmodule Beacon.Test.Fixtures do
       |> Content.LiveDataAssign.changeset(attrs)
       |> repo(site).insert!()
 
-    Loader.reload_live_data_module(site)
+    Loader.load_live_data_module(site)
 
     live_data
   end
@@ -554,6 +547,6 @@ defmodule Beacon.Test.Fixtures do
       code: code
     })
     |> Content.create_info_handler!()
-    |> tap(&Loader.reload_info_handlers_module(&1.site))
+    |> tap(&Loader.load_info_handlers_module(&1.site))
   end
 end

--- a/lib/beacon/web/data_source.ex
+++ b/lib/beacon/web/data_source.ex
@@ -11,28 +11,19 @@ defmodule Beacon.Web.DataSource do
 
   # TODO: revisit this logic to evaluate page_title for unpublished pages
   def page_title(site, page_id, live_data) do
-    page_assigns = page_assigns(site, page_id)
+    %{path: path, title: title} = page_assigns = page_assigns(site, page_id)
 
-    with {:ok, page_assigns} <- page_assigns,
-         {:ok, page_title} <- Beacon.Content.render_snippet(page_assigns.title, %{page: page_assigns, live_data: live_data}) do
+    with {:ok, page_title} <- Beacon.Content.render_snippet(title, %{page: page_assigns, live_data: live_data}) do
       page_title
     else
-      {:error, :page_module_not_found} ->
-        ""
-
       {:error, error} ->
-        {path, original_title} =
-          case page_assigns do
-            {:ok, page_assigns} -> {page_assigns.path, page_assigns.title}
-            _ -> {nil, ""}
-          end
-
         Logger.error("""
         failed to interpolate page title variables
 
         will return the original unmodified page title
 
         site: #{site}
+        title: #{title}
         page path: #{path}
 
         Got:
@@ -41,34 +32,20 @@ defmodule Beacon.Web.DataSource do
 
         """)
 
-        original_title
+        title
     end
   end
 
   # TODO: revisit this logic to evaluate meta_tags for unpublished pages
   def meta_tags(assigns) do
-    %{beacon: %{page: page, private: %{page_module: page_module, live_data_keys: live_data_keys}}} = assigns
+    %{beacon: %{private: %{page_module: page_module, live_data_keys: live_data_keys}}} = assigns
     %{site: site, id: page_id} = Beacon.apply_mfa(page_module, :page_assigns, [[:site, :id]])
     live_data = Map.take(assigns, live_data_keys)
 
-    case page_assigns(site, page_id) do
-      {:error, _} ->
-        Logger.error("""
-        failed to interpolate page meta tags, returning empty list of meta tags
-
-        Site: #{site}
-        Page path: #{page.path}
-
-        """)
-
-        []
-
-      {:ok, page_assigns} ->
-        assigns
-        |> Beacon.Web.Layouts.meta_tags()
-        |> List.wrap()
-        |> Enum.map(&interpolate_meta_tag(&1, %{page: page_assigns, live_data: live_data}))
-    end
+    assigns
+    |> Beacon.Web.Layouts.meta_tags()
+    |> List.wrap()
+    |> Enum.map(&interpolate_meta_tag(&1, %{page: page_assigns(site, page_id), live_data: live_data}))
   end
 
   defp interpolate_meta_tag(meta_tag, values) when is_map(meta_tag) do
@@ -87,12 +64,8 @@ defmodule Beacon.Web.DataSource do
   # which is what we need for sites to work properly but
   # the page builder could use this data as well
   defp page_assigns(site, page_id) do
-    page_module = Beacon.Loader.fetch_page_module(site, page_id)
-
-    if :erlang.module_loaded(page_module) do
-      {:ok, Beacon.apply_mfa(page_module, :page_assigns, [])}
-    else
-      {:error, :page_module_not_found}
-    end
+    site
+    |> Beacon.Loader.fetch_page_module(page_id)
+    |> Beacon.apply_mfa(:page_assigns, [])
   end
 end

--- a/test/beacon/content_test.exs
+++ b/test/beacon/content_test.exs
@@ -129,12 +129,6 @@ defmodule Beacon.ContentTest do
       assert_receive {:page_published, %{site: ^site, id: ^id}}
     end
 
-    test "broadcasts loaded event" do
-      :ok = Beacon.PubSub.subscribe_to_page(:booted, "/broadcast-test")
-      beacon_published_page_fixture(site: "booted", path: "/broadcast-test")
-      assert_receive {:page_loaded, %{site: :booted}}
-    end
-
     test "broadcasts unpublished event" do
       %{site: site, id: id, path: path} = page = beacon_published_page_fixture(site: "booted")
       :ok = Beacon.PubSub.subscribe_to_pages(site)

--- a/test/beacon/lifecycle/template_test.exs
+++ b/test/beacon/lifecycle/template_test.exs
@@ -4,6 +4,18 @@ defmodule Beacon.Lifecycle.TemplateTest do
   use Beacon.Test
   alias Beacon.Lifecycle
 
+  setup do
+    site = default_site()
+
+    # we aren't passing through PageLive normally in these tests so we have to manually
+    # enable the ErrorHandler and set the site in the Process dictionary
+    # (which would normally happen in the LiveView mount)
+    Process.put(:__beacon_site__, site)
+    Process.flag(:error_handler, Beacon.ErrorHandler)
+
+    [site: site]
+  end
+
   test "load_template" do
     page = %Beacon.Content.Page{
       site: :lifecycle_test,
@@ -15,9 +27,9 @@ defmodule Beacon.Lifecycle.TemplateTest do
     assert Lifecycle.Template.load_template(page) == "<div>beacon</div>"
   end
 
-  test "render_template" do
-    page = beacon_published_page_fixture(site: "my_site") |> Repo.preload(:variants)
-    env = Beacon.Web.PageLive.make_env(:my_site)
+  test "render_template", %{site: site} do
+    page = beacon_published_page_fixture(site: site) |> Repo.preload(:variants)
+    env = Beacon.Web.PageLive.make_env(site)
     assert %Phoenix.LiveView.Rendered{static: ["<main>\n  <h1>my_site#home</h1>\n</main>"]} = Lifecycle.Template.render_template(page, %{}, env)
   end
 end

--- a/test/beacon/loader/components_test.exs
+++ b/test/beacon/loader/components_test.exs
@@ -11,7 +11,7 @@ defmodule Beacon.Loader.ComponentsTest do
   end
 
   test "load empty module without components" do
-    {:ok, mod} = Loader.reload_components_module(default_site())
+    mod = Loader.load_components_module(default_site())
     assert mod.__info__(:functions) == [{:my_component, 1}, {:my_component, 2}]
   end
 

--- a/test/beacon/loader/error_page_test.exs
+++ b/test/beacon/loader/error_page_test.exs
@@ -11,7 +11,7 @@ defmodule Beacon.Loader.ErrorPageTest do
   setup %{conn: conn} do
     :ok = Beacon.Loader.populate_default_layouts(default_site())
     :ok = Beacon.Loader.populate_default_error_pages(default_site())
-    {:ok, error_module} = Beacon.Loader.reload_error_page_module(default_site())
+    error_module = Beacon.Loader.load_error_page_module(default_site())
 
     [conn: build_conn(conn), error_module: error_module]
   end

--- a/test/beacon/loader/page_test.exs
+++ b/test/beacon/loader/page_test.exs
@@ -1,8 +1,21 @@
 defmodule Beacon.Loader.PageTest do
   use Beacon.DataCase, async: false
   use Beacon.Test, site: :my_site
+
   alias Beacon.Loader
   alias Beacon.BeaconTest.Repo
+
+  setup do
+    site = default_site()
+
+    # we aren't passing through PageLive in these tests so we have to manually
+    # enable the ErrorHandler and set the site in the Process dictionary
+    # (which would normally happen in the LiveView mount)
+    Process.put(:__beacon_site__, site)
+    Process.flag(:error_handler, Beacon.ErrorHandler)
+
+    [site: site]
+  end
 
   describe "dynamic_helper" do
     test "generate each helper function and the proxy dynamic_helper" do
@@ -75,7 +88,7 @@ defmodule Beacon.Loader.PageTest do
       Beacon.Content.create_variant_for_page(page, %{name: "variant_a", weight: 1, template: "<div>variant_a</div>"})
       Beacon.Content.create_variant_for_page(page, %{name: "variant_b", weight: 2, template: "<div>variant_b</div>"})
       Beacon.Content.publish_page(page)
-      {:ok, module} = Loader.reload_page_module(page.site, page.id)
+      module = Loader.fetch_page_module(page.site, page.id)
 
       assert [
                %Phoenix.LiveView.Rendered{static: ["<main>\n  <h1>my_site#home</h1>\n</main>"]},

--- a/test/beacon/loader/routes_test.exs
+++ b/test/beacon/loader/routes_test.exs
@@ -2,43 +2,51 @@ defmodule Beacon.Loader.RoutesTest do
   use Beacon.DataCase, async: true
   use Beacon.Test
 
-  @routes_module :"Elixir.Beacon.Web.LiveRenderer.c55c9d9db8d6d8c4d34b4f249c20ed4e.Routes"
+  Beacon.Loader.ensure_loaded!([:"Elixir.Beacon.Web.LiveRenderer.c55c9d9db8d6d8c4d34b4f249c20ed4e.Routes"], :s3_site)
 
-  setup do
-    Process.flag(:error_handler, Beacon.ErrorHandler)
-    Process.put(:__beacon_site__, :s3_site)
-    :ok
+  # By adding this extra layer of delegation, it ensures the above call will be complete before
+  # attempting to import the Routes module.
+  defmodule MyRoutes do
+    import :"Elixir.Beacon.Web.LiveRenderer.c55c9d9db8d6d8c4d34b4f249c20ed4e.Routes"
+
+    defdelegate beacon_media_path(path), to: :"Elixir.Beacon.Web.LiveRenderer.c55c9d9db8d6d8c4d34b4f249c20ed4e.Routes"
+    defdelegate beacon_media_url(path), to: :"Elixir.Beacon.Web.LiveRenderer.c55c9d9db8d6d8c4d34b4f249c20ed4e.Routes"
+
+    def path("/"), do: ~p"/"
+    def path("/contact"), do: ~p"/contact"
+    def path("/posts/" <> page_id), do: ~p"/posts/#{page_id}"
+
+    def posts_page_path(page), do: ~p"/posts/#{page}"
+
+    def page_path(page), do: ~p"/#{page}"
   end
 
   test "beacon_media_path" do
-    assert @routes_module.beacon_media_path("logo.webp") == "/nested/media/__beacon_media__/logo.webp"
+    assert MyRoutes.beacon_media_path("logo.webp") == "/nested/media/__beacon_media__/logo.webp"
   end
 
   test "beacon_media_url" do
-    assert @routes_module.beacon_media_url("logo.webp") == "http://localhost:4000/nested/media/__beacon_media__/logo.webp"
+    assert MyRoutes.beacon_media_url("logo.webp") == "http://localhost:4000/nested/media/__beacon_media__/logo.webp"
   end
 
   describe "sigil_p" do
     test "static" do
-      require @routes_module
-      assert @routes_module.sigil_p("/", []) == "/nested/media"
-      assert @routes_module.sigil_p("/contact", []) == "/nested/media/contact"
+      assert MyRoutes.path("/") == "/nested/media"
+      assert MyRoutes.path("/contact") == "/nested/media/contact"
     end
 
     test "derive path from page" do
-      require @routes_module
       page = beacon_page_fixture(site: :s3_site, path: "/elixir-lang")
 
-      assert @routes_module.sigil_p("/#{page.id}", []) == "/nested/media/elixir-lang"
-      assert @routes_module.sigil_p("/posts/#{page.id}", []) == "/nested/media/posts/elixir-lang"
+      assert MyRoutes.page_path(page) == "/nested/media/elixir-lang"
+      assert MyRoutes.posts_page_path(page) == "/nested/media/posts/elixir-lang"
     end
 
     test "with dynamic segments" do
-      require @routes_module
       page = %{id: 1}
 
-      assert @routes_module.sigil_p("/posts/#{page.id}", []) == "/nested/media/posts/1"
-      assert @routes_module.sigil_p("/posts/#{"a b"}", []) == "/nested/media/posts/a%20b"
+      assert MyRoutes.path("/posts/#{page.id}") == "/nested/media/posts/1"
+      assert MyRoutes.path("/posts/#{"a b"}") == "/nested/media/posts/a%20b"
     end
   end
 end

--- a/test/beacon/loader/routes_test.exs
+++ b/test/beacon/loader/routes_test.exs
@@ -2,35 +2,43 @@ defmodule Beacon.Loader.RoutesTest do
   use Beacon.DataCase, async: true
   use Beacon.Test
 
-  # Beacon.Loader.fetch_routes_module(:s3_site)
-  import :"Elixir.Beacon.Web.LiveRenderer.c55c9d9db8d6d8c4d34b4f249c20ed4e.Routes"
+  @routes_module :"Elixir.Beacon.Web.LiveRenderer.c55c9d9db8d6d8c4d34b4f249c20ed4e.Routes"
+
+  setup do
+    Process.flag(:error_handler, Beacon.ErrorHandler)
+    Process.put(:__beacon_site__, :s3_site)
+    :ok
+  end
 
   test "beacon_media_path" do
-    assert beacon_media_path("logo.webp") == "/nested/media/__beacon_media__/logo.webp"
+    assert @routes_module.beacon_media_path("logo.webp") == "/nested/media/__beacon_media__/logo.webp"
   end
 
   test "beacon_media_url" do
-    assert beacon_media_url("logo.webp") == "http://localhost:4000/nested/media/__beacon_media__/logo.webp"
+    assert @routes_module.beacon_media_url("logo.webp") == "http://localhost:4000/nested/media/__beacon_media__/logo.webp"
   end
 
   describe "sigil_p" do
     test "static" do
-      assert ~p"/" == "/nested/media"
-      assert ~p"/contact" == "/nested/media/contact"
+      require @routes_module
+      assert @routes_module.sigil_p("/", []) == "/nested/media"
+      assert @routes_module.sigil_p("/contact", []) == "/nested/media/contact"
     end
 
     test "derive path from page" do
+      require @routes_module
       page = beacon_page_fixture(site: :s3_site, path: "/elixir-lang")
 
-      assert ~p"/#{page}" == "/nested/media/elixir-lang"
-      assert ~p"/posts/#{page}" == "/nested/media/posts/elixir-lang"
+      assert @routes_module.sigil_p("/#{page.id}", []) == "/nested/media/elixir-lang"
+      assert @routes_module.sigil_p("/posts/#{page.id}", []) == "/nested/media/posts/elixir-lang"
     end
 
     test "with dynamic segments" do
+      require @routes_module
       page = %{id: 1}
 
-      assert ~p"/posts/#{page.id}" == "/nested/media/posts/1"
-      assert ~p"/posts/#{"a b"}" == "/nested/media/posts/a%20b"
+      assert @routes_module.sigil_p("/posts/#{page.id}", []) == "/nested/media/posts/1"
+      assert @routes_module.sigil_p("/posts/#{"a b"}", []) == "/nested/media/posts/a%20b"
     end
   end
 end

--- a/test/beacon/loader_test.exs
+++ b/test/beacon/loader_test.exs
@@ -6,43 +6,55 @@ defmodule Beacon.LoaderTest do
   alias Beacon.BeaconTest.Repo
   alias Phoenix.LiveView.Rendered
 
+  setup do
+    site = default_site()
+
+    # we aren't spawning Workers in these tests so we have to locally
+    # enable the ErrorHandler and set the site in the Process dictionary
+    # (which would normally happen in the Worker `init/1`)
+    Process.put(:__beacon_site__, site)
+    Process.flag(:error_handler, Beacon.ErrorHandler)
+
+    [site: site]
+  end
+
   describe "populate default components" do
-    test "seeds initial data" do
+    test "seeds initial data", %{site: site} do
       assert Repo.all(Content.Component) == []
-      assert Loader.populate_default_components(default_site()) == :ok
+      assert Loader.populate_default_components(site) == :ok
       assert Repo.all(Content.Component) |> length() > 0
     end
   end
 
   describe "populate default layouts" do
-    test "seeds initial data" do
+    test "seeds initial data", %{site: site} do
       assert Repo.all(Content.Layout) == []
-      assert Loader.populate_default_layouts(default_site()) == :ok
+      assert Loader.populate_default_layouts(site) == :ok
       assert Repo.all(Content.Layout) |> length() > 0
     end
   end
 
   describe "populate default error pages" do
-    setup do
-      Loader.populate_default_layouts(default_site())
+    setup %{site: site} do
+      Loader.populate_default_layouts(site)
     end
 
-    test "seeds initial data" do
+    test "seeds initial data", %{site: site} do
       assert Repo.all(Content.ErrorPage) == []
-      assert Loader.populate_default_error_pages(default_site()) == :ok
+      assert Loader.populate_default_error_pages(site) == :ok
       assert Repo.all(Content.ErrorPage) |> length() > 0
     end
   end
 
   describe "snippets" do
-    test "loads module even without snippets helpers available" do
-      {:ok, module} = Loader.reload_snippets_module(default_site())
+    test "loads module even without snippets helpers available", %{site: site} do
+      module = Loader.load_snippets_module(site)
       assert :erlang.module_loaded(module)
     end
 
-    test "loads module containing all snippet helpers" do
+    test "loads module containing all snippet helpers", %{site: site} do
       beacon_snippet_helper_fixture()
-      module = Loader.fetch_snippets_module(default_site())
+      module = Loader.fetch_snippets_module(site)
       assert module.upcase_title(%{"page" => %{"title" => "Beacon"}}) == "BEACON"
     end
   end
@@ -53,21 +65,21 @@ defmodule Beacon.LoaderTest do
       :ok
     end
 
-    test "loads module containing all components" do
-      module = Loader.fetch_components_module(default_site())
+    test "loads module containing all components", %{site: site} do
+      module = Loader.fetch_components_module(site)
       assert %Rendered{static: ["<h1>A</h1>"]} = module.my_component("a", %{})
       assert %Rendered{static: ["<h1>A</h1>"]} = module.render("a", %{})
     end
 
-    test "adding or removing components reloads the component module" do
+    test "adding or removing components reloads the component module", %{site: site} do
       beacon_component_fixture(name: "b", template: "<h1>B</h1>")
 
-      module = Loader.fetch_components_module(default_site())
+      module = Loader.fetch_components_module(site)
       assert %Rendered{static: ["<h1>A</h1>"]} = module.my_component("a", %{})
       assert %Rendered{static: ["<h1>B</h1>"]} = module.my_component("b", %{})
 
       Repo.delete_all(Content.Component)
-      Loader.reload_components_module(default_site())
+      Loader.load_components_module(site)
 
       assert_raise Beacon.InvokeError, fn ->
         module.my_component("a", %{})
@@ -81,8 +93,8 @@ defmodule Beacon.LoaderTest do
       :ok
     end
 
-    test "loads module containing all live data" do
-      module = Loader.fetch_live_data_module(default_site())
+    test "loads module containing all live data", %{site: site} do
+      module = Loader.fetch_live_data_module(site)
       assert module.live_data(["foo", "bar"], %{}) == %{bar: "Hello world!"}
     end
   end
@@ -93,9 +105,9 @@ defmodule Beacon.LoaderTest do
       :ok
     end
 
-    test "loads module containing all page errors" do
+    test "loads module containing all page errors", %{site: site} do
       conn = Phoenix.ConnTest.build_conn()
-      {:ok, module} = Loader.reload_error_page_module(default_site())
+      module = Loader.load_error_page_module(site)
       assert module.render(conn, 404) == "Not Found"
     end
   end
@@ -106,8 +118,8 @@ defmodule Beacon.LoaderTest do
       :ok
     end
 
-    test "loads module containing all stylesheets" do
-      {:ok, module} = Loader.reload_stylesheet_module(default_site())
+    test "loads module containing all stylesheets", %{site: site} do
+      module = Loader.load_stylesheet_module(site)
       assert module.render() =~ "sample_stylesheet"
     end
   end
@@ -128,14 +140,14 @@ defmodule Beacon.LoaderTest do
       [page_a: page_a, page_b: page_b]
     end
 
-    test "loads page module", %{page_a: page} do
-      {:ok, module} = Loader.reload_page_module(default_site(), page.id)
+    test "loads page module", %{site: site, page_a: page} do
+      module = Loader.load_page_module(site, page.id)
       assert %{path: "/a"} = module.page_assigns()
       assert %Rendered{static: ["<h1>A</h1>"]} = module.render(%{})
     end
 
     test "unload page", %{page_a: page} do
-      {:ok, module} = Loader.reload_page_module(page.site, page.id)
+      module = Loader.load_page_module(page.site, page.id)
       assert :erlang.module_loaded(module)
       Loader.unload_page_module(page.site, page.id)
       refute :erlang.module_loaded(module)

--- a/test/beacon/media_library_test.exs
+++ b/test/beacon/media_library_test.exs
@@ -36,6 +36,9 @@ defmodule Beacon.MediaLibraryTest do
     end
 
     test "upload asset, converts to webp by default, repo store" do
+      Process.flag(:error_handler, Beacon.ErrorHandler)
+      Process.put(:__beacon_site__, :my_site)
+
       metadata = beacon_upload_metadata_fixture(file_name: "image.png")
       assert %Asset{file_name: "image.webp", media_type: "image/webp"} = asset = MediaLibrary.upload(metadata)
       assert "http://localhost:4000/__beacon_media__/image.webp" = MediaLibrary.url_for(asset)

--- a/test/beacon/router_server_test.exs
+++ b/test/beacon/router_server_test.exs
@@ -4,88 +4,99 @@ defmodule Beacon.RouterServerTest do
   alias Beacon.RouterServer
 
   setup do
-    RouterServer.del_pages(:my_site)
-    on_exit(fn -> RouterServer.del_pages(:my_site) end)
+    site = default_site()
+
+    RouterServer.del_pages(site)
+
+    # we aren't passing through PageLive in these tests so we have to manually
+    # enable the ErrorHandler and set the site in the Process dictionary
+    # (which would normally happen in the LiveView mount)
+    Process.put(:__beacon_site__, site)
+    Process.flag(:error_handler, Beacon.ErrorHandler)
+
+    on_exit(fn -> RouterServer.del_pages(site) end)
+
+    [site: site]
   end
 
   describe "lookup by path" do
-    test "not existing path" do
-      refute RouterServer.lookup_path(:my_site, ["home"])
+    test "not existing path", %{site: site} do
+      refute RouterServer.lookup_path(site, ["home"])
     end
 
-    test "exact match on static paths" do
-      RouterServer.add_page(:my_site, "1", "/")
-      RouterServer.add_page(:my_site, "2", "/about")
-      RouterServer.add_page(:my_site, "3", "/blog/posts/2020-01-my-post")
+    test "exact match on static paths", %{site: site} do
+      RouterServer.add_page(site, "1", "/")
+      RouterServer.add_page(site, "2", "/about")
+      RouterServer.add_page(site, "3", "/blog/posts/2020-01-my-post")
 
-      assert {"/", "1"} = RouterServer.lookup_path(:my_site, [])
-      assert {"/about", "2"} = RouterServer.lookup_path(:my_site, ["about"])
-      assert {"/blog/posts/2020-01-my-post", "3"} = RouterServer.lookup_path(:my_site, ["blog", "posts", "2020-01-my-post"])
+      assert {"/", "1"} = RouterServer.lookup_path(site, [])
+      assert {"/about", "2"} = RouterServer.lookup_path(site, ["about"])
+      assert {"/blog/posts/2020-01-my-post", "3"} = RouterServer.lookup_path(site, ["blog", "posts", "2020-01-my-post"])
     end
 
-    test "multiple dynamic segments" do
-      RouterServer.add_page(:my_site, "1", "/users/:user_id/posts/:id/edit")
+    test "multiple dynamic segments", %{site: site} do
+      RouterServer.add_page(site, "1", "/users/:user_id/posts/:id/edit")
 
-      assert {"/users/:user_id/posts/:id/edit", "1"} = RouterServer.lookup_path(:my_site, ["users", "1", "posts", "100", "edit"])
+      assert {"/users/:user_id/posts/:id/edit", "1"} = RouterServer.lookup_path(site, ["users", "1", "posts", "100", "edit"])
     end
 
-    test "dynamic segments lookup in batch" do
-      RouterServer.add_page(:my_site, "1", "/:page")
-      RouterServer.add_page(:my_site, "2", "/users/:user_id/posts/:id/edit")
+    test "dynamic segments lookup in batch", %{site: site} do
+      RouterServer.add_page(site, "1", "/:page")
+      RouterServer.add_page(site, "2", "/users/:user_id/posts/:id/edit")
 
-      assert {"/:page", "1"} = RouterServer.lookup_path(:my_site, ["home"], 1)
-      assert {"/users/:user_id/posts/:id/edit", "2"} = RouterServer.lookup_path(:my_site, ["users", "1", "posts", "100", "edit"], 1)
+      assert {"/:page", "1"} = RouterServer.lookup_path(site, ["home"], 1)
+      assert {"/users/:user_id/posts/:id/edit", "2"} = RouterServer.lookup_path(site, ["users", "1", "posts", "100", "edit"], 1)
     end
 
-    test "dynamic segments with same prefix" do
-      RouterServer.add_page(:my_site, "1", "/posts/:post_id")
-      RouterServer.add_page(:my_site, "2", "/posts/authors/:author_id")
+    test "dynamic segments with same prefix", %{site: site} do
+      RouterServer.add_page(site, "1", "/posts/:post_id")
+      RouterServer.add_page(site, "2", "/posts/authors/:author_id")
 
-      assert {"/posts/:post_id", "1"} = RouterServer.lookup_path(:my_site, ["posts", "1"])
-      assert {"/posts/authors/:author_id", "2"} = RouterServer.lookup_path(:my_site, ["posts", "authors", "1"])
+      assert {"/posts/:post_id", "1"} = RouterServer.lookup_path(site, ["posts", "1"])
+      assert {"/posts/authors/:author_id", "2"} = RouterServer.lookup_path(site, ["posts", "authors", "1"])
     end
 
-    test "static segments with varied size" do
-      RouterServer.add_page(:my_site, "1", "/blog/2020/01/07/hello")
-      refute RouterServer.lookup_path(:my_site, ["blog", "2020"])
-      refute RouterServer.lookup_path(:my_site, ["blog", "2020", "01", "07"])
-      refute RouterServer.lookup_path(:my_site, ["blog", "2020", "01", "07", "hello", "extra"])
+    test "static segments with varied size", %{site: site} do
+      RouterServer.add_page(site, "1", "/blog/2020/01/07/hello")
+      refute RouterServer.lookup_path(site, ["blog", "2020"])
+      refute RouterServer.lookup_path(site, ["blog", "2020", "01", "07"])
+      refute RouterServer.lookup_path(site, ["blog", "2020", "01", "07", "hello", "extra"])
     end
 
-    test "catch all" do
-      RouterServer.add_page(:my_site, "1", "/posts/*slug")
+    test "catch all", %{site: site} do
+      RouterServer.add_page(site, "1", "/posts/*slug")
 
-      assert {"/posts/*slug", "1"} = RouterServer.lookup_path(:my_site, ["posts", "2022", "my-post"])
+      assert {"/posts/*slug", "1"} = RouterServer.lookup_path(site, ["posts", "2022", "my-post"])
     end
 
-    test "catch all with existing path with same prefix" do
-      RouterServer.add_page(:my_site, "1", "/press/releases/*slug")
-      RouterServer.add_page(:my_site, "2", "/press/releases")
+    test "catch all with existing path with same prefix", %{site: site} do
+      RouterServer.add_page(site, "1", "/press/releases/*slug")
+      RouterServer.add_page(site, "2", "/press/releases")
 
-      assert {"/press/releases/*slug", "1"} = RouterServer.lookup_path(:my_site, ["press", "releases", "announcement"])
-      assert {"/press/releases", "2"} = RouterServer.lookup_path(:my_site, ["press", "releases"])
+      assert {"/press/releases/*slug", "1"} = RouterServer.lookup_path(site, ["press", "releases", "announcement"])
+      assert {"/press/releases", "2"} = RouterServer.lookup_path(site, ["press", "releases"])
     end
 
-    test "catch all must match at least 1 segment" do
-      RouterServer.add_page(:my_site, "1", "/posts/*slug")
+    test "catch all must match at least 1 segment", %{site: site} do
+      RouterServer.add_page(site, "1", "/posts/*slug")
 
-      refute RouterServer.lookup_path(:my_site, ["posts"])
+      refute RouterServer.lookup_path(site, ["posts"])
     end
 
-    test "mixed dynamic segments" do
-      RouterServer.add_page(:my_site, "1", "/posts/:year/*slug")
+    test "mixed dynamic segments", %{site: site} do
+      RouterServer.add_page(site, "1", "/posts/:year/*slug")
 
-      assert {"/posts/:year/*slug", "1"} = RouterServer.lookup_path(:my_site, ["posts", "2022", "my-post"])
+      assert {"/posts/:year/*slug", "1"} = RouterServer.lookup_path(site, ["posts", "2022", "my-post"])
     end
   end
 
-  test "add page on page_loaded event" do
+  test "add page on page_loaded event", %{site: site} do
     %{id: page_id} = page = Beacon.Test.Fixtures.beacon_published_page_fixture(path: "/test/router/add")
-    RouterServer.del_pages(:my_site)
+    RouterServer.del_pages(site)
 
-    server = :my_site |> Beacon.RouterServer.name() |> GenServer.whereis()
+    server = site |> Beacon.RouterServer.name() |> GenServer.whereis()
     send(server, {:page_loaded, page})
 
-    assert %Beacon.Content.Page{id: ^page_id} = Beacon.RouterServer.lookup_page!(:my_site, ["test", "router", "add"])
+    assert %Beacon.Content.Page{id: ^page_id} = Beacon.RouterServer.lookup_page!(site, ["test", "router", "add"])
   end
 end

--- a/test/beacon_web/beacon_assigns_test.exs
+++ b/test/beacon_web/beacon_assigns_test.exs
@@ -6,48 +6,33 @@ defmodule Beacon.Web.BeaconAssignsTest do
   @site :my_site
 
   setup do
-    [socket: %Phoenix.LiveView.Socket{assigns: %{__changed__: %{beacon: true}, beacon: %BeaconAssigns{}}}]
+    site = default_site()
+
+    # we aren't passing through PageLive in these tests so we have to manually
+    # enable the ErrorHandler and set the site in the Process dictionary
+    # (which would normally happen in the LiveView mount)
+    Process.put(:__beacon_site__, site)
+    Process.flag(:error_handler, Beacon.ErrorHandler)
+
+    [
+      socket: %Phoenix.LiveView.Socket{
+        assigns: %{__changed__: %{beacon: true}, beacon: %BeaconAssigns{}}
+      },
+      site: site
+    ]
   end
 
-  test "build with site" do
+  test "build with site", %{site: site} do
     assert %BeaconAssigns{
              site: @site,
              private: %{components_module: :"Elixir.Beacon.Web.LiveRenderer.6a217f0f7032720eb50a1a2fbf258463.Components"}
-           } = BeaconAssigns.new(default_site())
+           } = BeaconAssigns.new(site)
   end
 
-  test "build with unpublished page" do
-    page = beacon_page_fixture(path: "/blog")
-
-    assigns = BeaconAssigns.new(default_site(), page, %{}, ["blog"], %{})
-
-    assert %BeaconAssigns{
-             site: @site,
-             page: %{path: "/blog", title: ""},
-             private: %{
-               live_path: ["blog"]
-             }
-           } = assigns
-  end
-
-  test "build with non-persisted page" do
-    page = %Beacon.Content.Page{site: default_site(), path: "/blog"}
-
-    assigns = BeaconAssigns.new(default_site(), page, %{}, ["blog"], %{})
-
-    assert %BeaconAssigns{
-             site: @site,
-             page: %{path: "/blog", title: ""},
-             private: %{
-               live_path: ["blog"]
-             }
-           } = assigns
-  end
-
-  test "build with published page resolves page title" do
+  test "build with published page resolves page title", %{site: site} do
     page = beacon_published_page_fixture(path: "/blog", title: "blog index")
 
-    assigns = BeaconAssigns.new(default_site(), page, %{}, ["blog"], %{})
+    assigns = BeaconAssigns.new(site, page, %{}, ["blog"], %{})
 
     assert %BeaconAssigns{
              site: @site,
@@ -58,10 +43,10 @@ defmodule Beacon.Web.BeaconAssignsTest do
            } = assigns
   end
 
-  test "build with path info and query params" do
-    page = beacon_page_fixture(path: "/blog")
+  test "build with path info and query params", %{site: site} do
+    page = beacon_published_page_fixture(path: "/blog")
 
-    assigns = BeaconAssigns.new(default_site(), page, %{}, ["blog"], %{source: "search"})
+    assigns = BeaconAssigns.new(site, page, %{}, ["blog"], %{source: "search"})
 
     assert %BeaconAssigns{
              site: @site,
@@ -72,10 +57,10 @@ defmodule Beacon.Web.BeaconAssignsTest do
            } = assigns
   end
 
-  test "build with path params" do
-    page = beacon_page_fixture(path: "/blog/:post")
+  test "build with path params", %{site: site} do
+    page = beacon_published_page_fixture(path: "/blog/:post")
 
-    assigns = BeaconAssigns.new(default_site(), page, %{}, ["blog", "hello"], %{})
+    assigns = BeaconAssigns.new(site, page, %{}, ["blog", "hello"], %{})
 
     assert %BeaconAssigns{
              site: @site,
@@ -83,13 +68,13 @@ defmodule Beacon.Web.BeaconAssignsTest do
            } = assigns
   end
 
-  test "build with live data" do
-    page = beacon_page_fixture(path: "/blog")
+  test "build with live data", %{site: site} do
+    page = beacon_published_page_fixture(path: "/blog")
 
     live_data = beacon_live_data_fixture(path: "/blog")
     beacon_live_data_assign_fixture(live_data: live_data, format: :text, key: "customer_id", value: "123")
 
-    assigns = BeaconAssigns.new(default_site(), page, live_data, ["blog"], %{})
+    assigns = BeaconAssigns.new(site, page, live_data, ["blog"], %{})
 
     assert %BeaconAssigns{
              site: @site,

--- a/test/beacon_web/controllers/media_library_controller_test.exs
+++ b/test/beacon_web/controllers/media_library_controller_test.exs
@@ -1,6 +1,12 @@
 defmodule Beacon.Web.Controllers.MediaLibraryControllerTest do
   use Beacon.Web.ConnCase, async: true
 
+  setup do
+    Process.flag(:error_handler, Beacon.ErrorHandler)
+    Process.put(:__beacon_site__, :my_site)
+    :ok
+  end
+
   test "show", %{conn: conn} do
     %{file_name: file_name} = Beacon.Test.Fixtures.beacon_media_library_asset_fixture(site: :my_site)
     routes = Beacon.Loader.fetch_routes_module(:my_site)

--- a/test/beacon_web/data_source_test.exs
+++ b/test/beacon_web/data_source_test.exs
@@ -3,20 +3,32 @@ defmodule Beacon.Web.DataSourceTest do
   use Beacon.Test, site: :my_site
   alias Beacon.Web.DataSource
 
-  test "live_data" do
+  setup do
+    site = default_site()
+
+    # we aren't passing through PageLive in these tests so we have to manually
+    # enable the ErrorHandler and set the site in the Process dictionary
+    # (which would normally happen in the LiveView mount)
+    Process.put(:__beacon_site__, site)
+    Process.flag(:error_handler, Beacon.ErrorHandler)
+
+    [site: site]
+  end
+
+  test "live_data", %{site: site} do
     live_data = beacon_live_data_fixture()
     beacon_live_data_assign_fixture(live_data: live_data, format: :text, key: "name", value: "beacon")
-    assert DataSource.live_data(default_site(), ["foo", "bar"], %{}) == %{name: "beacon"}
+    assert DataSource.live_data(site, ["foo", "bar"], %{}) == %{name: "beacon"}
   end
 
   describe "page_title" do
-    test "renders static content" do
-      page = beacon_published_page_fixture(site: default_site(), title: "my title")
+    test "renders static content", %{site: site} do
+      page = beacon_published_page_fixture(site: site, title: "my title")
       assert DataSource.page_title(page.site, page.id, %{}) == "my title"
     end
 
-    test "renders snippet" do
-      page = beacon_published_page_fixture(site: default_site(), title: "{{ page.path | upcase }}")
+    test "renders snippet", %{site: site} do
+      page = beacon_published_page_fixture(site: site, title: "{{ page.path | upcase }}")
       assert DataSource.page_title(page.site, page.id, %{}) == "/HOME"
     end
   end

--- a/test/beacon_web/live/page_live_test.exs
+++ b/test/beacon_web/live/page_live_test.exs
@@ -276,7 +276,7 @@ defmodule Beacon.Web.Live.PageLiveTest do
     test "update resource links on layout publish", %{conn: conn, layout: layout} do
       {:ok, layout} = Content.update_layout(layout, %{"resource_links" => [%{"rel" => "stylesheet", "href" => "color.css"}]})
       {:ok, layout} = Content.publish_layout(layout)
-      Beacon.Loader.reload_layout_module(layout.site, layout.id)
+      Beacon.Loader.load_layout_module(layout.site, layout.id)
       {:ok, _view, html} = live(conn, "/home/hello")
       assert html =~ ~S|<link href="color.css" rel="stylesheet"/>|
     end
@@ -384,7 +384,7 @@ defmodule Beacon.Web.Live.PageLiveTest do
       assert html =~ "component_test_v1"
 
       Content.update_component(component, %{template: "component_test_v2"})
-      Beacon.Loader.reload_components_module(component.site)
+      Beacon.Loader.load_components_module(component.site)
 
       {:ok, _view, html} = live(conn, "/component_test")
       assert html =~ "component_test_v2"


### PR DESCRIPTION
## Resolves #575

This re-adds the Global locking mechanism via Registry, but with an extra feature to prevent crashes due to our Loader process of manually compiling dynamic modules which `import` other dynamic modules (which might not be loaded yet).

Now the Loader will force compilation of any `import` modules before compiling the module which does the importing