### PR TITLE
chore: isolate dynamic function calls

### DIFF
--- a/lib/beacon/beacon.ex
+++ b/lib/beacon/beacon.ex
@@ -159,14 +159,12 @@ defmodule Beacon do
   end
 
   @doc false
-  # This should always be used when calling dynamic modules to provide better error messages
-  def apply_mfa(module, function, args, opts \\ []) when is_atom(module) and is_atom(function) and is_list(args) and is_list(opts) do
-    apply(module, function, args)
-  rescue
-    error ->
-      context = Keyword.get(opts, :context, nil)
-      mfa = Exception.format_mfa(module, function, length(args))
-      message = "error applying #{mfa}"
-      reraise Beacon.InvokeError, [message: message, error: error, args: args, context: context], __STACKTRACE__
+  # This should always be used when calling dynamic modules
+  # 1. Isolate function calls
+  # 2. Enable Beacon's autoloading mechanism (ErrorHandler)
+  # 3. Provide more meaningful error messages
+  def apply_mfa(site, module, function, args, opts \\ [])
+      when is_atom(site) and is_atom(module) and is_atom(function) and is_list(args) and is_list(opts) do
+    Beacon.Loader.safe_apply_mfa(site, module, function, args, opts)
   end
 end

--- a/lib/beacon/content/snippets/tag_helper.ex
+++ b/lib/beacon/content/snippets/tag_helper.ex
@@ -27,8 +27,7 @@ defmodule Beacon.Content.Snippets.TagHelper do
 
     text =
       site
-      |> Beacon.Loader.fetch_snippets_module()
-      |> Beacon.apply_mfa(helper_name, [context.counter_vars])
+      |> Beacon.apply_mfa(Beacon.Loader.fetch_snippets_module(site), helper_name, [context.counter_vars])
       |> to_string()
 
     {[text: text], context}

--- a/lib/beacon/lifecycle/template.ex
+++ b/lib/beacon/lifecycle/template.ex
@@ -102,7 +102,7 @@ defmodule Beacon.Lifecycle.Template do
   @spec render_template(Beacon.Content.Page.t(), map(), Macro.Env.t()) :: Beacon.Template.t()
   def render_template(page, assigns, env) do
     page_module = Beacon.Loader.fetch_page_module(page.site, page.id)
-    template = Beacon.apply_mfa(page_module, :render, [assigns])
+    template = Beacon.apply_mfa(page.site, page_module, :render, [assigns])
     context = [path: page.path, assigns: assigns, env: env]
     lifecycle = Lifecycle.execute(__MODULE__, page.site, :render_template, template, sub_key: page.format, context: context)
     lifecycle.output

--- a/lib/beacon/loader.ex
+++ b/lib/beacon/loader.ex
@@ -26,6 +26,27 @@ defmodule Beacon.Loader do
     end
   end
 
+  def safe_apply_mfa(site, module, function, args, opts \\ []) do
+    if :erlang.module_loaded(module) do
+      apply(module, function, args)
+    else
+      case GenServer.call(worker(site), {:apply_mfa, module, function, args}) do
+        {:ok, result} ->
+          result
+
+        {:error, error, stacktrace} ->
+          raise_invoke_error(site, error, module, function, args, opts[:context], stacktrace)
+      end
+    end
+  rescue
+    error ->
+      raise_invoke_error(site, error, module, function, args, opts[:context], __STACKTRACE__)
+  end
+
+  defp raise_invoke_error(site, error, module, function, args, context, stacktrace) do
+    reraise Beacon.InvokeError, [site: site, error: error, module: module, function: function, args: args, context: context], stacktrace
+  end
+
   defp worker(site) do
     supervisor = Beacon.Registry.via({site, Beacon.LoaderSupervisor})
     config = %{site: site}
@@ -359,9 +380,11 @@ defmodule Beacon.Loader do
     {:noreply, config}
   end
 
-  def handle_info(msg, config) do
-    raise inspect(msg)
-    Logger.warning("Beacon.Loader can not handle the message: #{inspect(msg)}")
-    {:noreply, config}
-  end
+  # def handle_info(msg, config) do
+  #   dbg(msg)
+
+  #   raise inspect(msg)
+  #   Logger.warning("Beacon.Loader can not handle the message: #{inspect(msg)}")
+  #   {:noreply, config}
+  # end
 end

