### PR TITLE
Update tests for LV 1.0 compatibility

### DIFF
--- a/test/beacon/template/heex/heex_decoder_test.exs
+++ b/test/beacon/template/heex/heex_decoder_test.exs
@@ -28,8 +28,8 @@ defmodule Beacon.Template.HEEx.HEExDecoderTest do
 
   test "eex expressions" do
     assert_equal(~S|{_a = true}|)
-    assert_equal(~S|value: <%= 1 %>|)
-    assert_equal(~S|<% _a = 1 %>|)
+    assert_equal(~S|value: {1}|)
+    assert_equal(~S|{_a = 1}|)
   end
 
   test "eex blocks" do

--- a/test/beacon/template/heex/heex_decoder_test.exs
+++ b/test/beacon/template/heex/heex_decoder_test.exs
@@ -27,7 +27,7 @@ defmodule Beacon.Template.HEEx.HEExDecoderTest do
   end
 
   test "eex expressions" do
-    assert_equal(~S|<%= _a = true %>|)
+    assert_equal(~S|{_a = true}|)
     assert_equal(~S|value: <%= 1 %>|)
     assert_equal(~S|<% _a = 1 %>|)
   end
@@ -57,7 +57,7 @@ defmodule Beacon.Template.HEEx.HEExDecoderTest do
     assert_equal(
       ~S"""
       <%= for val <- @vals do %>
-        <%= val %>
+        {val}
       <% end %>
       """,
       %{vals: [1]}
@@ -132,8 +132,8 @@ defmodule Beacon.Template.HEEx.HEExDecoderTest do
 
       assert_equal(~S"""
       <.table id="users" rows={[%{id: 1, username: "foo"}]}>
-        <:col :let={user} label="id"><%= user.id %></:col>
-        <:col :let={user} label="username"><%= user.username %></:col>
+        <:col :let={user} label="id">{user.id}</:col>
+        <:col :let={user} label="username">{user.username}</:col>
       </.table>
       """)
     end
@@ -160,7 +160,7 @@ defmodule Beacon.Template.HEEx.HEExDecoderTest do
   end
 
   test "live data assigns" do
-    assert_equal(~S|<%= @name %>|, %{name: "Beacon"})
+    assert_equal(~S|{@name}|, %{name: "Beacon"})
   end
 
   test "script tag" do

--- a/test/beacon_web/live/page_live_test.exs
+++ b/test/beacon_web/live/page_live_test.exs
@@ -178,7 +178,7 @@ defmodule Beacon.Web.Live.PageLiveTest do
       # wait for event
       :sys.get_state(view.pid)
 
-      assert render(view) =~ "thiswillnotbefound"
+      assert String.slice(render(view), -50..-1) =~ "thiswillnotbefound"
 
       assert has_element?(view, "h1", "not_booted")
     end

--- a/test/beacon_web/live/page_live_test.exs
+++ b/test/beacon_web/live/page_live_test.exs
@@ -176,7 +176,7 @@ defmodule Beacon.Web.Live.PageLiveTest do
       |> render_click()
 
       # wait for event
-      :sys.get_state(view)
+      :sys.get_state(view.pid)
 
       assert has_element?(view, "h1", "not_booted")
     end

--- a/test/beacon_web/live/page_live_test.exs
+++ b/test/beacon_web/live/page_live_test.exs
@@ -178,6 +178,8 @@ defmodule Beacon.Web.Live.PageLiveTest do
       # wait for event
       :sys.get_state(view.pid)
 
+      assert render(view) =~ "thiswillnotbefound"
+
       assert has_element?(view, "h1", "not_booted")
     end
 

--- a/test/beacon_web/live/page_live_test.exs
+++ b/test/beacon_web/live/page_live_test.exs
@@ -178,7 +178,7 @@ defmodule Beacon.Web.Live.PageLiveTest do
       # wait for event
       :sys.get_state(view.pid)
 
-      assert String.slice(render(view), -50..-1) =~ "thiswillnotbefound"
+      assert String.slice(render(view), -500..-30) =~ "thiswillnotbefound"
 
       assert has_element?(view, "h1", "not_booted")
     end

--- a/test/beacon_web/live/page_live_test.exs
+++ b/test/beacon_web/live/page_live_test.exs
@@ -175,6 +175,9 @@ defmodule Beacon.Web.Live.PageLiveTest do
       |> element("a", "go_to_other_site")
       |> render_click()
 
+      # wait for event
+      :sys.get_state(view)
+
       assert has_element?(view, "h1", "not_booted")
     end
 

--- a/test/beacon_web/live/page_live_test.exs
+++ b/test/beacon_web/live/page_live_test.exs
@@ -68,7 +68,7 @@ defmodule Beacon.Web.Live.PageLiveTest do
           @beacon.query_params=<%= @beacon.query_params["query"] %>
 
           <.page_link path="/about">go_to_about_page</.page_link>
-          <.link patch={"#{Beacon.BeaconTest.Endpoint.url()}/other"}>go_to_other_site</.link>
+          <.link navigate="/other">go_to_other_site</.link>
 
           <.form :let={f} for={%{}} as={:greeting} phx-submit="hello">
             Name: <%= text_input f, :name %>
@@ -171,14 +171,11 @@ defmodule Beacon.Web.Live.PageLiveTest do
     test "patch to another site resets site data", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/home/hello")
 
-      view
-      |> element("a", "go_to_other_site")
-      |> render_click()
-
-      # wait for event
-      :sys.get_state(view.pid)
-
-      assert String.slice(render(view), -500..-30) =~ "thiswillnotbefound"
+      {:ok, view, _html} =
+        view
+        |> element("a", "go_to_other_site")
+        |> render_click()
+        |> follow_redirect(conn, "/other")
 
       assert has_element?(view, "h1", "not_booted")
     end


### PR DESCRIPTION
From LV patch notes:
> * Fix live_session not being enforced when patching to the same LiveView under a different route

this means we need to navigate instead of patch when moving between sites

also some renderings now use braces `{ }` instead of the previous HEEx interpolation `<%= %>` since we use that LiveView rendering engine under the hood