### PR TITLE
fix: load visual editor on new pages

### DIFF
--- a/lib/beacon/router.ex
+++ b/lib/beacon/router.ex
@@ -250,6 +250,8 @@ defmodule Beacon.Router do
     end)
   end
 
+  def path_params(_page_path, _path_info), do: %{}
+
   @doc false
   # Tells if a `beacon_site` is reachable in the current environment.
   #

--- a/lib/beacon/template.ex
+++ b/lib/beacon/template.ex
@@ -27,8 +27,8 @@ defmodule Beacon.Template do
 
       page ->
         page_module = Beacon.Loader.fetch_page_module(page.site, page.id)
-        live_data = Beacon.Web.DataSource.live_data(site, path_info)
-        beacon_assigns = BeaconAssigns.new(site, page, live_data, path_info, query_params, :beacon)
+        live_data = Beacon.Web.DataSource.live_data(site, path_info, query_params)
+        beacon_assigns = BeaconAssigns.new(page, path_info: path_info, query_params: query_params)
         assigns = Map.put(live_data, :beacon, beacon_assigns)
         env = Beacon.Web.PageLive.make_env(site)
 

--- a/lib/beacon/web/beacon_assigns.ex
+++ b/lib/beacon/web/beacon_assigns.ex
@@ -74,7 +74,7 @@ defmodule Beacon.Web.BeaconAssigns do
     page_module = Beacon.Loader.Page.module_name(site, page.id)
     live_data = Beacon.Web.DataSource.live_data(site, path_info, Map.drop(query_params, ["path"]))
     path_params = Beacon.Router.path_params(page.path, path_info)
-    page_title = Beacon.Web.DataSource.page_title(site, page.id, live_data, source)
+    page_title = Beacon.Web.DataSource.page_title(site, page, live_data, source)
     components_module = Beacon.Loader.Components.module_name(site)
     info_handlers_module = Beacon.Loader.InfoHandlers.module_name(site)
     event_handlers_module = Beacon.Loader.EventHandlers.module_name(site)

--- a/lib/beacon/web/beacon_assigns.ex
+++ b/lib/beacon/web/beacon_assigns.ex
@@ -33,8 +33,8 @@ defmodule Beacon.Web.BeaconAssigns do
         }
 
   defstruct site: nil,
-            path_params: %{},
-            query_params: %{},
+            path_params: nil,
+            query_params: nil,
             page: %{path: nil, title: nil},
             private: %{
               page_module: nil,
@@ -53,31 +53,18 @@ defmodule Beacon.Web.BeaconAssigns do
   end
 
   @doc false
-  def new(site, %Beacon.Content.Page{} = page, variant_roll) do
-    components_module = Beacon.Loader.Components.module_name(site)
-    page_module = Beacon.Loader.Page.module_name(site, page.id)
+  def new(%Beacon.Content.Page{} = page, metadata \\ []) do
+    path_info = Keyword.get(metadata, :path_info, [])
+    query_params = Keyword.get(metadata, :query_params, %{})
+    variant_roll = Keyword.get(metadata, :variant_roll, nil)
 
-    %__MODULE__{
-      site: site,
-      private: %{
-        components_module: components_module,
-        page_module: page_module,
-        variant_roll: variant_roll
-      }
-    }
-  end
-
-  @doc false
-  def new(site, %Beacon.Content.Page{} = page, live_data, path_info, query_params, source, variant_roll \\ nil)
-      when is_atom(site) and is_map(live_data) and is_list(path_info) and is_map(query_params) and source in [:beacon, :admin] do
-    %{site: ^site} = page
-    page_module = Beacon.Loader.Page.module_name(site, page.id)
-    live_data = Beacon.Web.DataSource.live_data(site, path_info, Map.drop(query_params, ["path"]))
+    page_module = Beacon.Loader.Page.module_name(page.site, page.id)
+    live_data = Beacon.Web.DataSource.live_data(page.site, path_info, Map.drop(query_params, ["path"]))
     path_params = Beacon.Router.path_params(page.path, path_info)
-    page_title = Beacon.Web.DataSource.page_title(site, page, live_data, source)
-    components_module = Beacon.Loader.Components.module_name(site)
-    info_handlers_module = Beacon.Loader.InfoHandlers.module_name(site)
-    event_handlers_module = Beacon.Loader.EventHandlers.module_name(site)
+    page_title = Beacon.Web.DataSource.page_title(page, live_data)
+    components_module = Beacon.Loader.Components.module_name(page.site)
+    info_handlers_module = Beacon.Loader.InfoHandlers.module_name(page.site)
+    event_handlers_module = Beacon.Loader.EventHandlers.module_name(page.site)
 
     %__MODULE__{
       site: page.site,
@@ -94,24 +81,5 @@ defmodule Beacon.Web.BeaconAssigns do
         variant_roll: variant_roll
       }
     }