--- a/lib/beacon/loader.ex
+++ b/lib/beacon/loader.ex
@@ -380,11 +380,9 @@ defmodule Beacon.Loader do
     {:noreply, config}
   end
 
-  # def handle_info(msg, config) do
-  #   dbg(msg)
-
-  #   raise inspect(msg)
-  #   Logger.warning("Beacon.Loader can not handle the message: #{inspect(msg)}")
-  #   {:noreply, config}
-  # end
+  def handle_info(msg, config) do
+    raise inspect(msg)
+    Logger.warning("Beacon.Loader can not handle the message: #{inspect(msg)}")
+    {:noreply, config}
+  end
 end

--- a/lib/beacon/loader/components.ex
+++ b/lib/beacon/loader/components.ex
@@ -14,10 +14,7 @@ defmodule Beacon.Loader.Components do
 
   def build_ast(site, [] = _components) do
     routes_module = Loader.Routes.module_name(site)
-
-    site
-    |> module_name()
-    |> render(routes_module)
+    render(site, module_name(site), routes_module)
   end
 
   def build_ast(site, components) do
@@ -29,12 +26,12 @@ defmodule Beacon.Loader.Components do
     # `import` modules won't be autoloaded
     Loader.ensure_loaded!([routes_module], site)
 
-    render(module, routes_module, render_functions, function_components)
+    render(site, module, routes_module, render_functions, function_components)
   end
 
   # generate the module even without functions because it gets
   # imported into other modules
-  defp render(component_module, routes_module) do
+  defp render(site, component_module, routes_module) do
     quote do
       defmodule unquote(component_module) do
         import Phoenix.HTML
@@ -51,13 +48,13 @@ defmodule Beacon.Loader.Components do
 
         # TODO: remove my_component/2
         def my_component(name, assigns \\ []) do
-          Beacon.apply_mfa(__MODULE__, :render, [name, Enum.into(assigns, %{})])
+          Beacon.apply_mfa(unquote(site), __MODULE__, :render, [name, Enum.into(assigns, %{})])
         end
       end
     end
   end
 
-  defp render(component_module, routes_module, render_functions, function_components) do
+  defp render(site, component_module, routes_module, render_functions, function_components) do
     quote do
       defmodule unquote(component_module) do
         import Phoenix.Component.Declarative
@@ -85,7 +82,7 @@ defmodule Beacon.Loader.Components do
 
         # TODO: remove my_component/2
         def my_component(name, assigns \\ []) do
-          Beacon.apply_mfa(__MODULE__, :render, [name, Enum.into(assigns, %{})])
+          Beacon.apply_mfa(unquote(site), __MODULE__, :render, [name, Enum.into(assigns, %{})])
         end
 
         unquote_splicing(render_functions)

--- a/lib/beacon/loader/page.ex
+++ b/lib/beacon/loader/page.ex
@@ -20,7 +20,7 @@ defmodule Beacon.Loader.Page do
         fun.(page)
       end,
       render(page),
-      dynamic_helper()
+      dynamic_helper(site)
     ]
 
     # `import` modules won't be autoloaded
@@ -228,10 +228,10 @@ defmodule Beacon.Loader.Page do
 
   defp load_variants(page), do: raise(Beacon.LoaderError, message: "failed to load variants for page #{page.id} - #{page.path}")
 
-  defp dynamic_helper do
+  defp dynamic_helper(site) do
     quote do
       def dynamic_helper(helper_name, args) do
-        Beacon.apply_mfa(__MODULE__, String.to_atom(helper_name), [args])
+        Beacon.apply_mfa(unquote(site), __MODULE__, String.to_atom(helper_name), [args])
       end
     end
   end

--- a/lib/beacon/loader/worker.ex
+++ b/lib/beacon/loader/worker.ex
@@ -27,6 +27,14 @@ defmodule Beacon.Loader.Worker do
     stop(:pong, config)
   end
 
