### PR TITLE
Fix variant roll changing when fetching assets

### DIFF
--- a/lib/beacon/plug.ex
+++ b/lib/beacon/plug.ex
@@ -21,5 +21,18 @@ defmodule Beacon.Plug do
   def init(_opts), do: []
 
   @impl Plug
-  def call(conn, _opts), do: Plug.Conn.put_session(conn, :beacon_variant_roll, Enum.random(1..100))
+  def call(conn, _opts) do
+    site =
+      case conn do
+        %{private: %{phoenix_live_view: {_page_live, _lv_opts, %{extra: %{session: %{"beacon_site" => site}}}}}} -> site
+        %{} -> nil
+      end
+
+    path_list = conn.path_params["path"]
+
+    case site && path_list && Beacon.RouterServer.lookup_page(site, path_list) do
+      nil -> conn
+      _page -> Plug.Conn.put_session(conn, "beacon_variant_roll", Enum.random(1..100))
+    end
+  end
 end

--- a/lib/beacon/web/live/page_live.ex
+++ b/lib/beacon/web/live/page_live.ex
@@ -23,8 +23,6 @@ defmodule Beacon.Web.PageLive do
       :ok = Beacon.PubSub.subscribe_to_page(site, path)
     end
 
-    page = RouterServer.lookup_page!(site, path)
-
     variant_roll =
       case session["beacon_variant_roll"] do
         nil ->
@@ -40,6 +38,7 @@ defmodule Beacon.Web.PageLive do
           roll
       end
 
+    page = RouterServer.lookup_page!(site, path)
     socket = Component.assign(socket, beacon: BeaconAssigns.new(site, page, variant_roll))
 
     {:ok, socket, layout: {Beacon.Web.Layouts, :dynamic}}

--- a/lib/beacon/web/live/page_live.ex
+++ b/lib/beacon/web/live/page_live.ex
@@ -23,6 +23,8 @@ defmodule Beacon.Web.PageLive do
       :ok = Beacon.PubSub.subscribe_to_page(site, path)
     end
 
+    page = RouterServer.lookup_page!(site, path)
+
     variant_roll =
       case session["beacon_variant_roll"] do
         nil ->
@@ -38,7 +40,6 @@ defmodule Beacon.Web.PageLive do
           roll
       end
 
-    page = RouterServer.lookup_page!(site, path)
     socket = Component.assign(socket, beacon: BeaconAssigns.new(site, page, variant_roll))
 
     {:ok, socket, layout: {Beacon.Web.Layouts, :dynamic}}


### PR DESCRIPTION
## Resolves #702 
If a page loads other assets which pass through the Beacon.Plug, those assets were re-rolling the page variant, which caused the live render to sometimes have a different variant than the dead render (especially when response time is slower).

This PR only allows the initial page request to roll a variant, all other requests passing through that Plug will leave the variant session data untouched.