### PR TITLE
chore: improve media library API

### DIFF
--- a/lib/beacon/media_library/provider.ex
+++ b/lib/beacon/media_library/provider.ex
@@ -11,7 +11,7 @@ defmodule Beacon.MediaLibrary.Provider do
   available, and caching is used to reduce overload on the database. But you can switch to `S3`
   using the `Beacon.MediaLibrary.Provider.S3` provider or create your own provider.
 
-  See `Beacon.Config` for more info.
+  See `Beacon.Config` and each provider module doc for more info.
 
   """
 

--- a/lib/beacon/media_library/provider/s3.ex
+++ b/lib/beacon/media_library/provider/s3.ex
@@ -2,7 +2,16 @@ defmodule Beacon.MediaLibrary.Provider.S3 do
   @moduledoc """
   Store assets in S3 using the `ex_aws` library.
 
-  All files are stored in the same bucket under the same level.
+  All files are stored in the same bucket under the same level,
+  and the bucket name must be present in the `:ex_aws` config:
+
+      config :ex_aws, s3: [bucket: "my_bucket"]
+
+  And then in your site config, register this provider for each mime type you want to use it:
+
+      assets: [
+        {"image/*", [providers: [Beacon.MediaLibrary.Provider.S3]]}
+      ]
 
   """
 

--- a/test/beacon/media_library_test.exs
+++ b/test/beacon/media_library_test.exs
@@ -68,4 +68,34 @@ defmodule Beacon.MediaLibraryTest do
       assert MediaLibrary.count_assets(default_site(), query: "image_a") == 1
     end
   end
+
+  describe "url_for/1" do
+    setup do
+      metadata = beacon_upload_metadata_fixture(file_name: "image.png")
+      [asset: MediaLibrary.upload(metadata)]
+    end
+
+    test "returns url for the first registered provider", %{asset: asset} do
+      assert MediaLibrary.url_for(asset) == "http://site_a.com/__beacon_media__/image.webp"
+    end
+
+    test "returns nil if asset is invalid" do
+      refute MediaLibrary.url_for(:noop)
+    end
+  end
+
+  describe "url_for/2" do
+    setup do
+      metadata = beacon_upload_metadata_fixture(file_name: "image.png")
+      [asset: MediaLibrary.upload(metadata)]
+    end
+
+    test "returns url for registered providers", %{asset: asset} do
+      assert MediaLibrary.url_for(asset, "repo") == "http://site_a.com/__beacon_media__/image.webp"
+    end
+
+    test "returns nil if provider is not registered", %{asset: asset} do
+      refute MediaLibrary.url_for(asset, "noop")
+    end
+  end
 end


### PR DESCRIPTION
- avoid crashing on invalid providers
- remove `media_path/2` since not all providers can return a path
- rename media_url -> url_for_asset to use same pattern as `url_for/1`
- make `url_for_asset/2` use the asset provider instead of generating a local URL

Follow-up of https://github.com/BeaconCMS/beacon/pull/774