+  def handle_call({:apply_mfa, module, function, args}, _from, config) do
+    result = apply(module, function, args)
+    {:stop, :shutdown, {:ok, result}, config}
+  rescue
+    error ->
+      {:stop, :shutdown, {:error, error, __STACKTRACE__}, config}
+  end
+
   def handle_call(:populate_default_media, _from, config) do
     %{site: site} = config
     path = Path.join(Application.app_dir(:beacon, "priv"), "beacon.png")

--- a/lib/beacon/media_library/provider/repo.ex
+++ b/lib/beacon/media_library/provider/repo.ex
@@ -37,7 +37,7 @@ defmodule Beacon.MediaLibrary.Provider.Repo do
   @doc false
   def url_for(asset) do
     routes = Beacon.Loader.fetch_routes_module(asset.site)
-    Beacon.apply_mfa(routes, :beacon_media_url, [asset.file_name])
+    Beacon.apply_mfa(asset.site, routes, :beacon_media_url, [asset.file_name])
   end
 
   @doc false

--- a/lib/beacon/router_server.ex
+++ b/lib/beacon/router_server.ex
@@ -40,7 +40,7 @@ defmodule Beacon.RouterServer do
   def lookup_page(site, path_info) when is_atom(site) and is_list(path_info) do
     with {_path, page_id} <- lookup_path(site, path_info) do
       page_module = Beacon.Loader.fetch_page_module(site, page_id)
-      Beacon.apply_mfa(page_module, :page, [])
+      Beacon.apply_mfa(site, page_module, :page, [])
     else
       _ -> nil
     end

--- a/lib/beacon/template.ex
+++ b/lib/beacon/template.ex
@@ -60,8 +60,8 @@ defmodule Beacon.Template do
         env = Beacon.Web.PageLive.make_env(site)
 
         template =
-          page_module
-          |> Beacon.apply_mfa(:page, [])
+          site
+          |> Beacon.apply_mfa(page_module, :page, [])
           |> Beacon.Lifecycle.Template.render_template(assigns, env)
 
         {:ok, template}

--- a/lib/beacon/web/components/layouts.ex
+++ b/lib/beacon/web/components/layouts.ex
@@ -39,10 +39,10 @@ defmodule Beacon.Web.Layouts do
 
   @doc false
   def render_dynamic_layout(assigns) do
-    %{beacon: %{private: %{page_module: page_module}}} = assigns
-    %{site: site, layout_id: layout_id} = Beacon.apply_mfa(page_module, :page_assigns, [[:site, :layout_id]])
+    %{beacon: %{site: site, private: %{page_module: page_module}}} = assigns
+    %{site: ^site, layout_id: layout_id} = Beacon.apply_mfa(site, page_module, :page_assigns, [[:site, :layout_id]])
     layout_module = Beacon.Loader.fetch_layout_module(site, layout_id)
-    Beacon.apply_mfa(layout_module, :render, [assigns])
+    Beacon.apply_mfa(site, layout_module, :render, [assigns])
   end
 
   @doc """
@@ -54,15 +54,11 @@ defmodule Beacon.Web.Layouts do
   end
 
   defp compiled_page_assigns(site, page_id) do
-    site
-    |> Beacon.Loader.fetch_page_module(page_id)
-    |> Beacon.apply_mfa(:page_assigns, [])
+    Beacon.apply_mfa(site, Beacon.Loader.fetch_page_module(site, page_id), :page_assigns, [])
   end
 
   defp compiled_layout_assigns(site, layout_id) do
-    site
-    |> Beacon.Loader.fetch_layout_module(layout_id)
-    |> Beacon.apply_mfa(:layout_assigns, [])
+    Beacon.apply_mfa(site, Beacon.Loader.fetch_layout_module(site, layout_id), :layout_assigns, [])
   end
 
   @doc """
@@ -108,8 +104,8 @@ defmodule Beacon.Web.Layouts do
   end
 
   defp compiled_page_meta_tags(assigns) do
-    %{beacon: %{private: %{page_module: page_module}}} = assigns
-    %{site: site, id: page_id} = Beacon.apply_mfa(page_module, :page_assigns, [[:site, :id]])
+    %{beacon: %{site: site, private: %{page_module: page_module}}} = assigns
+    %{site: ^site, id: page_id} = Beacon.apply_mfa(site, page_module, :page_assigns, [[:site, :id]])
     %{meta_tags: meta_tags} = compiled_page_assigns(site, page_id)
     meta_tags
   end
