### PR TITLE
allow admin source for beacon assigns in unpublished pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   - Introduce global process lock for Loader Workers, preventing multiple workers from
     attempting to compile the same module simultaneously
 
+### Fixes
+
+  - Allow `:admin` source for BeaconAssigns in unpublished Pages
+
 ## 0.2.2 (2024-11-17)
 
 ### Fixes

--- a/lib/beacon/loader/page.ex
+++ b/lib/beacon/loader/page.ex
@@ -94,7 +94,7 @@ defmodule Beacon.Loader.Page do
     end
   end
 
-  defp interpolate_raw_schema(page) do
+  def interpolate_raw_schema(page) do
     page.raw_schema
     |> List.wrap()
     |> Enum.map(&interpolate_raw_schema_record(&1, page))

--- a/lib/beacon/web/beacon_assigns.ex
+++ b/lib/beacon/web/beacon_assigns.ex
@@ -59,13 +59,13 @@ defmodule Beacon.Web.BeaconAssigns do
   end
 
   @doc false
-  def new(site, %Beacon.Content.Page{} = page, live_data, path_info, query_params)
+  def new(site, %Beacon.Content.Page{} = page, live_data, path_info, query_params, source \\ :beacon)
       when is_atom(site) and is_map(live_data) and is_list(path_info) and is_map(query_params) do
     %{site: ^site} = page
     page_module = Beacon.Loader.Page.module_name(site, page.id)
     live_data = Beacon.Web.DataSource.live_data(site, path_info, Map.drop(query_params, ["path"]))
     path_params = Beacon.Router.path_params(page.path, path_info)
-    page_title = Beacon.Web.DataSource.page_title(site, page.id, live_data)
+    page_title = Beacon.Web.DataSource.page_title(site, page.id, live_data, source)
     components_module = Beacon.Loader.Components.module_name(site)
     info_handlers_module = Beacon.Loader.InfoHandlers.module_name(site)
     event_handlers_module = Beacon.Loader.EventHandlers.module_name(site)

--- a/lib/beacon/web/controllers/api/page_json.ex
+++ b/lib/beacon/web/controllers/api/page_json.ex
@@ -24,7 +24,7 @@ defmodule Beacon.Web.API.PageJSON do
     Beacon.ErrorHandler.enable(page.site)
     path_info = for segment <- String.split(page.path, "/"), segment != "", do: segment
     live_data = Beacon.Web.DataSource.live_data(page.site, path_info, %{})
-    beacon_assigns = BeaconAssigns.new(page.site, page, live_data, path_info, %{})
+    beacon_assigns = BeaconAssigns.new(page.site, page, live_data, path_info, %{}, :admin)
 
     assigns =
       live_data

--- a/lib/beacon/web/data_source.ex
+++ b/lib/beacon/web/data_source.ex
@@ -9,9 +9,8 @@ defmodule Beacon.Web.DataSource do
     |> Beacon.apply_mfa(:live_data, [path_info, params])
   end
 
-  # TODO: revisit this logic to evaluate page_title for unpublished pages
-  def page_title(site, page_id, live_data) do
-    %{path: path, title: title} = page_assigns = page_assigns(site, page_id)
+  def page_title(site, page_id, live_data, source) do
+    %{path: path, title: title} = page_assigns = page_assigns(site, page_id, source)
 
     with {:ok, page_title} <- Beacon.Content.render_snippet(title, %{page: page_assigns, live_data: live_data}) do
       page_title
@@ -45,7 +44,7 @@ defmodule Beacon.Web.DataSource do
     assigns
     |> Beacon.Web.Layouts.meta_tags()
     |> List.wrap()
-    |> Enum.map(&interpolate_meta_tag(&1, %{page: page_assigns(site, page_id), live_data: live_data}))
+    |> Enum.map(&interpolate_meta_tag(&1, %{page: page_assigns(site, page_id, :beacon), live_data: live_data}))
   end
 
   defp interpolate_meta_tag(meta_tag, values) when is_map(meta_tag) do
@@ -60,12 +59,29 @@ defmodule Beacon.Web.DataSource do
     end
   end
 
-  # only published pages will have the title evaluated,
-  # which is what we need for sites to work properly but
-  # the page builder could use this data as well
-  defp page_assigns(site, page_id) do
+  # only published pages will have the title evaluated for beacon
+  defp page_assigns(site, page_id, :beacon) do
     site
     |> Beacon.Loader.fetch_page_module(page_id)
     |> Beacon.apply_mfa(:page_assigns, [])
+  end
+
+  # beacon_live_admin needs the title for unpublished pages also
+  defp page_assigns(site, page_id, :admin) do
+    page = Beacon.Content.get_page(site, page_id)
+
+    %{
+      id: page.id,
+      site: page.site,
+      layout_id: page.layout_id,
+      title: page.title,
+      meta_tags: page.meta_tags,
+      raw_schema: Beacon.Loader.Page.interpolate_raw_schema(page),
+      path: page.path,
+      description: page.description,
+      order: page.order,
+      format: page.format,
+      extra: page.extra
+    }
   end
 end

--- a/lib/beacon/web/live/page_live.ex
+++ b/lib/beacon/web/live/page_live.ex
@@ -134,7 +134,7 @@ defmodule Beacon.Web.PageLive do
           # TODO: remove deprecated @beacon_query_params
           |> Component.assign(:beacon_query_params, beacon_assigns.query_params)
           |> Component.assign(:beacon, beacon_assigns)
-          |> Component.assign(:page_title, Beacon.Web.DataSource.page_title(site, page.id, live_data))
+          |> Component.assign(:page_title, Beacon.Web.DataSource.page_title(site, page.id, live_data, :beacon))
 
         {:noreply, push_event(socket, "beacon:page-updated", %{meta_tags: Beacon.Web.DataSource.meta_tags(socket.assigns)})}
     end

--- a/test/beacon_web/data_source_test.exs
+++ b/test/beacon_web/data_source_test.exs
@@ -24,12 +24,12 @@ defmodule Beacon.Web.DataSourceTest do
   describe "page_title" do
     test "renders static content", %{site: site} do
       page = beacon_published_page_fixture(site: site, title: "my title")
-      assert DataSource.page_title(page.site, page.id, %{}) == "my title"
+      assert DataSource.page_title(page.site, page.id, %{}, :beacon) == "my title"
     end
 
     test "renders snippet", %{site: site} do
       page = beacon_published_page_fixture(site: site, title: "{{ page.path | upcase }}")
-      assert DataSource.page_title(page.site, page.id, %{}) == "/HOME"
+      assert DataSource.page_title(page.site, page.id, %{}, :beacon) == "/HOME"
     end
   end
 end


### PR DESCRIPTION
## Resolves #667 

This adds a `source` argument for building BeaconAssigns, particularly the `page_title`, which currently doesn't work for unpublished pages.

The `beacon_live_admin` visual editor goes through the JSON endpoint and often needs to build assigns for unpublished pages.  Therefore this endpoint will have the `:admin` source (default source is `:beacon`).

The `:admin` source requests will not do any Dynamic Module calling/loading (because this is not allowed for unpublished pages).  Instead, it will just do a database call.