### PR TITLE
feat: introduce `url_host/2` and `:hosts` Beacon.Config

### DIFF
--- a/lib/beacon/proxy_endpoint.ex
+++ b/lib/beacon/proxy_endpoint.ex
@@ -144,6 +144,35 @@ defmodule Beacon.ProxyEndpoint do
     %URI{scheme: scheme, host: host, port: port}
   end
 
+  @doc """
+  Returns the `:host` configuration for `site` to be used in the app config.
+
+  ## Examples
+
+      iex> url_host(:my_site, "prod")
+      "mysite.com"
+
+      iex> url_host(:my_site, "local")
+      "local.mysite.com"
+
+  The host is fetched from the `:hosts` config in your site config,
+  see `Beacon.Config` for more info.
+
+  Defaults to `"localhost"` if no host is found.
+  """
+  @spec url_host(Beacon.Types.Site.t(), beacon_env :: String.t() | atom()) :: String.t()
+  def url_host(site, beacon_env)
+
+  def url_host(site, beacon_env) when is_atom(site) and is_binary(beacon_env) do
+    beacon_env = String.to_existing_atom(beacon_env)
+    url_host(site, beacon_env)
+  end
+
+  def url_host(site, beacon_env) when is_atom(site) and is_atom(beacon_env) do
+    hosts = Beacon.Config.fetch!(site).hosts
+    Keyword.get(hosts, beacon_env) || "localhost"
+  end
+
   # https://github.com/phoenixframework/phoenix/blob/2614f2a0d95a3b4b745bdf88ccd9f3b7f6d5966a/lib/phoenix/endpoint/supervisor.ex#L386
   @doc """
   Similar to `public_url/1` but returns a `%URI{}` instead.

--- a/test/beacon/proxy_endpoint_test.exs
+++ b/test/beacon/proxy_endpoint_test.exs
@@ -1,0 +1,16 @@
+defmodule Beacon.ProxyEndpointTest do
+  use ExUnit.Case, async: true
+  use Beacon.Test
+
+  alias Beacon.ProxyEndpoint
+
+  describe "url_host" do
+    test "defaults to localhost when no host is found" do
+      assert ProxyEndpoint.url_host(:my_site, nil) == "localhost"
+    end
+
+    test "resolves to existing host when defined" do
+      assert ProxyEndpoint.url_host(:host_test, :local) == "local.mysite.com"
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -41,7 +41,10 @@ Supervisor.start_link(
          mode: :testing,
          endpoint: Beacon.BeaconTest.EndpointB,
          router: Beacon.BeaconTest.Router,
-         repo: Beacon.BeaconTest.Repo
+         repo: Beacon.BeaconTest.Repo,
+         hosts: [
+           local: "local.mysite.com"
+         ]
        ],
        [
          site: :no_routes,


### PR DESCRIPTION
Used to define the `:hosts` endpoint config dynamically, so the same site can be served from multiple domains even if multiple sites are served in the same prefix.

More docs to be added along with adjustments to generators in a following PR.