### PR TITLE
Don't run igniter tests on every push

### DIFF
--- a/test/mix/tasks/gen_proxy_endpoint_test.exs
+++ b/test/mix/tasks/gen_proxy_endpoint_test.exs
@@ -3,6 +3,8 @@ defmodule Mix.Tasks.Beacon.GenProxyEndpointTest do
 
   import Igniter.Test
 
+  @moduletag :igniter
+
   @signing_salt "SNUXnTNM"
   @secret_key_base "A0DSgxjGCYZ6fCIrBlg6L+qC/cdoFq5Rmomm53yacVmN95Wcpl57Gv0sTJjKjtIp"
 

--- a/test/mix/tasks/gen_site_test.exs
+++ b/test/mix/tasks/gen_site_test.exs
@@ -2,6 +2,8 @@ defmodule Mix.Tasks.Beacon.GenSiteTest do
   use Beacon.CodeGenCase
   import Igniter.Test
 
+  @moduletag :igniter
+
   @secret_key_base "A0DSgxjGCYZ6fCIrBlg6L+qC/cdoFq5Rmomm53yacVmN95Wcpl57Gv0sTJjKjtIo"
   @signing_salt "O68x1k5B"
   @port 4041

--- a/test/mix/tasks/gen_tailwind_config_test.exs
+++ b/test/mix/tasks/gen_tailwind_config_test.exs
@@ -2,6 +2,8 @@ defmodule Mix.Tasks.Beacon.GenTailwindConfigTest do
   use Beacon.CodeGenCase
   import Igniter.Test
 
+  @moduletag :igniter
+
   @opts_my_site ~w(--site my_site)
 
   setup do

--- a/test/mix/tasks/install_test.exs
+++ b/test/mix/tasks/install_test.exs
@@ -2,6 +2,8 @@ defmodule Mix.Tasks.Beacon.InstallTest do
   use Beacon.CodeGenCase
   import Igniter.Test
 
+  @moduletag :igniter
+
   setup do
     [project: phoenix_project()]
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -177,5 +177,5 @@ Enum.each(
   &Beacon.BeaconTest.Repo.delete_all/1
 )
 
-ExUnit.start(exclude: [:skip])
+ExUnit.start(exclude: [:skip, :igniter])
 Ecto.Adapters.SQL.Sandbox.mode(Beacon.BeaconTest.Repo, :manual)


### PR DESCRIPTION
These tests take a very long time to run

TODO: split the CI path to sometimes run `mix test --include igniter`