### PR TITLE
Page warming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
   - Introduce global process lock for Loader Workers, preventing multiple workers from
     attempting to compile the same module simultaneously
+  - Page Warming - Beacon will now eagerly load a small number of pages (default 10) at boot time for SEO 
+  - `Beacon.Config` option `:page_warming` can change the number of pages to warm, specify which pages, or disable warming per site
 
 ## 0.2.2 (2024-11-17)
 

--- a/lib/beacon/config.ex
+++ b/lib/beacon/config.ex
@@ -194,6 +194,11 @@ defmodule Beacon.Config do
   """
   @type default_meta_tags :: [%{binary() => binary()}]
 
+  @typedoc """
+  The strategy for pre-loading page modules at boot time.
+  """
+  @type page_warming :: {:shortest_paths, integer()} | {:specify_paths, [String.t()]} | :none
+
   @type t :: %__MODULE__{
           site: Beacon.Types.Site.t(),
           endpoint: endpoint(),
@@ -211,7 +216,8 @@ defmodule Beacon.Config do
           lifecycle: lifecycle(),
           extra_page_fields: extra_page_fields(),
           extra_asset_fields: extra_asset_fields(),
-          default_meta_tags: default_meta_tags()
+          default_meta_tags: default_meta_tags(),
+          page_warming: page_warming()
         }
 
   @default_load_template [
@@ -257,7 +263,8 @@ defmodule Beacon.Config do
             ],
             extra_page_fields: [],
             extra_asset_fields: [],
-            default_meta_tags: []
+            default_meta_tags: [],
+            page_warming: {:shortest_paths, 10}
 
   @type option ::
           {:site, Beacon.Types.Site.t()}
@@ -277,6 +284,7 @@ defmodule Beacon.Config do
           | {:extra_page_fields, extra_page_fields()}
           | {:extra_asset_fields, extra_asset_fields()}
           | {:default_meta_tags, default_meta_tags()}
+          | {:page_warming, page_warming()}
 
   @doc """
   Build a new `%Beacon.Config{}` instance to hold the entire configuration for each site.
@@ -324,6 +332,8 @@ defmodule Beacon.Config do
 
     * `:default_meta_tags` - `t:default_meta_tags/0` (optional). Defaults to `%{}`.
 
+    * `:page_warming` - `t:page_warming/0` (optional). Defaults to `{:shortest_paths, 10}`.
+
   ## Example
 
       iex> Beacon.Config.new(
@@ -352,7 +362,8 @@ defmodule Beacon.Config do
           after_publish_page: [
             notify_admin: fn page -> {:cont, MyApp.Admin.send_email(page)} end
           ]
-        ]
+        ],
+        page_warming: {:specify_paths, ["/", "/home", "/blog"]}
       )
       %Beacon.Config{
         site: :my_site,
@@ -400,7 +411,8 @@ defmodule Beacon.Config do
         ],
         extra_page_fields: [],
         extra_asset_fields: [],
-        default_meta_tags: []
+        default_meta_tags: [],
+        page_warming: {:specify_paths, ["/", "/home", "/blog"]}
       }
 
   """
@@ -442,6 +454,8 @@ defmodule Beacon.Config do
     default_meta_tags = Keyword.get(opts, :default_meta_tags, [])
     extra_asset_fields = Keyword.get(opts, :extra_asset_fields, [{"image/*", [Beacon.MediaLibrary.AssetFields.AltText]}])
 
+    page_warming = Keyword.get(opts, :page_warming, {:shortest_paths, 10})
+
     opts =
       opts
       |> Keyword.put(:tailwind_config, ensure_tailwind_config(opts[:tailwind_config]))
@@ -452,6 +466,7 @@ defmodule Beacon.Config do
       |> Keyword.put(:assets, assets)
       |> Keyword.put(:default_meta_tags, default_meta_tags)
       |> Keyword.put(:extra_asset_fields, extra_asset_fields)
+      |> Keyword.put(:page_warming, page_warming)
 
     struct!(__MODULE__, opts)
   end

--- a/lib/beacon/content.ex
+++ b/lib/beacon/content.ex
@@ -980,6 +980,20 @@ defmodule Beacon.Content do
     |> Enum.map(&extract_page_snapshot/1)
   end
 
+  @doc """
+  Similar to `list_published_pages/2`, but does not accept any options.  Instead, provide a list
+  of paths, and this function will return any published pages which match one of those paths.
+  """
+  @doc type: :pages
+  @spec list_published_pages_for_paths(Site.t(), [String.t()]) :: [Page.t()]
+  def list_published_pages_for_paths(site, paths) do
+    site
+    |> query_list_published_pages_base()
+    |> then(fn query -> from(q in query, where: q.path in ^paths) end)
+    |> repo(site).all()
+    |> Enum.map(&extract_page_snapshot/1)
+  end
+
   defp query_list_published_pages_base(site) do
     events =
       from event in PageEvent,
@@ -1026,6 +1040,7 @@ defmodule Beacon.Content do
 
   defp query_list_published_pages_search(query, _search), do: query
 
+  defp query_list_published_pages_sort(query, {:length, key}), do: from(q in query, order_by: [{:asc, fragment("length(?)", field(q, ^key))}])
   defp query_list_published_pages_sort(query, sort), do: from(q in query, order_by: [asc: ^sort])
 
   @doc """

--- a/test/beacon/content_test.exs
+++ b/test/beacon/content_test.exs
@@ -291,6 +291,31 @@ defmodule Beacon.ContentTest do
       assert [%Page{path: "/with-tags"}] = Content.list_published_pages(:my_site, search: %{extra: %{"tags" => "tag1"}})
     end
 
+    test "list_published_pages sort by path length" do
+      beacon_published_page_fixture(path: "/")
+      beacon_published_page_fixture(path: "/foo")
+      beacon_published_page_fixture(path: "/a")
+
+      assert [
+               %Page{path: "/"},
+               %Page{path: "/a"},
+               %Page{path: "/foo"}
+             ] = Content.list_published_pages(:my_site, sort: {:length, :path})
+    end
+
+    test "list_published_pages_for_paths/2" do
+      beacon_published_page_fixture(path: "/foo")
+      beacon_published_page_fixture(path: "/bar")
+      beacon_published_page_fixture(path: "/baz")
+      beacon_published_page_fixture(path: "/bong")
+      beacon_page_fixture(path: "/unpublished")
+
+      assert [
+               %Page{path: "/bar"},
+               %Page{path: "/baz"}
+             ] = Content.list_published_pages_for_paths(:my_site, ["/bar", "/baz", "/unpublished"])
+    end
+
     test "list_page_events" do
       page = beacon_page_fixture()
       Content.publish_page(page)


### PR DESCRIPTION
## Resolves #666 

Adds feature to warm pages on Beacon Boot.  Configured via `Beacon.Config` `:page_warming`. Allowed options are:
* `{:shortest_paths, n}` - warms the `n` pages with the shortest paths (using database `LENGTH()` function)
* `{:specific_paths, list_of_path_strings}` - attempts to warm all pages with the provided paths.  skips if the page is unpublished
* `:none` - disables the page warming feature entirely