### PR TITLE
fix: forward live data errors

### DIFF
--- a/lib/beacon/loader.ex
+++ b/lib/beacon/loader.ex
@@ -41,6 +41,8 @@ defmodule Beacon.Loader do
   rescue
     error ->
       if live_data_module?(module) do
+        # LiveData is user-provided code, which always has the possibility of errors.
+        # In this case, we want to ensure the original error is surfaced to the user for easier debugging.
         reraise error, __STACKTRACE__
       else
         raise_invoke_error(site, error, module, function, args, opts[:context], __STACKTRACE__)

--- a/lib/beacon/loader.ex
+++ b/lib/beacon/loader.ex
@@ -40,11 +40,22 @@ defmodule Beacon.Loader do
     end
   rescue
     error ->
-      raise_invoke_error(site, error, module, function, args, opts[:context], __STACKTRACE__)
+      if live_data_module?(module) do
+        reraise error, __STACKTRACE__
+      else
+        raise_invoke_error(site, error, module, function, args, opts[:context], __STACKTRACE__)
+      end
   end
 
   defp raise_invoke_error(site, error, module, function, args, context, stacktrace) do
     reraise Beacon.InvokeError, [site: site, error: error, module: module, function: function, args: args, context: context], stacktrace
+  end
+
+  defp live_data_module?(module) do
+    case module |> Module.split() |> List.last() do
+      "LiveData" -> true
+      _ -> false
+    end
   end
 
   defp worker(site) do

--- a/lib/beacon/loader/live_data.ex
+++ b/lib/beacon/loader/live_data.ex
@@ -77,8 +77,9 @@ defmodule Beacon.Loader.LiveData do
                     Logger.error("""
                     failed to evaluate Live Data
 
-                    assign: @#{assign.key}
                     path: #{path}
+                    params: #{inspect(unquote(params_var))}
+                    assign: @#{assign.key}
                     """)
 
                     reraise error, __STACKTRACE__

--- a/test/beacon/loader/live_data_test.exs
+++ b/test/beacon/loader/live_data_test.exs
@@ -27,6 +27,15 @@ defmodule Beacon.Loader.LiveDataTest do
     assert assigns_for_path("/bar") == %{product_id: "678"}
   end
 
+  test "forward errors" do
+    live_data = beacon_live_data_fixture(path: "/error")
+    beacon_live_data_assign_fixture(live_data: live_data, format: :elixir, key: "test", value: "String.foo()")
+
+    assert_raise UndefinedFunctionError, "function String.foo/0 is undefined or private", fn ->
+      assert assigns_for_path("/error")
+    end
+  end
+
   defp assigns_for_path(path) do
     path_list = String.split(path, "/", trim: true)
     module = Beacon.Loader.fetch_live_data_module(default_site())

--- a/test/beacon/loader_test.exs
+++ b/test/beacon/loader_test.exs
@@ -41,6 +41,21 @@ defmodule Beacon.LoaderTest do
         Loader.safe_apply_mfa(default_site(), String, :foo, ["bar"])
       end
     end
+
+    test "forwards live data errors" do
+      live_data = beacon_live_data_fixture(path: "/error")
+      beacon_live_data_assign_fixture(live_data: live_data, format: :elixir, key: "test", value: "String.foo()")
+
+      assert_raise UndefinedFunctionError, "function String.foo/0 is undefined or private", fn ->
+        assert assigns_for_path("/error")
+      end
+    end
+
+    defp assigns_for_path(path) do
+      path_list = String.split(path, "/", trim: true)
+      module = Beacon.Loader.fetch_live_data_module(default_site())
+      module.live_data(path_list, %{})
+    end
   end
 
   describe "populate default components" do


### PR DESCRIPTION
Live Data are invoked with Beacon.Loader which would rescue and reraise causing the original error to be lost, but that should not happen for Live Data calls since users might raise custom errors.