@@ -125,8 +121,8 @@ defmodule Beacon.Web.Layouts do
   end
 
   defp compiled_layout_meta_tags(assigns) do
-    %{beacon: %{private: %{page_module: page_module}}} = assigns
-    %{site: site, layout_id: layout_id} = Beacon.apply_mfa(page_module, :page_assigns, [[:site, :layout_id]])
+    %{beacon: %{site: site, private: %{page_module: page_module}}} = assigns
+    %{site: ^site, layout_id: layout_id} = Beacon.apply_mfa(site, page_module, :page_assigns, [[:site, :layout_id]])
     %{meta_tags: meta_tags} = compiled_layout_assigns(site, layout_id)
     meta_tags
   end
@@ -135,8 +131,8 @@ defmodule Beacon.Web.Layouts do
   Renders the Schema.org data defined in the current page.
   """
   def render_schema(assigns) do
-    %{beacon: %{private: %{page_module: page_module}}} = assigns
-    %{site: site, id: page_id} = Beacon.apply_mfa(page_module, :page_assigns, [[:site, :id]])
+    %{beacon: %{site: site, private: %{page_module: page_module}}} = assigns
+    %{site: ^site, id: page_id} = Beacon.apply_mfa(site, page_module, :page_assigns, [[:site, :id]])
     %{raw_schema: raw_schema} = compiled_page_assigns(site, page_id)
 
     is_empty = fn raw_schema ->
@@ -181,8 +177,8 @@ defmodule Beacon.Web.Layouts do
   end
 
   defp compiled_layout_resource_links(assigns) do
-    %{beacon: %{private: %{page_module: page_module}}} = assigns
-    %{site: site, layout_id: layout_id} = Beacon.apply_mfa(page_module, :page_assigns, [[:site, :layout_id]])
+    %{beacon: %{site: site, private: %{page_module: page_module}}} = assigns
+    %{site: ^site, layout_id: layout_id} = Beacon.apply_mfa(site, page_module, :page_assigns, [[:site, :layout_id]])
     %{resource_links: resource_links} = compiled_layout_assigns(site, layout_id)
     resource_links
   end

--- a/lib/beacon/web/controllers/api/page_json.ex
+++ b/lib/beacon/web/controllers/api/page_json.ex
@@ -21,7 +21,6 @@ defmodule Beacon.Web.API.PageJSON do
   end
 
   defp data(%Page{} = page) do
-    Beacon.ErrorHandler.enable(page.site)
     path_info = for segment <- String.split(page.path, "/"), segment != "", do: segment
     live_data = Beacon.Web.DataSource.live_data(page.site, path_info, %{})
     beacon_assigns = BeaconAssigns.new(page.site, page, live_data, path_info, %{}, :admin)

--- a/lib/beacon/web/controllers/error_html.ex
+++ b/lib/beacon/web/controllers/error_html.ex
@@ -10,9 +10,8 @@ defmodule Beacon.Web.ErrorHTML do
   def render(<<status_code::binary-size(3), _rest::binary>> = template, %{conn: conn}) do
     {_, _, %{extra: %{session: %{"beacon_site" => site}}}} = conn.private.phoenix_live_view
     error_module = Beacon.Loader.fetch_error_page_module(site)
-
     conn = Plug.Conn.assign(conn, :beacon, Beacon.Web.BeaconAssigns.new(site))
-    Beacon.apply_mfa(error_module, :render, [conn, String.to_integer(status_code)])
+    Beacon.apply_mfa(site, error_module, :render, [conn, String.to_integer(status_code)])
   rescue
     error ->
       Logger.warning("""

--- a/lib/beacon/web/data_source.ex
+++ b/lib/beacon/web/data_source.ex
@@ -4,9 +4,7 @@ defmodule Beacon.Web.DataSource do
   require Logger
 
   def live_data(site, path_info, params \\ %{}) when is_atom(site) and is_list(path_info) and is_map(params) do
-    site
-    |> Beacon.Loader.fetch_live_data_module()
-    |> Beacon.apply_mfa(:live_data, [path_info, params])
+    Beacon.apply_mfa(site, Beacon.Loader.fetch_live_data_module(site), :live_data, [path_info, params])
   end
 
   def page_title(site, page_id, live_data, source) do
