### PR TITLE
feat: always generate site endpoints

### DIFF
--- a/lib/beacon/loader/routes.ex
+++ b/lib/beacon/loader/routes.ex
@@ -60,6 +60,11 @@ defmodule Beacon.Loader.Routes do
 
         @doc """
         Returns the full public-facing site URL, including the prefix.
+
+        Scheme and port are fetched from the Proxy Endpoint, if available,
+        since that's the entry point for all requests.
+
+        Host is fetched from the site endpoint.
         """
         def public_site_url do
           uri =
@@ -86,6 +91,7 @@ defmodule Beacon.Loader.Routes do
           public_site_url() <> "/__beacon_assets__/css_config"
         end
 
+        # TODO: remove sanitize_path/1
         defp sanitize_path(path) do
           String.replace(path, "//", "/")
         end

--- a/lib/beacon/loader/routes.ex
+++ b/lib/beacon/loader/routes.ex
@@ -53,9 +53,8 @@ defmodule Beacon.Loader.Routes do
         end
 
         def public_site_host do
-          @site
-          |> Beacon.ProxyEndpoint.public_uri()
-          |> String.Chars.URI.to_string()
+          uri = Beacon.ProxyEndpoint.public_uri(@site)
+          String.Chars.URI.to_string(%URI{scheme: uri.scheme, host: uri.host, port: uri.port})
         end
 
         @doc """
@@ -68,9 +67,10 @@ defmodule Beacon.Loader.Routes do
         """
         def public_site_url do
           uri =
-            case @router.__beacon_scoped_prefix_for_site__(@site) do
-              "/" -> Beacon.ProxyEndpoint.public_uri(@site)
-              prefix -> %{Beacon.ProxyEndpoint.public_uri(@site) | path: prefix}
+            case Beacon.ProxyEndpoint.public_uri(@site) do
+              # remove path: "/"  to build URL without the / suffix
+              %{path: "/"} = uri -> %{uri | path: nil}
+              uri -> uri
             end
 
           String.Chars.URI.to_string(uri)

--- a/lib/beacon/loader/routes.ex
+++ b/lib/beacon/loader/routes.ex
@@ -79,7 +79,7 @@ defmodule Beacon.Loader.Routes do
         def public_page_url(%{site: site} = page) do
           site == @site || raise Beacon.RuntimeError, message: "failed to generate public page url "
           prefix = @router.__beacon_scoped_prefix_for_site__(@site)
-          path = sanitize_path("#{prefix}/#{page.path}")
+          path = sanitize_path("#{prefix}#{page.path}")
           String.Chars.URI.to_string(%{Beacon.ProxyEndpoint.public_uri(@site) | path: path})
         end
 

--- a/lib/beacon/private.ex
+++ b/lib/beacon/private.ex
@@ -70,4 +70,6 @@ defmodule Beacon.Private do
   # https://github.com/phoenixframework/phoenix/blob/4ebefb9d1f710c576f08c517f5852498dd9b935c/lib/phoenix/endpoint/supervisor.ex#L301-L302
   defp host_to_binary({:system, env_var}), do: host_to_binary(System.get_env(env_var))
   defp host_to_binary(host), do: host
+
+  def router(%{private: %{phoenix_router: router}}), do: router
 end

--- a/lib/beacon/proxy_endpoint.ex
+++ b/lib/beacon/proxy_endpoint.ex
@@ -1,6 +1,8 @@
 defmodule Beacon.ProxyEndpoint do
   @moduledoc false
 
+  require Logger
+
   defmacro __using__(opts) do
     quote location: :keep, generated: true do
       otp_app = Keyword.get(unquote(opts), :otp_app) || raise Beacon.RuntimeError, "missing required option :otp_app in Beacon.ProxyEndpoint"
@@ -19,14 +21,7 @@ defmodule Beacon.ProxyEndpoint do
         websocket: [connect_info: [session: @session_options]],
         longpoll: [connect_info: [session: @session_options]]
 
-      plug :port
       plug :proxy
-
-      def port(conn, opts) do
-        IO.puts("port")
-        IO.inspect(conn)
-        conn
-      end
 
       # TODO: cache endpoint resolver
       def proxy(%{host: host} = conn, opts) do
@@ -85,4 +80,55 @@ defmodule Beacon.ProxyEndpoint do
       defp check_origin(_, _), do: false
     end
   end
+
+  # TODO: docs, spec, error handling
+
+  # https://github.com/phoenixframework/phoenix/blob/2614f2a0d95a3b4b745bdf88ccd9f3b7f6d5966a/lib/phoenix/endpoint/supervisor.ex#L386
+  # proxy is the public facing entrypoint, ie: scheme and port
+  # host is defined by the site endpoint, which is used to generate links
+  def public_uri(site) do
+    site_endpoint = Beacon.Config.fetch!(site).endpoint
+    proxy_endpoint = site_endpoint.proxy_endpoint()
+
+    proxy_url = proxy_endpoint.config(:url)
+    site_url = site_endpoint.config(:url)
+
+    https = proxy_endpoint.config(:https)
+    http = proxy_endpoint.config(:http)
+
+    {scheme, port} =
+      cond do
+        https -> {"https", https[:port] || 443}
+        http -> {"http", http[:port] || 80}
+        true -> {"http", 80}
+      end
+
+    scheme = proxy_url[:scheme] || scheme
+    host = host_to_binary(site_url[:host] || "localhost")
+    port = port_to_integer(proxy_url[:port] || port)
+
+    if host =~ ~r"[^:]:\d" do
+      Logger.warning("url: [host: ...] configuration value #{inspect(host)} for #{inspect(site_endpoint)} is invalid")
+    end
+
+    %URI{scheme: scheme, port: port, host: host}
+  end
+
+  @doc """
+  TODO
+  """
+  def public_url(site) do
+    site
+    |> public_uri()
+    |> String.Chars.URI.to_string()
+  end
+
+  # TODO: Remove the first function clause once {:system, env_var} tuples are removed
+  defp host_to_binary({:system, env_var}), do: host_to_binary(System.get_env(env_var))
+  defp host_to_binary(host), do: host
+
+  # TODO: Remove the first function clause once {:system, env_var} tuples are removed
+  defp port_to_integer({:system, env_var}), do: port_to_integer(System.get_env(env_var))
+  defp port_to_integer(port) when is_binary(port), do: String.to_integer(port)
+  defp port_to_integer(port) when is_integer(port), do: port
 end

--- a/lib/beacon/proxy_endpoint.ex
+++ b/lib/beacon/proxy_endpoint.ex
@@ -19,7 +19,14 @@ defmodule Beacon.ProxyEndpoint do
         websocket: [connect_info: [session: @session_options]],
         longpoll: [connect_info: [session: @session_options]]
 
+      plug :port
       plug :proxy
