### PR TITLE
fix(beacon.gen.site): don't fail on pre-existing endpoint module or remove extra beacon runtime config

### DIFF
--- a/lib/mix/tasks/beacon.gen.site.ex
+++ b/lib/mix/tasks/beacon.gen.site.ex
@@ -386,7 +386,6 @@ if Code.ensure_loaded?(Igniter) do
         igniter,
         new_endpoint_module!(igniter, site),
         contents,
-        # maybe need to wrap contents?
         fn zipper -> {:ok, Igniter.Code.Common.replace_code(zipper, contents)} end
       )
     end

--- a/lib/mix/tasks/beacon.gen.site.ex
+++ b/lib/mix/tasks/beacon.gen.site.ex
@@ -287,16 +287,11 @@ if Code.ensure_loaded?(Igniter) do
     defp add_site_config_in_config_runtime(igniter, site, repo, router) do
       endpoint = new_endpoint_module!(igniter, site)
 
-      Igniter.Project.Config.configure(
-        igniter,
-        "runtime.exs",
-        :beacon,
-        [site],
-        {:code,
-         Sourceror.parse_string!("""
-         [site: :#{site}, repo: #{inspect(repo)}, endpoint: #{inspect(endpoint)}, router: #{inspect(router)}]
-         """)}
-      )
+      igniter
+      |> Igniter.Project.Config.configure("runtime.exs", :beacon, [site, :site], {:code, Sourceror.parse_string!(":#{site}")})
+      |> Igniter.Project.Config.configure("runtime.exs", :beacon, [site, :repo], {:code, Sourceror.parse_string!(inspect(repo))})
+      |> Igniter.Project.Config.configure("runtime.exs", :beacon, [site, :endpoint], {:code, Sourceror.parse_string!(inspect(endpoint))})
+      |> Igniter.Project.Config.configure("runtime.exs", :beacon, [site, :router], {:code, Sourceror.parse_string!(inspect(router))})
     end
 
     defp add_beacon_config_in_app_supervisor(igniter, site, repo) do
@@ -344,51 +339,55 @@ if Code.ensure_loaded?(Igniter) do
     defp create_new_endpoint(igniter, site, otp_app, web_module) do
       proxy_endpoint_module_name = Igniter.Libs.Phoenix.web_module_name(igniter, "ProxyEndpoint")
 
-      Igniter.Project.Module.create_module(
+      contents = """
+      use Phoenix.Endpoint, otp_app: #{inspect(otp_app)}
+
+      @session_options Application.compile_env!(#{inspect(otp_app)}, :session_options)
+
+      def proxy_endpoint, do: #{inspect(proxy_endpoint_module_name)}
+
+      # socket /live must be in the proxy endpoint
+
+      # Serve at "/" the static files from "priv/static" directory.
+      #
+      # You should set gzip to true if you are running phx.digest
+      # when deploying your static files in production.
+      plug Plug.Static,
+        at: "/",
+        from: #{inspect(otp_app)},
+        gzip: false,
+        # robots.txt is served by Beacon
+        only: ~w(assets fonts images favicon.ico)
+
+      # Code reloading can be explicitly enabled under the
+      # :code_reloader configuration of your endpoint.
+      if code_reloading? do
+        socket "/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket
+        plug Phoenix.LiveReloader
+        plug Phoenix.CodeReloader
+        plug Phoenix.Ecto.CheckRepoStatus, otp_app: #{inspect(otp_app)}
+      end
+
+      plug Plug.RequestId
+      plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
+
+      plug Plug.Parsers,
+        parsers: [:urlencoded, :multipart, :json],
+        pass: ["*/*"],
+        json_decoder: Phoenix.json_library()
+
+      plug Plug.MethodOverride
+      plug Plug.Head
+      plug Plug.Session, @session_options
+      plug #{inspect(web_module)}.Router
+      """
+
+      Igniter.Project.Module.find_and_update_or_create_module(
         igniter,
         new_endpoint_module!(igniter, site),
-        """
-        use Phoenix.Endpoint, otp_app: #{inspect(otp_app)}
-
-        @session_options Application.compile_env!(#{inspect(otp_app)}, :session_options)
-
-        def proxy_endpoint, do: #{inspect(proxy_endpoint_module_name)}
-
-        # socket /live must be in the proxy endpoint
-
-        # Serve at "/" the static files from "priv/static" directory.
-        #
-        # You should set gzip to true if you are running phx.digest
-        # when deploying your static files in production.
-        plug Plug.Static,
-          at: "/",
-          from: #{inspect(otp_app)},
-          gzip: false,
-          # robots.txt is served by Beacon
-          only: ~w(assets fonts images favicon.ico)
-
-        # Code reloading can be explicitly enabled under the
-        # :code_reloader configuration of your endpoint.
-        if code_reloading? do
-          socket "/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket
-          plug Phoenix.LiveReloader
-          plug Phoenix.CodeReloader
-          plug Phoenix.Ecto.CheckRepoStatus, otp_app: #{inspect(otp_app)}
-        end
-
-        plug Plug.RequestId
-        plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
-
-        plug Plug.Parsers,
-          parsers: [:urlencoded, :multipart, :json],
-          pass: ["*/*"],
-          json_decoder: Phoenix.json_library()
-
-        plug Plug.MethodOverride
-        plug Plug.Head
-        plug Plug.Session, @session_options
-        plug #{inspect(web_module)}.Router
-        """
+        contents,
+        # maybe need to wrap contents?
+        fn zipper -> {:ok, Igniter.Code.Common.replace_code(zipper, contents)} end
       )
     end
 


### PR DESCRIPTION
## Resolves #763 and #764 

* Now overwrites site endpoint if it already exists, instead of failing the task (#764)
* Don't remove extra Beacon.Config the user may have set for the site in `runtime.exs` (#763)