@@ -37,8 +35,8 @@ defmodule Beacon.Web.DataSource do
 
   # TODO: revisit this logic to evaluate meta_tags for unpublished pages
   def meta_tags(assigns) do
-    %{beacon: %{private: %{page_module: page_module, live_data_keys: live_data_keys}}} = assigns
-    %{site: site, id: page_id} = Beacon.apply_mfa(page_module, :page_assigns, [[:site, :id]])
+    %{beacon: %{site: site, private: %{page_module: page_module, live_data_keys: live_data_keys}}} = assigns
+    %{site: ^site, id: page_id} = Beacon.apply_mfa(site, page_module, :page_assigns, [[:site, :id]])
     live_data = Map.take(assigns, live_data_keys)
 
     assigns
@@ -61,9 +59,7 @@ defmodule Beacon.Web.DataSource do
 
   # only published pages will have the title evaluated for beacon
   defp page_assigns(site, page_id, :beacon) do
-    site
-    |> Beacon.Loader.fetch_page_module(page_id)
-    |> Beacon.apply_mfa(:page_assigns, [])
+    Beacon.apply_mfa(site, Beacon.Loader.fetch_page_module(site, page_id), :page_assigns, [])
   end
 
   # beacon_live_admin needs the title for unpublished pages also

--- a/lib/beacon/web/live/page_live.ex
+++ b/lib/beacon/web/live/page_live.ex
@@ -33,10 +33,13 @@ defmodule Beacon.Web.PageLive do
   end
 
   def render(assigns) do
-    %{beacon: %{private: %{page_module: page_module}}} = assigns
+    %{beacon: %{site: site, private: %{page_module: page_module}}} = assigns
 
-    page_module
-    |> Beacon.apply_mfa(:page, [])
+    # do not allow overwritring site to avoid rendering a leaked page
+    %{site: ^site} = Beacon.apply_mfa(site, page_module, :page_assigns, [[:site]])
+
+    site
+    |> Beacon.apply_mfa(page_module, :page, [])
     |> Lifecycle.Template.render_template(assigns, __ENV__)
   end
 
@@ -56,11 +59,12 @@ defmodule Beacon.Web.PageLive do
   end
 
   def handle_info(msg, socket) do
