### PR TITLE
fix: boot beacon even without defined beacon_site routes in host app …

### DIFF
--- a/guides/general/troubleshooting.md
+++ b/guides/general/troubleshooting.md
@@ -29,9 +29,13 @@ a site prefix can never match and it will never receive requests.
 
 That's is not necessarily an error if you have multiple sites in the same project
 and each scope is filtering requests on the `:host` option.
+But it may indicate:
 
-But it may indicate an invalid configuration, as a preceding route matching the prefix
+1. An invalid configuration, as a preceding route matching the prefix
 that was supposed to be handled by this site, or an invalid `:host` value.
+
+2. Missing `use Beacon.Router` and/or missing `beacon_site` in your
+app's router file.
 
 Note that if you're using `:host` on the scope and running in `localhost`,
 consider adding `"localhost"` to the list of allowed hosts.

--- a/lib/beacon/router.ex
+++ b/lib/beacon/router.ex
@@ -271,6 +271,14 @@ defmodule Beacon.Router do
   def reachable?(%Beacon.Config{} = config, opts \\ []) do
     %{site: site, endpoint: endpoint, router: router} = config
 
+    if function_exported?(router, :__beacon_scoped_prefix_for_site__, 1) do
+      reachable?(site, endpoint, router, opts)
+    else
+      false
+    end
+  end
+
+  defp reachable?(site, endpoint, router, opts) do
     host = Keyword.get_lazy(opts, :host, fn -> endpoint.host() end)
 
     prefix =

--- a/lib/beacon/router.ex
+++ b/lib/beacon/router.ex
@@ -270,12 +270,7 @@ defmodule Beacon.Router do
   # match and invalidate the `beacon_site` mount.
   def reachable?(%Beacon.Config{} = config, opts \\ []) do
     %{site: site, endpoint: endpoint, router: router} = config
-
-    if function_exported?(router, :__beacon_scoped_prefix_for_site__, 1) do
-      reachable?(site, endpoint, router, opts)
-    else
-      false
-    end
+    function_exported?(router, :__beacon_scoped_prefix_for_site__, 1) && reachable?(site, endpoint, router, opts)
   end
 
   defp reachable?(site, endpoint, router, opts) do

--- a/test/beacon/registry_test.exs
+++ b/test/beacon/registry_test.exs
@@ -12,6 +12,7 @@ defmodule Beacon.RegistryTest do
              :lifecycle_test,
              :lifecycle_test_fail,
              :my_site,
+             :no_routes,
              :not_booted,
              :raw_schema_test,
              :s3_site

--- a/test/beacon/router_test.exs
+++ b/test/beacon/router_test.exs
@@ -86,5 +86,10 @@ defmodule Beacon.RouterTest do
     test "do not match any existing host/path", %{config: config} do
       refute Router.reachable?(config, host: nil, prefix: "/nested/invalid")
     end
+
+    test "router without beacon routes" do
+      config = Beacon.Config.fetch!(:no_routes)
+      refute Router.reachable?(config)
+    end
   end
 end

--- a/test/support/routers.ex
+++ b/test/support/routers.ex
@@ -1,3 +1,7 @@
+defmodule Beacon.BeaconTest.NoRoutesRouter do
+  use Beacon.BeaconTest.Web, :router
+end
+
 defmodule Beacon.BeaconTest.Router do
   use Beacon.BeaconTest.Web, :router
   use Beacon.Router

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -51,6 +51,13 @@ Supervisor.start_link(
          repo: Beacon.BeaconTest.Repo
        ],
        [
+         site: :no_routes,
+         mode: :testing,
+         endpoint: Beacon.BeaconTest.Endpoint,
+         router: Beacon.BeaconTest.NoRoutesRouter,
+         repo: Beacon.BeaconTest.Repo
+       ],
+       [
          site: :not_booted,
          mode: :testing,
          endpoint: Beacon.BeaconTest.Endpoint,


### PR DESCRIPTION
Starting a site in the sup tree is not enough, each site must have a corresponding route in the host app's router. But in some cases the route might be missing, which would lead to boot crashes.

Now we're guarding against such scenario and allowing Beacon to boot, but we emit a warning with a link to a troubleshot guide.