### PR TITLE
fix: make Router.reachable/2 less strict

### DIFF
--- a/lib/beacon/router.ex
+++ b/lib/beacon/router.ex
@@ -278,7 +278,7 @@ defmodule Beacon.Router do
         router.__beacon_scoped_prefix_for_site__(site)
       end)
 
-    case Phoenix.Router.route_info(router, "GET", prefix, host) do
+    case Phoenix.Router.route_info(router, "GET", prefix, host) |> dbg do
       # bypass and allow booting beacon sites even though there's a route conflict
       # but only for root paths, for example:
       #   live /

--- a/lib/beacon/router.ex
+++ b/lib/beacon/router.ex
@@ -278,7 +278,7 @@ defmodule Beacon.Router do
         router.__beacon_scoped_prefix_for_site__(site)
       end)
 
-    case Phoenix.Router.route_info(router, "GET", prefix, host) |> dbg do
+    case Phoenix.Router.route_info(router, "GET", prefix, host) do
       # bypass and allow booting beacon sites even though there's a route conflict
       # but only for root paths, for example:
       #   live /

--- a/lib/beacon/router.ex
+++ b/lib/beacon/router.ex
@@ -270,10 +270,24 @@ defmodule Beacon.Router do
   # match and invalidate the `beacon_site` mount.
   def reachable?(%Beacon.Config{} = config, opts \\ []) do
     %{site: site, endpoint: endpoint, router: router} = config
+
     host = Keyword.get_lazy(opts, :host, fn -> endpoint.host() end)
-    prefix = router.__beacon_scoped_prefix_for_site__(site)
+
+    prefix =
+      Keyword.get_lazy(opts, :prefix, fn ->
+        router.__beacon_scoped_prefix_for_site__(site)
+      end)
 
     case Phoenix.Router.route_info(router, "GET", prefix, host) do
+      # bypass and allow booting beacon sites even though there's a route conflict
+      # but only for root paths, for example:
+      #   live /
+      #   beacon_site /
+      # that's because even though they share the same prefix,
+      # beacon can still serve pages at /:page
+      %{route: "/"} ->
+        true
+
       %{phoenix_live_view: {Beacon.Web.PageLive, _, _, %{extra: %{session: %{"beacon_site" => ^site}}}}} ->
         true
 

--- a/test/beacon/router_test.exs
+++ b/test/beacon/router_test.exs
@@ -80,7 +80,7 @@ defmodule Beacon.RouterTest do
     end
 
     test "with no specific host", %{config: config} do
-      assert Router.reachable?(config, host: nil, prefix: "/")
+      assert Router.reachable?(config, host: nil)
     end
 
     test "do not match any existing host/path", %{config: config} do

--- a/test/beacon/router_test.exs
+++ b/test/beacon/router_test.exs
@@ -63,14 +63,19 @@ defmodule Beacon.RouterTest do
   end
 
   describe "reachable?" do
-    test "test" do
+    setup do
       site = :host_test
       config = Beacon.Config.fetch!(site)
-      valid_host = "host.com"
+      [config: config]
+    end
 
+    test "match existing host", %{config: config} do
+      valid_host = "host.com"
       assert Router.reachable?(config, host: valid_host)
-      refute Router.reachable?(%{config | site: :my_site}, host: valid_host)
-      refute Router.reachable?(config, host: "other.com")
+    end
+
+    test "do not match any existing host/path", %{config: config} do
+      refute Router.reachable?(config, host: nil, prefix: "/nested/invalid")
     end
   end
 end

--- a/test/beacon/router_test.exs
+++ b/test/beacon/router_test.exs
@@ -74,8 +74,13 @@ defmodule Beacon.RouterTest do
       assert Router.reachable?(config, host: valid_host)
     end
 
+    test "existing nested conflicting route", %{config: config} do
+      valid_host = "host.com"
+      refute Router.reachable?(config, host: valid_host, prefix: "/some_page")
+    end
+
     test "with no specific host", %{config: config} do