-    %{page_module: page_module, live_path: live_path, info_handlers_module: info_handlers_module} = socket.assigns.beacon.private
-    %{site: site, id: page_id} = Beacon.apply_mfa(page_module, :page_assigns, [[:site, :id]])
+    %{beacon: %{site: site, private: %{page_module: page_module, live_path: live_path, info_handlers_module: info_handlers_module}}} = socket.assigns
+    %{site: ^site, id: page_id} = Beacon.apply_mfa(site, page_module, :page_assigns, [[:site, :id]])
 
     result =
       Beacon.apply_mfa(
+        site,
         info_handlers_module,
         :handle_info,
         [msg, socket],
@@ -78,11 +82,14 @@ defmodule Beacon.Web.PageLive do
   end
 
   def handle_event(event_name, event_params, socket) do
-    %{page_module: page_module, live_path: live_path, event_handlers_module: event_handlers_module} = socket.assigns.beacon.private
-    %{site: site, id: page_id} = Beacon.apply_mfa(page_module, :page_assigns, [[:site, :id]])
+    %{beacon: %{site: site, private: %{page_module: page_module, live_path: live_path, event_handlers_module: event_handlers_module}}} =
+      socket.assigns
+
+    %{site: ^site, id: page_id} = Beacon.apply_mfa(site, page_module, :page_assigns, [[:site, :id]])
 
     result =
       Beacon.apply_mfa(
+        site,
         event_handlers_module,
         :handle_event,
         [event_name, event_params, socket],

--- a/lib/beacon/web/live/page_live.ex
+++ b/lib/beacon/web/live/page_live.ex
@@ -19,9 +19,6 @@ defmodule Beacon.Web.PageLive do
     %{"path" => path} = params
     %{"beacon_site" => site} = session
 
-    # Use Beacon custom error handler to automatically load modules on-demand
-    Beacon.ErrorHandler.enable(site)
-
     if Beacon.Config.fetch!(site).mode == :live and connected?(socket) do
       :ok = Beacon.PubSub.subscribe_to_page(site, path)
     end
@@ -119,8 +116,6 @@ defmodule Beacon.Web.PageLive do
         %{"path" => path_info} = params
 
         if socket.assigns.beacon.site != site do
-          Beacon.ErrorHandler.enable(site)
-
           if Beacon.Config.fetch!(site).mode == :live do
             Beacon.PubSub.unsubscribe_to_page(socket.assigns.beacon.site, path_info)
             Beacon.PubSub.subscribe_to_page(site, path_info)

--- a/lib/errors.ex
+++ b/lib/errors.ex
@@ -42,7 +42,25 @@ defmodule Beacon.InvokeError do
   otherwise that might be a bug in Beacon.
   """
 
-  defexception error: nil, args: [], context: nil, message: "error applying function", plug_status: 404
+  defexception site: nil, error: nil, module: nil, function: nil, args: [], context: nil, message: "error applying function", plug_status: 404
+
+  @impl true
+  def message(%{site: site, module: module, function: function, args: args, context: context}) do
+    mfa = Exception.format_mfa(module, function, length(args))
+
+    if context do
+      """
+      error applying #{mfa} on site #{site}
+
+      Context:
+
+        #{inspect(context)}
+
+      """
+    else
+      "error applying #{mfa} on site #{site}"
+    end
+  end
 end
 
 defmodule Beacon.ParserError do

--- a/test/beacon/loader_test.exs
+++ b/test/beacon/loader_test.exs
@@ -32,7 +32,7 @@ defmodule Beacon.LoaderTest do
 
     test "undefined module" do
       assert_raise Beacon.InvokeError, "error applying Foo.bar/0 on site my_site", fn ->
-        Loader.safe_apply_mfa(default_site(), Foo, :bar, []) |> dbg
+        Loader.safe_apply_mfa(default_site(), Foo, :bar, [])
       end
     end
 

--- a/test/beacon/loader_test.exs
+++ b/test/beacon/loader_test.exs
@@ -18,6 +18,31 @@ defmodule Beacon.LoaderTest do
     [site: site]
   end
 
+  describe "safe_apply_mfa" do
+    setup do
+      # reset (turn off) beacon autoloader
+      Process.delete(:__beacon_site__)
+      Process.flag(:error_handler, :error_handler)
+      :ok
+    end
+
+    test "loaded module" do
+      assert Loader.safe_apply_mfa(default_site(), String, :to_integer, ["1"]) == 1
+    end
+
+    test "undefined module" do
+      assert_raise Beacon.InvokeError, "error applying Foo.bar/0 on site my_site", fn ->
+        Loader.safe_apply_mfa(default_site(), Foo, :bar, []) |> dbg
+      end
+    end
+
+    test "undefined function" do
+      assert_raise Beacon.InvokeError, "error applying String.foo/1 on site my_site", fn ->
+        Loader.safe_apply_mfa(default_site(), String, :foo, ["bar"])
+      end
+    end
+  end
+
   describe "populate default components" do
     test "seeds initial data", %{site: site} do
       assert Repo.all(Content.Component) == []

--- a/test/beacon_web/controllers/media_library_controller_test.exs
+++ b/test/beacon_web/controllers/media_library_controller_test.exs
@@ -10,7 +10,7 @@ defmodule Beacon.Web.Controllers.MediaLibraryControllerTest do
   test "show", %{conn: conn} do
     %{file_name: file_name} = Beacon.Test.Fixtures.beacon_media_library_asset_fixture(site: :my_site)
     routes = Beacon.Loader.fetch_routes_module(:my_site)
-    path = Beacon.apply_mfa(routes, :beacon_media_path, [file_name])
+    path = Beacon.apply_mfa(:my_site, routes, :beacon_media_path, [file_name])
 
     conn = get(conn, path)
 


### PR DESCRIPTION
Ensure Beacon's autoloader is enabled (Beacon.ErrorHandler) before trying to call a dynamic function in a module managed by Beacon (page module, components module, routes, etc)

We concentrate all calls into `Beacon.apply_mfa/5` so we have a single source to maintain and it will also spawn a `Loader` worker process to avoid leaking the `:error_handler` flag into the caller.