### PR TITLE
Reload components module after updating

### DIFF
--- a/lib/beacon/loader.ex
+++ b/lib/beacon/loader.ex
@@ -362,7 +362,10 @@ defmodule Beacon.Loader do
     |> Loader.Components.module_name()
     |> unload()
 
+    # consider implementing HTML and Tag engines
+    # to intercept component module calls
     load_components_module(site)
+
     load_runtime_css(site)
 
     {:noreply, config}

--- a/lib/beacon/loader.ex
+++ b/lib/beacon/loader.ex
@@ -362,6 +362,7 @@ defmodule Beacon.Loader do
     |> Loader.Components.module_name()
     |> unload()
 
+    load_components_module(site)
     load_runtime_css(site)
 
     {:noreply, config}


### PR DESCRIPTION
This is a fix for possible site instability after updating a Beacon Component via LiveAdmin

* Reports of 500 response across the entire site, after making an update to a Beacon Component
* Seems like the cause is existing templates `import`ing that Component module, which for some reason does not trigger `Beacon.ErrorHandler`
* If we find a culprit for ^ this line could be removed again, but for now it prevents the bug from occurring