+
+      def port(conn, opts) do
+        IO.puts("port")
+        IO.inspect(conn)
+        conn
+      end
 
       # TODO: cache endpoint resolver
       def proxy(%{host: host} = conn, opts) do

--- a/lib/beacon/router.ex
+++ b/lib/beacon/router.ex
@@ -185,6 +185,9 @@ defmodule Beacon.Router do
   Then Beacon will reference both of those sitemaps in the top-level index:
     * `my_domain.com/sitemap_index.xml`
 
+  Note that `beacon_sitemap_index` will include the sitemap URL of all mounted sites
+  in the router, so that macro should be at the root and not duplicated.
+
   ## Requirements
 
   Note that your sitemap index cannot have a path which is "deeper" in the directory structure than

--- a/lib/beacon/runtime_css.ex
+++ b/lib/beacon/runtime_css.ex
@@ -31,11 +31,10 @@ defmodule Beacon.RuntimeCSS do
   @doc """
   Returns the URL to fetch the CSS config used to generate the site stylesheet.
   """
-  @spec asset_url(Site.t()) :: String.t()
-  def asset_url(site) do
-    %{endpoint: endpoint, router: router} = Beacon.Config.fetch!(site)
-    prefix = router.__beacon_scoped_prefix_for_site__(site)
-    endpoint.url() <> Beacon.Router.sanitize_path("#{prefix}/__beacon_assets__/css_config")
+  @spec css_config_url(Site.t()) :: String.t()
+  def css_config_url(site) do
+    routes_module = Beacon.Loader.fetch_routes_module(site)
+    Beacon.apply_mfa(site, routes_module, :public_css_config_url, [])
   end
 
   @doc false

--- a/lib/beacon/web/controllers/robots_controller.ex
+++ b/lib/beacon/web/controllers/robots_controller.ex
@@ -10,11 +10,11 @@ defmodule Beacon.Web.RobotsController do
     |> put_view(Beacon.Web.RobotsTxt)
     |> put_resp_content_type("text/txt")
     |> put_resp_header("cache-control", "public max-age=300")
-    |> render(:robots, sitemap_url: get_sitemap_url(conn, site))
+    |> render(:robots, sitemap_url: get_sitemap_url(site))
   end
 
-  defp get_sitemap_url(conn, site) do
+  defp get_sitemap_url(site) do
     routes_module = Beacon.Loader.fetch_routes_module(site)
-    Beacon.apply_mfa(site, routes_module, :beacon_sitemap_url, [conn])
+    Beacon.apply_mfa(site, routes_module, :public_sitemap_url, [])
   end
 end

--- a/lib/beacon/web/controllers/sitemap_controller.ex
+++ b/lib/beacon/web/controllers/sitemap_controller.ex
@@ -5,44 +5,43 @@ defmodule Beacon.Web.SitemapController do
   def init(action) when action in [:index, :show], do: action
 
   def call(conn, :index) do
+    sites = Beacon.Private.router(conn).__beacon_sites__
+
     conn
     |> accepts(["xml"])
     |> put_view(Beacon.Web.SitemapXML)
     |> put_resp_content_type("text/xml")
     |> put_resp_header("cache-control", "public max-age=300")
-    |> render(:sitemap_index, urls: get_sitemap_urls(conn))
+    |> render(:sitemap_index, urls: get_sitemap_urls(sites))
   end
 
   def call(%{assigns: %{site: site}} = conn, :show) do
-    IO.puts("sitemap.xml")
-    IO.inspect(conn)
-
     conn
     |> accepts(["xml"])
     |> put_view(Beacon.Web.SitemapXML)
     |> put_resp_content_type("text/xml")
     |> put_resp_header("cache-control", "public max-age=300")
-    |> render(:sitemap, pages: get_pages(conn, site))
+    |> render(:sitemap, pages: get_pages(site))
   end
 
