### PR TITLE
feat(visual editor): resolve on_mount assigns

### DIFF
--- a/lib/beacon/web/controllers/api/page_json.ex
+++ b/lib/beacon/web/controllers/api/page_json.ex
@@ -24,9 +24,11 @@ defmodule Beacon.Web.API.PageJSON do
     path_info = for segment <- String.split(page.path, "/"), segment != "", do: segment
     live_data = Beacon.Web.DataSource.live_data(page.site, path_info, %{})
     beacon_assigns = BeaconAssigns.new(page, path_info: path_info)
+    route_assigns = Beacon.Private.route_assigns(page.site, page.path)
 
     assigns =
-      live_data
+      route_assigns
+      |> Map.merge(live_data)
       |> Map.put(:beacon, beacon_assigns)
       # TODO: remove deprecated @beacon_live_data
       |> Map.put(:beacon_live_data, live_data)

--- a/lib/beacon/web/controllers/api/page_json.ex
+++ b/lib/beacon/web/controllers/api/page_json.ex
@@ -28,6 +28,7 @@ defmodule Beacon.Web.API.PageJSON do
 
     assigns =
       route_assigns
+      # live data should overwrite on_mount assigns in case of a name conflict
       |> Map.merge(live_data)
       |> Map.put(:beacon, beacon_assigns)
       # TODO: remove deprecated @beacon_live_data

--- a/test/beacon/private_test.exs
+++ b/test/beacon/private_test.exs
@@ -1,0 +1,16 @@
+defmodule Beacon.PrivateTest do
+  use Beacon.Web.ConnCase, async: true
+  use Beacon.Test, site: :my_site
+
+  setup do
+    beacon_page_fixture(path: "/on_mount")
+
+    :ok
+  end
+
+  test "router assigns" do
+    assert Beacon.Private.route_assigns(default_site(), "/on_mount") == %{
+             on_mount_var: "on_mount_test"
+           }
+  end
+end

--- a/test/beacon_web/live/page_live_test.exs
+++ b/test/beacon_web/live/page_live_test.exs
@@ -62,6 +62,9 @@ defmodule Beacon.Web.Live.PageLiveTest do
             <.sample_component project={project} />
           <% end %>
 
+          <h2>on_mount:</h2>
+          on_mount_var=<%= @on_mount_var %>
+
           <h2>Beacon:</h2>
           @beacon.site=<%= @beacon.site %>
           @beacon.path_params=<%= @beacon.path_params["greet"] %>
@@ -149,6 +152,12 @@ defmodule Beacon.Web.Live.PageLiveTest do
     assert html =~ ~r/@beacon.site=my_site/
     assert html =~ ~r/@beacon.path_params=hello/
     assert html =~ ~r/@beacon.query_params=param/
+  end
+
+  test "on_mount", %{conn: conn} do
+    {:ok, _view, html} = live(conn, "/home/hello")
+
+    assert html =~ ~r/on_mount_var=on_mount_test/
   end
 
   test "live data", %{conn: conn} do

--- a/test/support/routers.ex
+++ b/test/support/routers.ex
@@ -64,6 +64,14 @@ defmodule Beacon.BeaconTest.Router do
     pipe_through :browser
 
     beacon_site "/other", site: :not_booted
-    beacon_site "/", site: :my_site
+    beacon_site "/", site: :my_site, on_mount: [{Beacon.BeaconTest.OnMount, []}]
+  end
+end
+
+defmodule Beacon.BeaconTest.OnMount do
+  import Phoenix.Component
+
+  def on_mount(_scope, _params, _session, socket) do
+    {:cont, assign(socket, :on_mount_var, "on_mount_test")}
   end
 end


### PR DESCRIPTION
Assigns defined in `beacon_site` `:on_mount` should display their actual values in the Visual Editor.