### PR TITLE
fix(`beacon.gen.proxy_endpoint`): configure ProxyEndpoint `:pubsub_server`

### DIFF
--- a/lib/mix/tasks/beacon.gen.proxy_endpoint.ex
+++ b/lib/mix/tasks/beacon.gen.proxy_endpoint.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Beacon.Gen.ProxyEndpoint.Docs do
     ## Options
 
     * `--secret-key-base` (optional) - The value to use for secret_key_base in your app config.
-      By default, Beacon will generate a new value and update all existing config to match that value. 
+      By default, Beacon will generate a new value and update all existing config to match that value.
       If you don't want this behavior, copy the secret_key_base from your app config and provide it here.
     * `--signing-salt` (optional) - The value to use for signing_salt in your app config.
       By default, Beacon will generate a new value and update all existing config to match that value.
@@ -154,6 +154,8 @@ if Code.ensure_loaded?(Igniter) do
     end
 
     defp configure_proxy_endpoint(igniter, otp_app, proxy_endpoint_module_name) do
+      pubsub = Igniter.Project.Module.module_name(igniter, "PubSub")
+
       igniter
       |> Igniter.update_elixir_file("config/config.exs", fn zipper ->
         {:ok,
@@ -163,7 +165,11 @@ if Code.ensure_loaded?(Igniter) do
            [proxy_endpoint_module_name],
            otp_app,
            Sourceror.parse_string!("""
-           [adapter: Bandit.PhoenixAdapter, live_view: [signing_salt: signing_salt]]
+           [
+             adapter: Bandit.PhoenixAdapter,
+             pubsub_server: #{inspect(pubsub)},
+             live_view: [signing_salt: signing_salt]
+           ]
            """)
          )}
       end)

--- a/test/mix/tasks/gen_proxy_endpoint_test.exs
+++ b/test/mix/tasks/gen_proxy_endpoint_test.exs
@@ -72,25 +72,28 @@ defmodule Mix.Tasks.Beacon.GenProxyEndpointTest do
     """)
     # add proxy endpoint config
     |> assert_has_patch("config/config.exs", """
-       12 + |config :test, TestWeb.ProxyEndpoint, adapter: Bandit.PhoenixAdapter, live_view: [signing_salt: signing_salt]
-       13 + |
+    10 12   |config :test,
+       13 + |       TestWeb.ProxyEndpoint,
+       14 + |       adapter: Bandit.PhoenixAdapter,
+       15 + |       pubsub_server: Test.PubSub,
+       16 + |       live_view: [signing_salt: signing_salt]
     """)
     # add session options config
     |> assert_has_patch("config/config.exs", """
-    10 14   |config :test,
-    11 15   |  ecto_repos: [Test.Repo],
-    12    - |  generators: [timestamp_type: :utc_datetime]
-       16 + |  generators: [timestamp_type: :utc_datetime],
-       17 + |  session_options: [
-       18 + |    store: :cookie,
-       19 + |    key: "_test_key",
-       20 + |    signing_salt: signing_salt,
-       21 + |    same_site: "Lax"
-       22 + |  ]
+        18 + |config :test,
+     11 19   |  ecto_repos: [Test.Repo],
+     12    - |  generators: [timestamp_type: :utc_datetime]
+        20 + |  generators: [timestamp_type: :utc_datetime],
+        21 + |  session_options: [
+        22 + |    store: :cookie,
+        23 + |    key: "_test_key",
+        24 + |    signing_salt: signing_salt,
+        25 + |    same_site: "Lax"
+        26 + |  ]
     """)
     # update fallback endpoint signing salt
     |> assert_has_patch("config/config.exs", """
-       33 + |  live_view: [signing_salt: signing_salt]
+       37 + |  live_view: [signing_salt: signing_salt]
     """)
   end
 

--- a/test/mix/tasks/gen_site_test.exs
+++ b/test/mix/tasks/gen_site_test.exs
@@ -172,11 +172,11 @@ defmodule Mix.Tasks.Beacon.GenSiteTest do
       """)
       # update signing salt for host app session_options
       |> assert_has_patch("config/config.exs", """
-         31 + |    signing_salt: signing_salt,
+         35 + |    signing_salt: signing_salt,
       """)
       # update signing salt for existing endpoint
       |> assert_has_patch("config/config.exs", """
-         44 + |  live_view: [signing_salt: signing_salt]
+         48 + |  live_view: [signing_salt: signing_salt]
       """)
     end
 


### PR DESCRIPTION
Apps will crash on PubSub broadcast if this config value isn't set in the ProxyEndpoint