### PR TITLE
fix: make `node` in `UploadMetadata.new` optional

### DIFF
--- a/lib/beacon/loader/worker.ex
+++ b/lib/beacon/loader/worker.ex
@@ -44,7 +44,6 @@ defmodule Beacon.Loader.Worker do
         Beacon.MediaLibrary.UploadMetadata.new(
           site,
           path,
-          Node.self(),
           name: "beacon.png",
           extra: %{"alt" => "logo"}
         )

--- a/lib/beacon/media_library/upload_metadata.ex
+++ b/lib/beacon/media_library/upload_metadata.ex
@@ -24,7 +24,7 @@ defmodule Beacon.MediaLibrary.UploadMetadata do
 
   # TODO: https://github.com/BeaconCMS/beacon/pull/239#discussion_r1194160478
   @doc false
-  def new(site, path, node, opts \\ []) do
+  def new(site, path,  opts \\ []) do
     opts =
       Keyword.reject(opts, fn
         {_, ""} -> true
@@ -33,6 +33,7 @@ defmodule Beacon.MediaLibrary.UploadMetadata do
 
     config = Beacon.Config.fetch!(site)
     name = Keyword.get(opts, :name, Path.basename(path))
+    node = opts[:node] || Node.self()
 
     media_type =
       opts

--- a/lib/beacon/media_library/upload_metadata.ex
+++ b/lib/beacon/media_library/upload_metadata.ex
@@ -24,7 +24,7 @@ defmodule Beacon.MediaLibrary.UploadMetadata do
 
   # TODO: https://github.com/BeaconCMS/beacon/pull/239#discussion_r1194160478
   @doc false
-  def new(site, path,  opts \\ []) do
+  def new(site, path, opts \\ []) do
     opts =
       Keyword.reject(opts, fn
         {_, ""} -> true

--- a/lib/beacon/test/fixtures.ex
+++ b/lib/beacon/test/fixtures.ex
@@ -368,7 +368,7 @@ defmodule Beacon.Test.Fixtures do
 
     attrs = Map.put_new(attrs, :file_path, path_for(attrs.file_name))
 
-    UploadMetadata.new(attrs.site, attrs.file_path, Node.self(), name: attrs.file_name, size: attrs.file_size, extra: attrs.extra)
+    UploadMetadata.new(attrs.site, attrs.file_path, name: attrs.file_name, size: attrs.file_size, extra: attrs.extra)
   end
 
   defp path_for(file_name) do


### PR DESCRIPTION
So it doesn't introduce breaking changes and also doesn't require consumers/clients to pass it, unless they need to, since the default is `Node.self()`