-      assert Router.reachable?(config, host: nil)
+      assert Router.reachable?(config, host: nil, prefix: "/")
     end
 
     test "do not match any existing host/path", %{config: config} do

--- a/test/beacon/router_test.exs
+++ b/test/beacon/router_test.exs
@@ -74,6 +74,10 @@ defmodule Beacon.RouterTest do
       assert Router.reachable?(config, host: valid_host)
     end
 
+    test "with no specific host", %{config: config} do
+      assert Router.reachable?(config, host: nil)
+    end
+
     test "do not match any existing host/path", %{config: config} do
       refute Router.reachable?(config, host: nil, prefix: "/nested/invalid")
     end

--- a/test/beacon/router_test.exs
+++ b/test/beacon/router_test.exs
@@ -76,7 +76,7 @@ defmodule Beacon.RouterTest do
 
     test "existing nested conflicting route", %{config: config} do
       valid_host = "host.com"
-      refute Router.reachable?(config, host: valid_host, prefix: "/some_page")
+      refute Router.reachable?(config, host: valid_host, prefix: "/nested/some_page")
     end
 
     test "with no specific host", %{config: config} do

--- a/test/support/live_views.ex
+++ b/test/support/live_views.ex
@@ -1,0 +1,4 @@
+defmodule Beacon.BeaconTest.LiveViews.FooBarLive do
+  use Phoenix.LiveView
+  def render(assigns), do: ~H""
+end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -1,5 +1,4 @@
 defmodule Beacon.BeaconTest.Router do
-  alias Beacon.BeaconTest
   use Beacon.BeaconTest.Web, :router
   use Beacon.Router
 

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -1,4 +1,5 @@
 defmodule Beacon.BeaconTest.Router do
+  alias Beacon.BeaconTest
   use Beacon.BeaconTest.Web, :router
   use Beacon.Router
 
@@ -16,11 +17,12 @@ defmodule Beacon.BeaconTest.Router do
     beacon_site "/media", site: :s3_site
   end
 
-  scope "/", Beacon.BeaconTest do
+  scope "/", Beacon.BeaconTest.Web do
     pipe_through :browser
 
     live_session :default do
       live "/", Beacon.BeaconTest.LiveViews.FooBarLive
+      live "/:page", Beacon.BeaconTest.LiveViews.FooBarLive
     end
   end
 

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -16,7 +16,7 @@ defmodule Beacon.BeaconTest.Router do
     beacon_site "/media", site: :s3_site
   end
 
-  scope "/", Beacon.BeaconTest.Web do
+  scope "/" do
     pipe_through :browser
 
     live_session :default do

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -16,8 +16,16 @@ defmodule Beacon.BeaconTest.Router do
     beacon_site "/media", site: :s3_site
   end
 
-  # test :host
+  scope "/", Beacon.BeaconTest do
+    pipe_through :browser
+
+    live_session :default do
+      live "/", Beacon.BeaconTest.LiveViews.FooBarLive
+    end
+  end
+
   scope path: "/", host: "host.com" do
+    pipe_through :browser
     beacon_site "/", site: :host_test
   end
 

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -21,7 +21,7 @@ defmodule Beacon.BeaconTest.Router do
 
     live_session :default do
       live "/", Beacon.BeaconTest.LiveViews.FooBarLive
-      live "/:page", Beacon.BeaconTest.LiveViews.FooBarLive
+      live "/nested/:page", Beacon.BeaconTest.LiveViews.FooBarLive
     end
   end
 


### PR DESCRIPTION
Allow root paths / to coexist and start beacon sites even if there's a conflict to allow nested beacon pages as /:page to be served, even in the presence of another live / route.

This change will potentially cause more sites to be started but being to restrictive is a breaking change either, so we're partially reverting to v0.2 behavior.