-  end
-
-  @doc false
-  def update(_socket_or_assigns, _key, _value)
-
-  def update(%{assigns: %{beacon: _beacon}} = socket, key, value) do
-    do_update_socket_or_assigns(socket, key, value)
-  end
-
-  def update(%{beacon: _beacon} = assigns, key, value) do
-    do_update_socket_or_assigns(assigns, key, value)
-  end
-
-  def update(_socket_or_assigns, _key, _value), do: raise("expected :beacon assign in socket but none found")
-
-  defp do_update_socket_or_assigns(socket_or_assigns, key, value) do
-    Phoenix.Component.update(socket_or_assigns, :beacon, fn beacon ->
-      Map.put(beacon, key, value)
-    end)
   end
 end

--- a/lib/beacon/web/controllers/api/page_json.ex
+++ b/lib/beacon/web/controllers/api/page_json.ex
@@ -23,7 +23,7 @@ defmodule Beacon.Web.API.PageJSON do
   defp data(%Page{} = page) do
     path_info = for segment <- String.split(page.path, "/"), segment != "", do: segment
     live_data = Beacon.Web.DataSource.live_data(page.site, path_info, %{})
-    beacon_assigns = BeaconAssigns.new(page.site, page, live_data, path_info, %{}, :admin)
+    beacon_assigns = BeaconAssigns.new(page, path_info: path_info)
 
     assigns =
       live_data

--- a/lib/beacon/web/data_source.ex
+++ b/lib/beacon/web/data_source.ex
@@ -3,12 +3,14 @@ defmodule Beacon.Web.DataSource do
 
   require Logger
 
-  def live_data(site, path_info, params \\ %{}) when is_atom(site) and is_list(path_info) and is_map(params) do
-    Beacon.apply_mfa(site, Beacon.Loader.fetch_live_data_module(site), :live_data, [path_info, params])
+  def live_data(site, path_info, query_params) when is_atom(site) and is_list(path_info) and is_map(query_params) do
+    Beacon.apply_mfa(site, Beacon.Loader.fetch_live_data_module(site), :live_data, [path_info, query_params])
   end
 
-  def page_title(site, page, live_data, source) do
-    %{path: path, title: title} = page_assigns = page_assigns(site, page, source)
+  def live_data(_site, _path_info, _query_params), do: %{}
+
+  def page_title(%Beacon.Content.Page{} = page, live_data) do
+    %{path: path, title: title} = page_assigns = page_assigns(page)
 
     with {:ok, page_title} <- Beacon.Content.render_snippet(title, %{page: page_assigns, live_data: live_data}) do
       page_title
@@ -19,7 +21,7 @@ defmodule Beacon.Web.DataSource do
 
         will return the original unmodified page title
 
-        site: #{site}
+        site: #{page.site}
         title: #{title}
         page path: #{path}
 
@@ -36,13 +38,14 @@ defmodule Beacon.Web.DataSource do
   # TODO: revisit this logic to evaluate meta_tags for unpublished pages
   def meta_tags(assigns) do
     %{beacon: %{site: site, private: %{page_module: page_module, live_data_keys: live_data_keys}}} = assigns
-    %{site: ^site, id: page_id} = Beacon.apply_mfa(site, page_module, :page_assigns, [[:site, :id]])
+    %{site: ^site} = page_assigns = Beacon.apply_mfa(site, page_module, :page_assigns, [])
+
     live_data = Map.take(assigns, live_data_keys)
 
     assigns
     |> Beacon.Web.Layouts.meta_tags()
     |> List.wrap()
