### PR TITLE
add customizable asset delete callbacks

### DIFF
--- a/lib/beacon/lifecycle/asset.ex
+++ b/lib/beacon/lifecycle/asset.ex
@@ -4,6 +4,7 @@ defmodule Beacon.Lifecycle.Asset do
   alias Beacon.Lifecycle
   alias Beacon.MediaLibrary
   alias Beacon.MediaLibrary.Processors
+  alias Beacon.MediaLibrary.Provider
 
   @behaviour Beacon.Lifecycle
 
@@ -48,4 +49,16 @@ defmodule Beacon.Lifecycle.Asset do
   end
 
   def variant_480w(asset, _metadata), do: {:cont, asset}
+
+  def delete_uploaded_asset(%MediaLibrary.Asset{site: site, media_type: media_type} = asset) do
+    config =
+      site
+      |> Beacon.Config.fetch!()
+      |> Beacon.Config.config_for_media_type(media_type)
+      |> Enum.into(%{})
+
+    Provider.soft_delete(asset, config)
+
+    {:cont, asset}
+  end
 end

--- a/lib/beacon/media_library.ex
+++ b/lib/beacon/media_library.ex
@@ -369,18 +369,10 @@ defmodule Beacon.MediaLibrary do
       {:ok, %Asset{}}
 
   """
-  @spec soft_delete(Asset.t()) :: {:ok, Asset.t()} | :error
+  @spec soft_delete(Asset.t()) :: {:ok, Asset.t()}
   def soft_delete(%Asset{} = asset) do
-    update =
-      repo(asset).update_all(
-        from(asset in Asset, where: asset.id == ^asset.id),
-        set: [deleted_at: DateTime.utc_now()]
-      )
-
-    case update do
-      {1, _} -> {:ok, repo(asset).reload(asset)}
-      _ -> :error
-    end
+    Lifecycle.Asset.delete_uploaded_asset(asset)
+    {:ok, repo(asset).reload(asset)}
   end
 
   @doc """

--- a/lib/beacon/media_library/provider/repo.ex
+++ b/lib/beacon/media_library/provider/repo.ex
@@ -42,4 +42,9 @@ defmodule Beacon.MediaLibrary.Provider.Repo do
 
   @doc false
   def provider_key, do: @provider_key
+
+  @doc false
+  def soft_delete(_asset) do
+    # implement asset removal from Repo
+  end
 end

--- a/lib/beacon/media_library/provider/s3.ex
+++ b/lib/beacon/media_library/provider/s3.ex
@@ -80,4 +80,9 @@ defmodule Beacon.MediaLibrary.Provider.S3 do
 
   @doc false
   def provider_key, do: @provider_key
+
+  @doc false
+  def soft_delete(_asset) do
+    # implement asset removal from S3 bucket
+  end
 end


### PR DESCRIPTION
### **What will it allow you to do that you can't do today?**

It will allow users to customize a `soft_delete/1` callback that's used when `Beacon.MediaLibrary.soft_delete/1` gets called.

### **Why do you need this feature and how will it benefit other users?**

This feature is necessary to be able to programmatically delete stored assets where they are stored when utilizing custom provider modules for the media library's asset upload functionality.

@leandrocp I added this PR since [this one](https://github.com/BeaconCMS/beacon/pull/601) is being blocked from merging because it contains merge commits.