### PR TITLE
Fix media uploads in multi node deployments

### DIFF
--- a/lib/beacon/loader/worker.ex
+++ b/lib/beacon/loader/worker.ex
@@ -44,6 +44,7 @@ defmodule Beacon.Loader.Worker do
         Beacon.MediaLibrary.UploadMetadata.new(
           site,
           path,
+          Node.self(),
           name: "beacon.png",
           extra: %{"alt" => "logo"}
         )

--- a/lib/beacon/media_library/processors/default.ex
+++ b/lib/beacon/media_library/processors/default.ex
@@ -3,7 +3,7 @@ defmodule Beacon.MediaLibrary.Processors.Default do
   alias Beacon.MediaLibrary.UploadMetadata
 
   def process!(%UploadMetadata{} = metadata) do
-    output = File.read!(metadata.path)
+    output = Beacon.MediaLibrary.read_binary!(metadata)
 
     config = UploadMetadata.config_for_media_type(metadata, metadata.media_type)
 

--- a/lib/beacon/media_library/processors/image.ex
+++ b/lib/beacon/media_library/processors/image.ex
@@ -10,8 +10,9 @@ defmodule Beacon.MediaLibrary.Processors.Image do
     target_file_type = ".webp"
 
     output =
-      metadata.path
-      |> Image.open!(access: :random)
+      metadata
+      |> MediaLibrary.read_binary!()
+      |> Image.from_binary!(access: :random)
       |> Image.write!(:memory, suffix: target_file_type)
 
     name = rename_to_target_file_type(metadata.name, target_file_type)

--- a/lib/beacon/media_library/upload_metadata.ex
+++ b/lib/beacon/media_library/upload_metadata.ex
@@ -6,7 +6,7 @@ defmodule Beacon.MediaLibrary.UploadMetadata do
   alias Beacon.MediaLibrary.Asset
   alias Beacon.MediaTypes
 
-  defstruct [:site, :config, :allowed_media_accept_types, :path, :name, :media_type, :size, :output, :resource, :extra]
+  defstruct [:site, :config, :allowed_media_accept_types, :path, :name, :media_type, :size, :output, :resource, :node, :extra]
 
   @type t :: %__MODULE__{
           site: Beacon.Types.Site.t(),
@@ -18,12 +18,13 @@ defmodule Beacon.MediaLibrary.UploadMetadata do
           size: integer() | nil,
           output: any(),
           resource: Ecto.Changeset.t(%Asset{}),
+          node: Node.t(),
           extra: map() | nil
         }
 
   # TODO: https://github.com/BeaconCMS/beacon/pull/239#discussion_r1194160478
   @doc false
-  def new(site, path, opts \\ []) do
+  def new(site, path, node, opts \\ []) do
     opts =
       Keyword.reject(opts, fn
         {_, ""} -> true
@@ -40,7 +41,7 @@ defmodule Beacon.MediaLibrary.UploadMetadata do
 
     size =
       Keyword.get_lazy(opts, :size, fn ->
-        case File.stat(path) do
+        case Beacon.MediaLibrary.file_stat(path, node) do
           {:ok, stat} -> stat.size
           _ -> nil
         end
@@ -60,6 +61,7 @@ defmodule Beacon.MediaLibrary.UploadMetadata do
       size: size,
       output: output,
       resource: resource,
+      node: node,
       extra: extra
     }
   end

--- a/lib/beacon/test/fixtures.ex
+++ b/lib/beacon/test/fixtures.ex
@@ -368,7 +368,7 @@ defmodule Beacon.Test.Fixtures do
 
     attrs = Map.put_new(attrs, :file_path, path_for(attrs.file_name))
 
-    UploadMetadata.new(attrs.site, attrs.file_path, name: attrs.file_name, size: attrs.file_size, extra: attrs.extra)
+    UploadMetadata.new(attrs.site, attrs.file_path, Node.self(), name: attrs.file_name, size: attrs.file_size, extra: attrs.extra)
   end
 
   defp path_for(file_name) do


### PR DESCRIPTION
## Resolves #709 

UploadMetadata will now hold a `:node` along with the `:path` of the file.  This ensures that in a multi-node setup, we are looking on the appropriate node when reading the file.