-    |> Enum.map(&interpolate_meta_tag(&1, %{page: page_assigns(site, page_id, :beacon), live_data: live_data}))
+    |> Enum.map(&interpolate_meta_tag(&1, %{page: page_assigns, live_data: live_data}))
   end
 
   defp interpolate_meta_tag(meta_tag, values) when is_map(meta_tag) do
@@ -57,16 +60,21 @@ defmodule Beacon.Web.DataSource do
     end
   end
 
-  # only published pages will have the title evaluated for beacon
-  defp page_assigns(site, page, :beacon) do
-    Beacon.apply_mfa(site, Beacon.Loader.fetch_page_module(site, page.id), :page_assigns, [])
+  # return the page assigns from unpublished page assigns,
+  # either saved in the database or page in-memory (for new pages)
+  # this fallback is here mostly to support  beacon_live_admin visual editor,
+  # which makes use of the `@beacon` assign when creating or editing pages
+  defp page_assigns(%Beacon.Content.Page{id: nil} = page) do
+    unpublished_page_assigns(page)
   end
 
-  # beacon_live_admin needs the title for unpublished pages also
-  defp page_assigns(site, page, :admin) do
-    # new pages are not yet in the database
-    page = if page.id, do: Beacon.Content.get_page(site, page.id), else: page
+  defp page_assigns(%Beacon.Content.Page{} = page) do
+    Beacon.apply_mfa(page.site, Beacon.Loader.fetch_page_module(page.site, page.id), :page_assigns, [])
+  rescue
+    _ -> unpublished_page_assigns(page)
+  end
 
+  defp unpublished_page_assigns(page) do
     %{
       id: page.id,
       site: page.site,

--- a/lib/beacon/web/data_source.ex
+++ b/lib/beacon/web/data_source.ex
@@ -7,8 +7,8 @@ defmodule Beacon.Web.DataSource do
     Beacon.apply_mfa(site, Beacon.Loader.fetch_live_data_module(site), :live_data, [path_info, params])
   end
 
-  def page_title(site, page_id, live_data, source) do
-    %{path: path, title: title} = page_assigns = page_assigns(site, page_id, source)
+  def page_title(site, page, live_data, source) do
+    %{path: path, title: title} = page_assigns = page_assigns(site, page, source)
 
     with {:ok, page_title} <- Beacon.Content.render_snippet(title, %{page: page_assigns, live_data: live_data}) do
       page_title
@@ -58,13 +58,14 @@ defmodule Beacon.Web.DataSource do
   end
 
   # only published pages will have the title evaluated for beacon
-  defp page_assigns(site, page_id, :beacon) do
-    Beacon.apply_mfa(site, Beacon.Loader.fetch_page_module(site, page_id), :page_assigns, [])
+  defp page_assigns(site, page, :beacon) do
+    Beacon.apply_mfa(site, Beacon.Loader.fetch_page_module(site, page.id), :page_assigns, [])
   end
 
   # beacon_live_admin needs the title for unpublished pages also
-  defp page_assigns(site, page_id, :admin) do
-    page = Beacon.Content.get_page(site, page_id)
+  defp page_assigns(site, page, :admin) do
+    # new pages are not yet in the database
+    page = if page.id, do: Beacon.Content.get_page(site, page.id), else: page
 
     %{
       id: page.id,

--- a/test/beacon_web/data_source_test.exs
+++ b/test/beacon_web/data_source_test.exs
@@ -24,12 +24,12 @@ defmodule Beacon.Web.DataSourceTest do
   describe "page_title" do
     test "renders static content", %{site: site} do
       page = beacon_published_page_fixture(site: site, title: "my title")
-      assert DataSource.page_title(page.site, page.id, %{}, :beacon) == "my title"
+      assert DataSource.page_title(page, %{}) == "my title"
     end
 
     test "renders snippet", %{site: site} do
       page = beacon_published_page_fixture(site: site, title: "{{ page.path | upcase }}")
-      assert DataSource.page_title(page.site, page.id, %{}, :beacon) == "/HOME"
+      assert DataSource.page_title(page, %{}) == "/HOME"
     end
   end
 end


### PR DESCRIPTION
`Beacon.Content.get_page/2` fails since there's no page saved yet. This PR also simplified a few things:

- Simplify the build of a new `@beacon` assign
- Make the arguments more explicit
- Remove the `source` arg so callers don't need to be responsible for how the assign is built