-  defp get_sitemap_urls(conn) do
-    Beacon.Registry.running_sites()
-    |> Enum.map(fn site ->
+  defp get_sitemap_urls(sites) do
+    sites
+    |> Enum.map(fn {site, _} ->
       routes_module = Beacon.Loader.fetch_routes_module(site)
-      Beacon.apply_mfa(site, routes_module, :beacon_sitemap_url, [conn])
+      Beacon.apply_mfa(site, routes_module, :public_sitemap_url, [])
     end)
     |> Enum.reject(&is_nil/1)
     |> Enum.sort()
   end
 
-  defp get_pages(conn, site) do
+  defp get_pages(site) do
     routes_module = Beacon.Loader.fetch_routes_module(site)
 
     site
     |> Beacon.Content.list_published_pages()
     |> Enum.map(fn page ->
       %{
-        loc: Beacon.apply_mfa(site, routes_module, :beacon_page_url, [conn, page]),
+        loc: Beacon.apply_mfa(site, routes_module, :public_page_url, [page]),
         lastmod: DateTime.to_iso8601(page.updated_at)
       }
     end)

--- a/lib/beacon/web/controllers/sitemap_controller.ex
+++ b/lib/beacon/web/controllers/sitemap_controller.ex
@@ -5,7 +5,7 @@ defmodule Beacon.Web.SitemapController do
   def init(action) when action in [:index, :show], do: action
 
   def call(conn, :index) do
-    sites = Beacon.Private.router(conn).__beacon_sites__
+    sites = Beacon.Private.router(conn).__beacon_sites__()
 
     conn
     |> accepts(["xml"])

--- a/lib/beacon/web/controllers/sitemap_controller.ex
+++ b/lib/beacon/web/controllers/sitemap_controller.ex
@@ -14,6 +14,8 @@ defmodule Beacon.Web.SitemapController do
   end
 
   def call(%{assigns: %{site: site}} = conn, :show) do
+    IO.inspect(conn)
+
     conn
     |> accepts(["xml"])
     |> put_view(Beacon.Web.SitemapXML)

--- a/lib/beacon/web/controllers/sitemap_controller.ex
+++ b/lib/beacon/web/controllers/sitemap_controller.ex
@@ -14,6 +14,7 @@ defmodule Beacon.Web.SitemapController do
   end
 
   def call(%{assigns: %{site: site}} = conn, :show) do
+    IO.puts("sitemap.xml")
     IO.inspect(conn)
 
     conn

--- a/lib/beacon/web/sitemap/sitemap_index.xml.eex
+++ b/lib/beacon/web/sitemap/sitemap_index.xml.eex
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <%= for url <- @urls do %><sitemap>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><%= for url <- @urls do %>
+  <sitemap>
     <loc><%= url %></loc>
   </sitemap><% end %>
 </sitemapindex>

--- a/lib/mix/tasks/beacon.gen.proxy_endpoint.ex
+++ b/lib/mix/tasks/beacon.gen.proxy_endpoint.ex
@@ -50,7 +50,7 @@ defmodule Mix.Tasks.Beacon.Gen.ProxyEndpoint do
 
     case Igniter.Project.Module.module_exists(igniter, proxy_endpoint_module_name) do
       {true, igniter} ->
-        Igniter.add_notice(igniter, """
+        Igniter.add_warning(igniter, """
         Module #{inspect(proxy_endpoint_module_name)} already exists. Skipping.
         """)
 

--- a/lib/mix/tasks/beacon.gen.site.ex
+++ b/lib/mix/tasks/beacon.gen.site.ex
@@ -470,7 +470,8 @@ defmodule Mix.Tasks.Beacon.Gen.Site do
     |> Kernel.<>("Endpoint")
   end
 
-  defp new_endpoint_module!(igniter, site) when is_atom(site) do
+  @doc false
+  def new_endpoint_module!(igniter, site) when is_atom(site) do
     suffix = new_endpoint_module!(site)
     Igniter.Libs.Phoenix.web_module_name(igniter, suffix)
   end

--- a/lib/mix/tasks/beacon.gen.site.ex
+++ b/lib/mix/tasks/beacon.gen.site.ex
@@ -406,7 +406,7 @@ defmodule Mix.Tasks.Beacon.Gen.Site do
           end)
       )
     )
-    |> Igniter.Project.Config.configure_runtime_env(:prod, otp_app, [new_endpoint, :url, :host], host)
+    |> configure_runtime_env_host(otp_app, new_endpoint, host)
     |> Igniter.Project.Config.configure_runtime_env(:prod, otp_app, [new_endpoint, :url, :port], secure_port)
     |> Igniter.Project.Config.configure_runtime_env(:prod, otp_app, [new_endpoint, :url, :scheme], "https")
     |> Igniter.Project.Config.configure_runtime_env(
@@ -427,6 +427,14 @@ defmodule Mix.Tasks.Beacon.Gen.Site do
       [new_endpoint, :server],
       {:code, Sourceror.parse_string!("!!System.get_env(\"PHX_SERVER\")")}
     )
+  end
+
+  def configure_runtime_env_host(igniter, otp_app, new_endpoint, nil = _host) do
+    Igniter.Project.Config.configure_runtime_env(igniter, :prod, otp_app, [new_endpoint, :url, :host], {:code, Sourceror.parse_string!("host")})
+  end
+
+  def configure_runtime_env_host(igniter, otp_app, new_endpoint, host) do
+    Igniter.Project.Config.configure_runtime_env(igniter, :prod, otp_app, [new_endpoint, :url, :host], host)
   end
 
   defp maybe_update_existing_endpoints(igniter, nil, _, _), do: igniter

--- a/lib/mix/tasks/beacon.gen.site.ex
+++ b/lib/mix/tasks/beacon.gen.site.ex
@@ -346,8 +346,7 @@ defmodule Mix.Tasks.Beacon.Gen.Site do
 
   defp configure_new_endpoint(igniter, site, host, otp_app, port, secure_port) do
     new_endpoint = new_endpoint_module!(igniter, site)
-    error_html = Igniter.Libs.Phoenix.web_module_name(igniter, "ErrorHTML")
-    error_json = Igniter.Libs.Phoenix.web_module_name(igniter, "ErrorJSON")
+    error_html = "Beacon.Web.ErrorHTML"
     pubsub = Igniter.Project.Module.module_name(igniter, "PubSub")
 
     # TODO: replace the first two steps with `configure/6` once the `:after` option is allowed
@@ -368,7 +367,7 @@ defmodule Mix.Tasks.Beacon.Gen.Site do
                  url: [host: "localhost"],
                  adapter: Bandit.PhoenixAdapter,
                  render_errors: [
-                   formats: [html: #{inspect(error_html)}, json: #{inspect(error_json)}],
+                   formats: [html: #{error_html}],
                    layout: false
                  ],
                  pubsub_server: #{inspect(pubsub)},

--- a/lib/mix/tasks/beacon.gen.site.ex
+++ b/lib/mix/tasks/beacon.gen.site.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Beacon.Gen.Site do
 
   * `--site` (required) - The name of your site. Should not contain special characters nor start with "beacon_"
   * `--path` (optional) - Where your site will be mounted. Follows the same convention as Phoenix route prefixes. Defaults to `"/"`
-  * `--host` (optional) - If provided, a new endpoint will be created for this site with the given URL.
+  * `--host` (optional) - If provided, site will be served on that host.
   * `--port` (optional) - The port to use for http requests. Only needed when `--host` is provided.  If no port is given, one will be chosen at random.
   * `--secure-port` (optional) - The port to use for https requests. Only needed when `--host` is provided.  If no port is given, one will be chosen at random.
   * `--secret-key-base` (optional) - The value to use for secret_key_base in your app config.
@@ -80,14 +80,14 @@ defmodule Mix.Tasks.Beacon.Gen.Site do
     |> add_use_beacon_in_router(router)
     |> add_beacon_pipeline_in_router(router)
     |> mount_site_in_router(router, site, path, host)
-    |> add_site_config_in_config_runtime(site, repo, router, host)
+    |> add_site_config_in_config_runtime(site, repo, router)
     |> add_beacon_config_in_app_supervisor(site, repo)
-    |> maybe_create_proxy_endpoint(host, argv)
-    |> maybe_create_new_endpoint(host, otp_app, web_module)
-    |> maybe_configure_new_endpoint(host, otp_app, port, secure_port)
+    |> create_proxy_endpoint(argv)
+    |> create_new_endpoint(site, otp_app, web_module)
+    |> configure_new_endpoint(site, host, otp_app, port, secure_port)
     |> maybe_update_existing_endpoints(host, otp_app, existing_endpoints)
     |> maybe_update_session_options(host, otp_app)
-    |> maybe_add_new_endpoint_to_application(host, repo)
+    |> add_new_endpoint_to_application(site, repo)
     |> Igniter.add_notice("""
     Site #{inspect(site)} generated successfully.
 
@@ -236,12 +236,8 @@ defmodule Mix.Tasks.Beacon.Gen.Site do
     end
   end
 
-  defp add_site_config_in_config_runtime(igniter, site, repo, router, host) do
-    {igniter, endpoint} =
-      case host do
-        nil -> Beacon.Igniter.select_endpoint!(igniter, router)
-        host -> {igniter, new_endpoint_module!(igniter, host)}
-      end
+  defp add_site_config_in_config_runtime(igniter, site, repo, router) do
+    endpoint = new_endpoint_module!(igniter, site)
 
     Igniter.Project.Config.configure(
       igniter,
@@ -295,21 +291,20 @@ defmodule Mix.Tasks.Beacon.Gen.Site do
     )
   end
 
-  defp maybe_create_proxy_endpoint(igniter, nil, _argv), do: igniter
+  defp create_proxy_endpoint(igniter, argv), do: Igniter.compose_task(igniter, "beacon.gen.proxy_endpoint", argv)
 
-  defp maybe_create_proxy_endpoint(igniter, _host, argv),
-    do: Igniter.compose_task(igniter, "beacon.gen.proxy_endpoint", argv)
+  defp create_new_endpoint(igniter, site, otp_app, web_module) do
+    proxy_endpoint_module_name = Igniter.Libs.Phoenix.web_module_name(igniter, "ProxyEndpoint")
 
-  defp maybe_create_new_endpoint(igniter, nil, _, _), do: igniter
-
-  defp maybe_create_new_endpoint(igniter, host, otp_app, web_module) do
     Igniter.Project.Module.create_module(
       igniter,
-      new_endpoint_module!(igniter, host),
+      new_endpoint_module!(igniter, site),
       """
       use Phoenix.Endpoint, otp_app: #{inspect(otp_app)}
 
       @session_options Application.compile_env!(#{inspect(otp_app)}, :session_options)
+
+      def proxy_endpoint, do: #{inspect(proxy_endpoint_module_name)}
 
       # socket /live must be in the proxy endpoint
 
@@ -349,10 +344,8 @@ defmodule Mix.Tasks.Beacon.Gen.Site do
     )
   end
 
-  defp maybe_configure_new_endpoint(igniter, nil, _, _, _), do: igniter
-
-  defp maybe_configure_new_endpoint(igniter, host, otp_app, port, secure_port) do
-    new_endpoint = new_endpoint_module!(igniter, host)
+  defp configure_new_endpoint(igniter, site, host, otp_app, port, secure_port) do
+    new_endpoint = new_endpoint_module!(igniter, site)
     error_html = Igniter.Libs.Phoenix.web_module_name(igniter, "ErrorHTML")
     error_json = Igniter.Libs.Phoenix.web_module_name(igniter, "ErrorJSON")
     pubsub = Igniter.Project.Module.module_name(igniter, "PubSub")
@@ -464,21 +457,21 @@ defmodule Mix.Tasks.Beacon.Gen.Site do
     )
   end
 
-  defp maybe_add_new_endpoint_to_application(igniter, nil, _), do: igniter
-
-  defp maybe_add_new_endpoint_to_application(igniter, host, repo) do
-    Igniter.Project.Application.add_new_child(igniter, new_endpoint_module!(igniter, host), after: [repo, Phoenix.PubSub, Finch, Beacon])
+  defp add_new_endpoint_to_application(igniter, site, repo) do
+    Igniter.Project.Application.add_new_child(igniter, new_endpoint_module!(igniter, site), after: [repo, Phoenix.PubSub, Finch, Beacon])
   end
 
-  defp new_endpoint_module!(igniter, host) do
-    {:ok, prefix} = domain_prefix(host)
+  @doc false
+  def new_endpoint_module!(site) when is_atom(site) do
+    site
+    |> to_string()
+    |> String.split(~r/[^[:alnum:]]+/)
+    |> Enum.map_join("", &String.capitalize/1)
+    |> Kernel.<>("Endpoint")
+  end
 
-    suffix =
-      prefix
-      |> String.split(~r/[^[:alnum:]]+/)
-      |> Enum.map_join("", &String.capitalize/1)
-      |> Kernel.<>("Endpoint")
-
+  defp new_endpoint_module!(igniter, site) when is_atom(site) do
+    suffix = new_endpoint_module!(site)
     Igniter.Libs.Phoenix.web_module_name(igniter, suffix)
   end
 end

--- a/lib/mix/tasks/beacon.gen.tailwind_config.ex
+++ b/lib/mix/tasks/beacon.gen.tailwind_config.ex
@@ -34,8 +34,7 @@ defmodule Mix.Tasks.Beacon.Gen.TailwindConfig do
     site = Keyword.fetch!(options, :site) |> String.to_atom()
 
     app_name = Igniter.Project.Application.app_name(igniter)
-    {igniter, router} = Beacon.Igniter.select_router!(igniter)
-    {igniter, endpoint} = Beacon.Igniter.select_endpoint!(igniter, router)
+    endpoint = Mix.Tasks.Beacon.Gen.Site.new_endpoint_module!(igniter, site)
 
     igniter
     |> create_tailwind_config()

--- a/test/beacon/loader/routes_test.exs
+++ b/test/beacon/loader/routes_test.exs
@@ -1,5 +1,5 @@
 defmodule Beacon.Loader.RoutesTest do
-  use Beacon.DataCase, async: true
+  use Beacon.Web.ConnCase, async: true
   use Beacon.Test
 
   Beacon.Loader.ensure_loaded!([:"Elixir.Beacon.Web.LiveRenderer.c55c9d9db8d6d8c4d34b4f249c20ed4e.Routes"], :s3_site)
@@ -11,6 +11,9 @@ defmodule Beacon.Loader.RoutesTest do
 
     defdelegate beacon_media_path(path), to: :"Elixir.Beacon.Web.LiveRenderer.c55c9d9db8d6d8c4d34b4f249c20ed4e.Routes"
     defdelegate beacon_media_url(path), to: :"Elixir.Beacon.Web.LiveRenderer.c55c9d9db8d6d8c4d34b4f249c20ed4e.Routes"
+    defdelegate public_site_url, to: :"Elixir.Beacon.Web.LiveRenderer.c55c9d9db8d6d8c4d34b4f249c20ed4e.Routes"
+    defdelegate public_page_url(page), to: :"Elixir.Beacon.Web.LiveRenderer.c55c9d9db8d6d8c4d34b4f249c20ed4e.Routes"
+    defdelegate public_sitemap_url, to: :"Elixir.Beacon.Web.LiveRenderer.c55c9d9db8d6d8c4d34b4f249c20ed4e.Routes"
 
     def path("/"), do: ~p"/"
     def path("/contact"), do: ~p"/contact"
@@ -26,7 +29,23 @@ defmodule Beacon.Loader.RoutesTest do
   end
 
   test "beacon_media_url" do
-    assert MyRoutes.beacon_media_url("logo.webp") == "http://localhost:4000/nested/media/__beacon_media__/logo.webp"
+    assert MyRoutes.beacon_media_url("logo.webp") == "http://localhost/nested/media/__beacon_media__/logo.webp"
+  end
+
+  test "public_site_url" do
+    assert MyRoutes.public_site_url() == "http://localhost/nested/media"
+  end
+
+  test "public_page_url" do
+    assert MyRoutes.public_page_url(%Beacon.Content.Page{site: :s3_site, path: "/"}) == "http://localhost/nested/media/"
+    assert MyRoutes.public_page_url(%Beacon.Content.Page{site: :s3_site, path: "/about"}) == "http://localhost/nested/media/about"
+  end
+
+  test "sitemap_index" do
+  end
+
+  test "public_sitemap_url" do
+    assert MyRoutes.public_sitemap_url() == "http://localhost/nested/media/sitemap.xml"
   end
 
   describe "sigil_p" do

--- a/test/beacon/media_library_test.exs
+++ b/test/beacon/media_library_test.exs
@@ -41,7 +41,7 @@ defmodule Beacon.MediaLibraryTest do
 
       metadata = beacon_upload_metadata_fixture(file_name: "image.png")
       assert %Asset{file_name: "image.webp", media_type: "image/webp"} = asset = MediaLibrary.upload(metadata)
-      assert "http://localhost:4000/__beacon_media__/image.webp" = MediaLibrary.url_for(asset)
+      assert "http://localhost/__beacon_media__/image.webp" = MediaLibrary.url_for(asset)
     end
   end
 

--- a/test/beacon_web/controllers/robots_controller_test.exs
+++ b/test/beacon_web/controllers/robots_controller_test.exs
@@ -7,7 +7,7 @@ defmodule Beacon.Web.RobotsControllerTest do
     assert response(conn, 200) == """
            # http://www.robotstxt.org
            User-agent: *
-           Sitemap: http://localhost:4000/sitemap.xml
+           Sitemap: http://localhost/sitemap.xml
            """
 
     assert response_content_type(conn, :txt) =~ "charset=utf-8"
@@ -18,7 +18,7 @@ defmodule Beacon.Web.RobotsControllerTest do
     assert response(conn, 200) == """
            # http://www.robotstxt.org
            User-agent: *
-           Sitemap: http://localhost:4000/other/sitemap.xml
+           Sitemap: http://localhost/other/sitemap.xml
            """
 
     assert response_content_type(conn, :txt) =~ "charset=utf-8"

--- a/test/beacon_web/controllers/sitemap_controller_test.exs
+++ b/test/beacon_web/controllers/sitemap_controller_test.exs
@@ -21,22 +21,26 @@ defmodule Beacon.Web.SitemapControllerTest do
     [site: site, layout: layout, page: page, routes: routes]
   end
 
-  test "index", %{conn: conn} do
+  test "index only includes sitemap of mounted sites", %{conn: conn} do
     conn = get(conn, "/sitemap_index.xml")
 
     assert response(conn, 200) == """
            <?xml version="1.0" encoding="UTF-8"?>
            <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
              <sitemap>
-               <loc>http://localhost:4000/nested/media/sitemap.xml</loc>
-             </sitemap><sitemap>
-               <loc>http://localhost:4000/nested/site/sitemap.xml</loc>
-             </sitemap><sitemap>
-               <loc>http://localhost:4000/other/sitemap.xml</loc>
-             </sitemap><sitemap>
-               <loc>http://localhost:4000/sitemap.xml</loc>
-             </sitemap><sitemap>
-               <loc>http://site_b.com:4000/sitemap.xml</loc>
+               <loc>http://localhost/nested/media/sitemap.xml</loc>
+             </sitemap>
+             <sitemap>
+               <loc>http://localhost/nested/site/sitemap.xml</loc>
+             </sitemap>
+             <sitemap>
+               <loc>http://localhost/other/sitemap.xml</loc>
+             </sitemap>
+             <sitemap>
+               <loc>http://localhost/sitemap.xml</loc>
+             </sitemap>
+             <sitemap>
+               <loc>http://site_b.com/sitemap.xml</loc>
              </sitemap>
            </sitemapindex>
            """
@@ -49,7 +53,7 @@ defmodule Beacon.Web.SitemapControllerTest do
            <?xml version="1.0" encoding="UTF-8"?>
            <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
                <url>
-                   <loc>#{routes.beacon_page_url(conn, page)}</loc>
+                   <loc>#{routes.public_page_url(page)}</loc>
                    <lastmod>#{DateTime.to_iso8601(page.updated_at)}</lastmod>
                </url>
            </urlset>

--- a/test/beacon_web/controllers/sitemap_controller_test.exs
+++ b/test/beacon_web/controllers/sitemap_controller_test.exs
@@ -16,9 +16,7 @@ defmodule Beacon.Web.SitemapControllerTest do
 
     page = beacon_published_page_fixture(site: site, path: "/foo", layout_id: layout.id)
 
-    routes = Beacon.Loader.fetch_routes_module(site)
-
-    [site: site, layout: layout, page: page, routes: routes]
+    [site: site, layout: layout, page: page]
   end
 
   test "index only includes sitemap of mounted sites", %{conn: conn} do
@@ -46,14 +44,14 @@ defmodule Beacon.Web.SitemapControllerTest do
            """
   end
 
-  test "show", %{conn: conn, page: page, routes: routes} do
+  test "show", %{conn: conn, page: page} do
     conn = get(conn, "/sitemap.xml")
 
     assert response(conn, 200) == """
            <?xml version="1.0" encoding="UTF-8"?>
            <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
                <url>
-                   <loc>#{routes.public_page_url(page)}</loc>
+                   <loc>http://localhost/foo</loc>
                    <lastmod>#{DateTime.to_iso8601(page.updated_at)}</lastmod>
                </url>
            </urlset>

--- a/test/mix/tasks/gen_site_test.exs
+++ b/test/mix/tasks/gen_site_test.exs
@@ -7,9 +7,8 @@ defmodule Mix.Tasks.Beacon.GenSiteTest do
   @port 4041
   @secure_port 8445
 
-  @opts_my_site ~w(--site my_site --path /)
-  @opts_other_site ~w(--site other --path /other)
-  @opts_host ~w(--site my_site --path / --host example.com --port #{@port} --secure-port #{@secure_port} --secret-key-base #{@secret_key_base} --signing-salt #{@signing_salt})
+  @opts_my_site ~w(--site my_site --path / --port #{@port} --secure-port #{@secure_port} --secret-key-base #{@secret_key_base} --signing-salt #{@signing_salt})
+  @opts_other_site ~w(--site other --path /other --port #{@port} --secure-port #{@secure_port} --secret-key-base #{@secret_key_base} --signing-salt #{@signing_salt})
 
   describe "options validation" do
     test "validates site" do
@@ -27,6 +26,12 @@ defmodule Mix.Tasks.Beacon.GenSiteTest do
         Igniter.compose_task(test_project(), "beacon.gen.site", ~w(--site my_site --path nil))
       end
     end
+
+    test "validates host" do
+      assert_raise Mix.Error, fn ->
+        Igniter.compose_task(test_project(), "beacon.gen.site", ~w(--site my_site --path / --host 1989))
+      end
+    end
   end
 
   test "do not duplicate files and configs" do
@@ -37,11 +42,11 @@ defmodule Mix.Tasks.Beacon.GenSiteTest do
     |> assert_unchanged()
   end
 
-  test "host option does not duplicate files and configs" do
+  test "do not duplicate files and configs with --host option" do
     phoenix_project()
-    |> Igniter.compose_task("beacon.gen.site", @opts_host)
+    |> Igniter.compose_task("beacon.gen.site", @opts_my_site ++ ~w(--host example.com))
     |> apply_igniter!()
-    |> Igniter.compose_task("beacon.gen.site", @opts_host)
+    |> Igniter.compose_task("beacon.gen.site", @opts_my_site ++ ~w(--host example.com))
     |> assert_unchanged()
   end
 
@@ -120,11 +125,80 @@ defmodule Mix.Tasks.Beacon.GenSiteTest do
       26 31   |  end
       """)
     end
+
+    test "--host option", %{project: project} do
+      project
+      |> Igniter.compose_task("beacon.gen.site", @opts_my_site ++ ~w(--host example.com))
+      |> assert_has_patch("lib/test_web/router.ex", """
+        23 + |  scope "/", alias: TestWeb, host: ["localhost", "example.com"] do
+        24 + |    pipe_through [:browser, :beacon]
+        25 + |    beacon_site "/", site: :my_site
+        26 + |  end
+        27 + |
+      """)
+    end
   end
 
   describe "config" do
     setup do
       [project: phoenix_project()]
+    end
+
+    test "updates config.exs", %{project: project} do
+      project
+      |> Igniter.compose_task("beacon.gen.site", @opts_my_site)
+      |> assert_has_patch("config/config.exs", """
+         10 + |signing_salt = "#{@signing_salt}"
+      """)
+      # add config for new endpoint
+      |> assert_has_patch("config/config.exs", """
+      10 12   |config :test,
+         13 + |       TestWeb.MySiteEndpoint,
+         14 + |       url: [host: "localhost"],
+         15 + |       adapter: Bandit.PhoenixAdapter,
+         16 + |       render_errors: [
+         17 + |         formats: [html: TestWeb.ErrorHTML, json: TestWeb.ErrorJSON],
+         18 + |         layout: false
+         19 + |       ],
+         20 + |       pubsub_server: Test.PubSub,
+         21 + |       live_view: [signing_salt: signing_salt]
+         22 + |
+      """)
+      # update signing salt for host app session_options
+      |> assert_has_patch("config/config.exs", """
+         31 + |    signing_salt: signing_salt,
+      """)
+      # update signing salt for existing endpoint
+      |> assert_has_patch("config/config.exs", """
+         44 + |  live_view: [signing_salt: signing_salt]
+      """)
+    end
+
+    test "updates dev.exs", %{project: project} do
+      project
+      |> Igniter.compose_task("beacon.gen.site", @opts_my_site)
+      |> assert_has_patch("config/dev.exs", """
+          2 + |secret_key_base = "#{@secret_key_base}"
+      """)
+      # add config for new endpoint
+      |> assert_has_patch("config/dev.exs", """
+          4 + |config :test,
+          5 + |       TestWeb.MySiteEndpoint,
+          6 + |       http: [ip: {127, 0, 0, 1}, port: 4041],
+          7 + |       check_origin: false,
+          8 + |       code_reloader: true,
+          9 + |       debug_errors: true,
+         10 + |       secret_key_base: secret_key_base,
+         11 + |       watchers: [
+         12 + |         esbuild: {Esbuild, :install_and_run, [:default, ~w(--sourcemap=inline --watch)]},
+         13 + |         tailwind: {Tailwind, :install_and_run, [:default, ~w(--watch)]}
+         14 + |       ]
+         15 + |
+      """)
+      # update secret key base for existing endpoint
+      |> assert_has_patch("config/dev.exs", """
+         36 + |  secret_key_base: secret_key_base,
+      """)
     end
 
     test "add site config in runtime", %{project: project} do
@@ -146,6 +220,40 @@ defmodule Mix.Tasks.Beacon.GenSiteTest do
           3 + |config :beacon,
           4 + |  my_site: [site: :my_site, repo: Test.Repo, endpoint: TestWeb.MySiteEndpoint, router: TestWeb.Router],
           5 + |  other: [site: :other, repo: Test.Repo, endpoint: TestWeb.OtherEndpoint, router: TestWeb.Router]
+      """)
+    end
+
+    test "configure check_origin for ProxyEndpoint in runtime", %{project: project} do
+      project
+      |> Igniter.compose_task("beacon.gen.site", @opts_my_site)
+      |> assert_has_patch("config/runtime.exs", """
+        48 + |    check_origin: {TestWeb.ProxyEndpoint, :check_origin, []},
+      """)
+    end
+
+    test "configure new endpoint in runtime", %{project: project} do
+      project
+      |> Igniter.compose_task("beacon.gen.site", @opts_my_site)
+      |> assert_has_patch("config/runtime.exs", """
+        54 + |config :test, TestWeb.MySiteEndpoint,
+        55 + |  url: [host: host, port: #{@secure_port}, scheme: "https"],
+        56 + |  http: [ip: {0, 0, 0, 0, 0, 0, 0, 0}, port: #{@port}],
+        57 + |  secret_key_base: secret_key_base,
+        58 + |  server: !!System.get_env("PHX_SERVER")
+        59 + |
+      """)
+    end
+
+    test "configure new endpoint (with --host) in runtime", %{project: project} do
+      project
+      |> Igniter.compose_task("beacon.gen.site", @opts_my_site ++ ~w(--host example.com))
+      |> assert_has_patch("config/runtime.exs", """
+        54 + |config :test, TestWeb.MySiteEndpoint,
+        55 + |  url: [host: "example.com", port: #{@secure_port}, scheme: "https"],
+        56 + |  http: [ip: {0, 0, 0, 0, 0, 0, 0, 0}, port: #{@port}],
+        57 + |  secret_key_base: secret_key_base,
+        58 + |  server: !!System.get_env("PHX_SERVER")
+        59 + |
       """)
     end
   end
@@ -179,6 +287,14 @@ defmodule Mix.Tasks.Beacon.GenSiteTest do
          14 + |      {Beacon, [sites: [Application.fetch_env!(:beacon, :my_site), Application.fetch_env!(:beacon, :other)]]},
       """)
     end
+
+    test "add new endpoint", %{project: project} do
+      project
+      |> Igniter.compose_task("beacon.gen.site", @opts_my_site)
+      |> assert_has_patch("lib/test/application.ex", """
+        22 + | TestWeb.MySiteEndpoint,
+      """)
+    end
   end
 
   describe "site endpoint" do
@@ -188,7 +304,7 @@ defmodule Mix.Tasks.Beacon.GenSiteTest do
 
     test "creates endpoint", %{project: project} do
       project
-      |> Igniter.compose_task("beacon.gen.site", @opts_host)
+      |> Igniter.compose_task("beacon.gen.site", @opts_my_site)
       |> assert_creates("lib/test_web/my_site_endpoint.ex", """
       defmodule TestWeb.MySiteEndpoint do
         use Phoenix.Endpoint, otp_app: :test
@@ -232,105 +348,6 @@ defmodule Mix.Tasks.Beacon.GenSiteTest do
         plug Plug.Session, @session_options
         plug TestWeb.Router
       end
-      """)
-    end
-
-    test "updates config.exs", %{project: project} do
-      project
-      |> Igniter.compose_task("beacon.gen.site", @opts_host)
-      |> assert_has_patch("config/config.exs", """
-         10 + |signing_salt = "#{@signing_salt}"
-      """)
-      # add config for new endpoint
-      |> assert_has_patch("config/config.exs", """
-      10 12   |config :test,
-         13 + |       TestWeb.MySiteEndpoint,
-         14 + |       url: [host: "localhost"],
-         15 + |       adapter: Bandit.PhoenixAdapter,
-         16 + |       render_errors: [
-         17 + |         formats: [html: Beacon.Web.ErrorHTML],
-         18 + |         layout: false
-         19 + |       ],
-         20 + |       pubsub_server: Test.PubSub,
-         21 + |       live_view: [signing_salt: signing_salt]
-         22 + |
-      """)
-      # update signing salt for host app session_options
-      |> assert_has_patch("config/config.exs", """
-         31 + |    signing_salt: signing_salt,
-      """)
-      # update signing salt for existing endpoint
-      |> assert_has_patch("config/config.exs", """
-         44 + |  live_view: [signing_salt: signing_salt]
-      """)
-    end
-
-    test "updates dev.exs", %{project: project} do
-      project
-      |> Igniter.compose_task("beacon.gen.site", @opts_host)
-      |> assert_has_patch("config/dev.exs", """
-          2 + |secret_key_base = "#{@secret_key_base}"
-      """)
-      # add config for new endpoint
-      |> assert_has_patch("config/dev.exs", """
-          4 + |config :test,
-          5 + |       TestWeb.MySiteEndpoint,
-          6 + |       http: [ip: {127, 0, 0, 1}, port: 4041],
-          7 + |       check_origin: false,
-          8 + |       code_reloader: true,
-          9 + |       debug_errors: true,
-         10 + |       secret_key_base: secret_key_base,
-         11 + |       watchers: [
-         12 + |         esbuild: {Esbuild, :install_and_run, [:default, ~w(--sourcemap=inline --watch)]},
-         13 + |         tailwind: {Tailwind, :install_and_run, [:default, ~w(--watch)]}
-         14 + |       ]
-         15 + |
-      """)
-      # update secret key base for existing endpoint
-      |> assert_has_patch("config/dev.exs", """
-         36 + |  secret_key_base: secret_key_base,
-      """)
-    end
-
-    test "updates runtime.exs", %{project: project} do
-      project
-      |> Igniter.compose_task("beacon.gen.site", @opts_host)
-      # add beacon site config
-      |> assert_has_patch("config/runtime.exs", """
-         2 + |config :beacon, my_site: [site: :my_site, repo: Test.Repo, endpoint: TestWeb.MySiteEndpoint, router: TestWeb.Router]
-      """)
-      # configure check_origin for ProxyEndpoint
-      |> assert_has_patch("config/runtime.exs", """
-        48 + |    check_origin: {TestWeb.ProxyEndpoint, :check_origin, []},
-      """)
-      # add config for new endpoint
-      |> assert_has_patch("config/runtime.exs", """
-        54 + |config :test, TestWeb.MySiteEndpoint,
-        55 + |  url: [host: "example.com", port: #{@secure_port}, scheme: "https"],
-        56 + |  http: [ip: {0, 0, 0, 0, 0, 0, 0, 0}, port: #{@port}],
-        57 + |  secret_key_base: secret_key_base,
-        58 + |  server: !!System.get_env("PHX_SERVER")
-        59 + |
-      """)
-    end
-
-    test "updates application.ex", %{project: project} do
-      project
-      |> Igniter.compose_task("beacon.gen.site", @opts_host)
-      |> assert_has_patch("lib/test/application.ex", """
-        22 + | TestWeb.MySiteEndpoint,
-      """)
-    end
-
-    test "updates router", %{project: project} do
-      project
-      |> Igniter.compose_task("beacon.gen.site", @opts_host)
-      |> assert_has_patch("lib/test_web/router.ex", """
-        23 + |  scope "/", alias: TestWeb, host: ["localhost", "example.com"] do
-        24 + |    pipe_through [:browser, :beacon]
-        25 + |    beacon_site "/", site: :my_site
-        26 + |  end
-        27 + |
       """)
     end
   end

--- a/test/mix/tasks/gen_site_test.exs
+++ b/test/mix/tasks/gen_site_test.exs
@@ -334,7 +334,4 @@ defmodule Mix.Tasks.Beacon.GenSiteTest do
       """)
     end
   end
-
-  test "new_endpoint_module!" do
-  end
 end

--- a/test/mix/tasks/gen_site_test.exs
+++ b/test/mix/tasks/gen_site_test.exs
@@ -248,7 +248,7 @@ defmodule Mix.Tasks.Beacon.GenSiteTest do
          14 + |       url: [host: "localhost"],
          15 + |       adapter: Bandit.PhoenixAdapter,
          16 + |       render_errors: [
-         17 + |         formats: [html: TestWeb.ErrorHTML, json: TestWeb.ErrorJSON],
+         17 + |         formats: [html: Beacon.Web.ErrorHTML],
          18 + |         layout: false
          19 + |       ],
          20 + |       pubsub_server: Test.PubSub,

--- a/test/mix/tasks/gen_site_test.exs
+++ b/test/mix/tasks/gen_site_test.exs
@@ -157,12 +157,11 @@ defmodule Mix.Tasks.Beacon.GenSiteTest do
          14 + |       url: [host: "localhost"],
          15 + |       adapter: Bandit.PhoenixAdapter,
          16 + |       render_errors: [
-         17 + |         formats: [html: TestWeb.ErrorHTML, json: TestWeb.ErrorJSON],
+         17 + |         formats: [html: Beacon.Web.ErrorHTML],
          18 + |         layout: false
          19 + |       ],
          20 + |       pubsub_server: Test.PubSub,
          21 + |       live_view: [signing_salt: signing_salt]
-         22 + |
       """)
       # update signing salt for host app session_options
       |> assert_has_patch("config/config.exs", """
@@ -288,11 +287,15 @@ defmodule Mix.Tasks.Beacon.GenSiteTest do
       """)
     end
 
-    test "add new endpoint", %{project: project} do
+    test "add new site endpoint after Beacon supervisor", %{project: project} do
       project
       |> Igniter.compose_task("beacon.gen.site", @opts_my_site)
       |> assert_has_patch("lib/test/application.ex", """
-        22 + | TestWeb.MySiteEndpoint,
+         14 + |      {Beacon, [sites: [Application.fetch_env!(:beacon, :my_site)]]},
+      14 15   |      {Phoenix.PubSub, name: Test.PubSub},
+      15 16   |      # Start the Finch HTTP client for sending emails
+      16 17   |      {Finch, name: Test.Finch},
+         18 + |      TestWeb.MySiteEndpoint,
       """)
     end
   end

--- a/test/mix/tasks/gen_tailwind_config_test.exs
+++ b/test/mix/tasks/gen_tailwind_config_test.exs
@@ -33,10 +33,16 @@ defmodule Mix.Tasks.Beacon.GenTailwindConfigTest do
   test "add endpoint watcher", %{project: project} do
     project
     |> Igniter.compose_task("beacon.install")
+    |> Igniter.compose_task("beacon.gen.site", @opts_my_site)
     |> apply_igniter!()
     |> Igniter.compose_task("beacon.gen.tailwind_config", @opts_my_site)
     |> assert_has_patch("config/dev.exs", """
-       20 + |    beacon_tailwind_config: {Esbuild, :install_and_run, [:beacon_tailwind_config, ~w(--watch)]}
+    11 11   |       watchers: [
+    12 12   |         esbuild: {Esbuild, :install_and_run, [:default, ~w(--sourcemap=inline --watch)]},
+    13    - |         tailwind: {Tailwind, :install_and_run, [:default, ~w(--watch)]}
+       13 + |         tailwind: {Tailwind, :install_and_run, [:default, ~w(--watch)]},
+       14 + |         beacon_tailwind_config: {Esbuild, :install_and_run, [:beacon_tailwind_config, ~w(--watch)]}
+    14 15   |       ]
     """)
   end
 
@@ -67,13 +73,13 @@ defmodule Mix.Tasks.Beacon.GenTailwindConfigTest do
     |> apply_igniter!()
     |> Igniter.compose_task("beacon.gen.tailwind_config", @opts_my_site)
     |> assert_has_patch("config/runtime.exs", """
-    2     - |config :beacon, my_site: [site: :my_site, repo: Test.Repo, endpoint: TestWeb.Endpoint, router: TestWeb.Router]
+    2     - |config :beacon, my_site: [site: :my_site, repo: Test.Repo, endpoint: TestWeb.MySiteEndpoint, router: TestWeb.Router]
     3   2   |
         3 + |config :beacon,
         4 + |  my_site: [
         5 + |    site: :my_site,
         6 + |    repo: Test.Repo,
-        7 + |    endpoint: TestWeb.Endpoint,
+        7 + |    endpoint: TestWeb.MySiteEndpoint,
         8 + |    router: TestWeb.Router,
         9 + |    tailwind_config: Path.join(Application.app_dir(:test, "priv"), "beacon.tailwind.config.bundle.js")
        10 + |  ]

--- a/test/support/endpoint.ex
+++ b/test/support/endpoint.ex
@@ -1,9 +1,0 @@
-defmodule Beacon.BeaconTest.Endpoint do
-  # The otp app needs to be beacon otherwise Phoenix LiveView will not be
-  # able to build the static path since it tries to get from `Application.app_dir`
-  # which expects that a real "application" is settled.
-  use Phoenix.Endpoint, otp_app: :beacon
-
-  plug Plug.Session, Application.compile_env!(:beacon, :session_options)
-  plug Beacon.BeaconTest.Router
-end

--- a/test/support/endpoint_b.ex
+++ b/test/support/endpoint_b.ex
@@ -1,9 +1,0 @@
-defmodule Beacon.BeaconTest.EndpointB do
-  # The otp app needs to be beacon otherwise Phoenix LiveView will not be
-  # able to build the static path since it tries to get from `Application.app_dir`
-  # which expects that a real "application" is settled.
-  use Phoenix.Endpoint, otp_app: :beacon
-
-  plug Plug.Session, Application.compile_env!(:beacon, :session_options)
-  plug Beacon.BeaconTest.Router
-end

--- a/test/support/endpoint_site.ex
+++ b/test/support/endpoint_site.ex
@@ -1,9 +1,0 @@
-defmodule Beacon.BeaconTest.EndpointSite do
-  # The otp app needs to be beacon otherwise Phoenix LiveView will not be
-  # able to build the static path since it tries to get from `Application.app_dir`
-  # which expects that a real "application" is settled.
-  use Phoenix.Endpoint, otp_app: :beacon
-
-  plug Plug.Session, Application.compile_env!(:beacon, :session_options)
-  plug Beacon.BeaconTest.Router
-end

--- a/test/support/endpoints.ex
+++ b/test/support/endpoints.ex
@@ -1,0 +1,30 @@
+defmodule Beacon.BeaconTest.ProxyEndpoint do
+  use Beacon.ProxyEndpoint,
+    otp_app: :beacon,
+    session_options: Application.compile_env!(:beacon, :session_options),
+    fallback: Beacon.BeaconTest.Endpoint
+end
+
+defmodule Beacon.BeaconTest.Endpoint do
+  # The otp app needs to be beacon otherwise Phoenix LiveView will not be
+  # able to build the static path since it tries to get from `Application.app_dir`
+  # which expects that a real "application" is settled.
+  use Phoenix.Endpoint, otp_app: :beacon
+
+  def proxy_endpoint, do: Beacon.BeaconTest.ProxyEndpoint
+
+  plug Plug.Session, Application.compile_env!(:beacon, :session_options)
+  plug Beacon.BeaconTest.Router
+end
+
+defmodule Beacon.BeaconTest.EndpointB do
+  # The otp app needs to be beacon otherwise Phoenix LiveView will not be
+  # able to build the static path since it tries to get from `Application.app_dir`
+  # which expects that a real "application" is settled.
+  use Phoenix.Endpoint, otp_app: :beacon
+
+  def proxy_endpoint, do: Beacon.BeaconTest.ProxyEndpoint
+
+  plug Plug.Session, Application.compile_env!(:beacon, :session_options)
+  plug Beacon.BeaconTest.Router
+end

--- a/test/support/proxy_endpoint.ex
+++ b/test/support/proxy_endpoint.ex
@@ -1,6 +1,0 @@
-defmodule Beacon.BeaconTest.ProxyEndpoint do
-  use Beacon.ProxyEndpoint,
-    otp_app: :beacon,
-    session_options: Application.compile_env!(:beacon, :session_options),
-    fallback: Beacon.BeaconTest.Endpoint
-end


### PR DESCRIPTION
- Isolate each site on its own endpoint to avoid conflicts with static paths and other configs
- Use the Proxy Endpoint to generate public URL for sites
- Fix the URL in robots.txt and sitemap.xml (should use the exposed public scheme/port)
- Fix to use Beacon ErrorHTML 
- Update generators to always create the site endpoint and use it in configs
- (Breaking) asset_url -> css_config_url (needs to change admin as well)