### PR TITLE
fix: remove :watcher from site endpoint

### DIFF
--- a/lib/mix/tasks/beacon.gen.site.ex
+++ b/lib/mix/tasks/beacon.gen.site.ex
@@ -411,11 +411,7 @@ if Code.ensure_loaded?(Igniter) do
                    check_origin: false,
                    code_reloader: true,
                    debug_errors: true,
-                   secret_key_base: secret_key_base,
-                   watchers: [
-                     esbuild: {Esbuild, :install_and_run, [:default, ~w(--sourcemap=inline --watch)]},
-                     tailwind: {Tailwind, :install_and_run, [:default, ~w(--watch)]}
-                   ]
+                   secret_key_base: secret_key_base
                  ]
                  """)
                )}

--- a/lib/mix/tasks/beacon.gen.tailwind_config.ex
+++ b/lib/mix/tasks/beacon.gen.tailwind_config.ex
@@ -108,7 +108,7 @@ if Code.ensure_loaded?(Igniter) do
         "dev.exs",
         app_name,
         [endpoint, :watchers],
-        [],
+        {:code, Sourceror.parse_string!("[beacon_tailwind_config: {Esbuild, :install_and_run, [:beacon_tailwind_config, ~w(--watch)]}]")},
         updater: fn zipper ->
           Igniter.Code.Keyword.put_in_keyword(
             zipper,

--- a/test/mix/tasks/gen_site_test.exs
+++ b/test/mix/tasks/gen_site_test.exs
@@ -194,16 +194,12 @@ defmodule Mix.Tasks.Beacon.GenSiteTest do
           7 + |       check_origin: false,
           8 + |       code_reloader: true,
           9 + |       debug_errors: true,
-         10 + |       secret_key_base: secret_key_base,
-         11 + |       watchers: [
-         12 + |         esbuild: {Esbuild, :install_and_run, [:default, ~w(--sourcemap=inline --watch)]},
-         13 + |         tailwind: {Tailwind, :install_and_run, [:default, ~w(--watch)]}
-         14 + |       ]
-         15 + |
+         10 + |       secret_key_base: secret_key_base
+         11 + |
       """)
       # update secret key base for existing endpoint
       |> assert_has_patch("config/dev.exs", """
-         36 + |  secret_key_base: secret_key_base,
+         32 + |  secret_key_base: secret_key_base,
       """)
     end
 

--- a/test/mix/tasks/gen_tailwind_config_test.exs
+++ b/test/mix/tasks/gen_tailwind_config_test.exs
@@ -37,12 +37,9 @@ defmodule Mix.Tasks.Beacon.GenTailwindConfigTest do
     |> apply_igniter!()
     |> Igniter.compose_task("beacon.gen.tailwind_config", @opts_my_site)
     |> assert_has_patch("config/dev.exs", """
-    11 11   |       watchers: [
-    12 12   |         esbuild: {Esbuild, :install_and_run, [:default, ~w(--sourcemap=inline --watch)]},
-    13    - |         tailwind: {Tailwind, :install_and_run, [:default, ~w(--watch)]}
-       13 + |         tailwind: {Tailwind, :install_and_run, [:default, ~w(--watch)]},
-       14 + |         beacon_tailwind_config: {Esbuild, :install_and_run, [:beacon_tailwind_config, ~w(--watch)]}
-    14 15   |       ]
+    10    - |       secret_key_base: secret_key_base
+       10 + |       secret_key_base: secret_key_base,
+       11 + |       watchers: [beacon_tailwind_config: {Esbuild, :install_and_run, [:beacon_tailwind_config, ~w(--watch)]}]
     """)
   end
 


### PR DESCRIPTION
esbuild config `:default` is no longer used and those watchers are not needed