### PR TITLE
Hardcode "inserted_at" & "updated_at" in Ecto migrations & schemas.

### DIFF
--- a/lib/beacon/migrations/v001.ex
+++ b/lib/beacon/migrations/v001.ex
@@ -17,7 +17,7 @@ defmodule Beacon.Migrations.V001 do
 
       add :deleted_at, :utc_datetime
 
-      timestamps(type: :utc_datetime_usec)
+      timestamps(inserted_at: :inserted_at, updated_at: :updated_at, type: :utc_datetime_usec)
     end
 
     create_if_not_exists index(:beacon_assets, [:source_id])
@@ -29,7 +29,7 @@ defmodule Beacon.Migrations.V001 do
       add :name, :text, null: false
       add :content, :text, null: false
 
-      timestamps(type: :utc_datetime_usec)
+      timestamps(inserted_at: :inserted_at, updated_at: :updated_at, type: :utc_datetime_usec)
     end
 
     create_if_not_exists table(:beacon_live_data, primary_key: false) do
@@ -37,7 +37,7 @@ defmodule Beacon.Migrations.V001 do
       add :site, :text, null: false
       add :path, :text, null: false
 
-      timestamps(type: :utc_datetime_usec)
+      timestamps(inserted_at: :inserted_at, updated_at: :updated_at, type: :utc_datetime_usec)
     end
 
     create_if_not_exists index(:beacon_live_data, [:site])
@@ -50,7 +50,7 @@ defmodule Beacon.Migrations.V001 do
 
       add :live_data_id, references(:beacon_live_data, on_delete: :delete_all, type: :binary_id), null: false
 
-      timestamps(type: :utc_datetime_usec)
+      timestamps(inserted_at: :inserted_at, updated_at: :updated_at, type: :utc_datetime_usec)
     end
 
     create_if_not_exists index(:beacon_live_data_assigns, [:live_data_id])
@@ -61,7 +61,7 @@ defmodule Beacon.Migrations.V001 do
       add :name, :text, null: false
       add :body, :text, null: false
 
-      timestamps(type: :utc_datetime_usec)
+      timestamps(inserted_at: :inserted_at, updated_at: :updated_at, type: :utc_datetime_usec)
     end
 
     create_if_not_exists unique_index(:beacon_snippet_helpers, [:site, :name])
@@ -77,13 +77,13 @@ defmodule Beacon.Migrations.V001 do
       add :example, :text, null: false
       add :category, :string, null: false, default: "element"
 
-      timestamps(type: :utc_datetime_usec)
+      timestamps(inserted_at: :inserted_at, updated_at: :updated_at, type: :utc_datetime_usec)
     end
 
     create_if_not_exists table(:beacon_component_attrs, primary_key: false) do
       add :id, :binary_id, primary_key: true
       add :component_id, references(:beacon_components, on_delete: :delete_all, type: :binary_id), null: false
-      timestamps(type: :utc_datetime_usec)
+      timestamps(inserted_at: :inserted_at, updated_at: :updated_at, type: :utc_datetime_usec)
     end
 
     alter table(:beacon_component_attrs, primary_key: false) do
@@ -100,13 +100,13 @@ defmodule Beacon.Migrations.V001 do
 
       add :component_id, references(:beacon_components, on_delete: :delete_all, type: :binary_id), null: false
 
-      timestamps(type: :utc_datetime_usec)
+      timestamps(inserted_at: :inserted_at, updated_at: :updated_at, type: :utc_datetime_usec)
     end
 
     create_if_not_exists table(:beacon_component_slot_attrs, primary_key: false) do
       add :id, :binary_id, primary_key: true
       add :slot_id, references(:beacon_component_slots, on_delete: :delete_all, type: :binary_id), null: false
-      timestamps(type: :utc_datetime_usec)
+      timestamps(inserted_at: :inserted_at, updated_at: :updated_at, type: :utc_datetime_usec)
     end
 
     alter table(:beacon_component_slot_attrs, primary_key: false) do
@@ -124,7 +124,7 @@ defmodule Beacon.Migrations.V001 do
       add :meta_tags, {:array, :map}, default: []
       add :resource_links, :map, default: %{}, null: false
 
-      timestamps(type: :utc_datetime_usec)
+      timestamps(inserted_at: :inserted_at, updated_at: :updated_at, type: :utc_datetime_usec)
     end
 
     create_if_not_exists table(:beacon_layout_events, primary_key: false) do
@@ -134,7 +134,7 @@ defmodule Beacon.Migrations.V001 do
 
       add :layout_id, references(:beacon_layouts, on_delete: :delete_all, type: :binary_id), null: false
 
-      timestamps(updated_at: false, type: :utc_datetime_usec)
+      timestamps(inserted_at: :inserted_at, updated_at: false, type: :utc_datetime_usec)
     end
 
     drop_if_exists constraint(:beacon_layout_events, :beacon_layout_events_check_event, check: "event = 'created' or event = 'published'")
@@ -149,7 +149,7 @@ defmodule Beacon.Migrations.V001 do
       add :layout_id, references(:beacon_layouts, on_delete: :delete_all, type: :binary_id), null: false
       add :event_id, references(:beacon_layout_events, on_delete: :delete_all, type: :binary_id)
 
-      timestamps(updated_at: false, type: :utc_datetime_usec)
+      timestamps(inserted_at: :inserted_at, updated_at: false, type: :utc_datetime_usec)
     end
 
     create_if_not_exists table(:beacon_pages, primary_key: false) do
@@ -168,7 +168,7 @@ defmodule Beacon.Migrations.V001 do
 
       add :layout_id, references(:beacon_layouts, type: :binary_id), null: false
 
-      timestamps(type: :utc_datetime_usec)
+      timestamps(inserted_at: :inserted_at, updated_at: :updated_at, type: :utc_datetime_usec)
     end
 
     create_if_not_exists unique_index(:beacon_pages, [:path, :site])
@@ -180,7 +180,7 @@ defmodule Beacon.Migrations.V001 do
 
       add :page_id, references(:beacon_pages, on_delete: :delete_all, type: :binary_id), null: false
 
-      timestamps(updated_at: false, type: :utc_datetime_usec)
+      timestamps(inserted_at: :inserted_at, updated_at: false, type: :utc_datetime_usec)
     end
 
     drop_if_exists constraint(:beacon_page_events, :beacon_page_events_check_event,
@@ -204,7 +204,7 @@ defmodule Beacon.Migrations.V001 do
       add :page_id, references(:beacon_pages, on_delete: :delete_all, type: :binary_id), null: false
       add :event_id, references(:beacon_page_events, on_delete: :delete_all, type: :binary_id)
 
-      timestamps(updated_at: false, type: :utc_datetime_usec)
+      timestamps(inserted_at: :inserted_at, updated_at: false, type: :utc_datetime_usec)
     end
 
     create_if_not_exists table(:beacon_page_variants, primary_key: false) do
@@ -215,7 +215,7 @@ defmodule Beacon.Migrations.V001 do
 
       add :page_id, references(:beacon_pages, on_delete: :delete_all, type: :binary_id), null: false
 
-      timestamps(type: :utc_datetime_usec)
+      timestamps(inserted_at: :inserted_at, updated_at: :updated_at, type: :utc_datetime_usec)
     end
 
     create_if_not_exists index(:beacon_page_variants, [:page_id])
@@ -227,7 +227,7 @@ defmodule Beacon.Migrations.V001 do
 
       add :page_id, references(:beacon_pages, on_delete: :delete_all, type: :binary_id), null: false
 
-      timestamps(type: :utc_datetime_usec)
+      timestamps(inserted_at: :inserted_at, updated_at: :updated_at, type: :utc_datetime_usec)
     end
 
     create_if_not_exists index(:beacon_page_event_handlers, [:page_id])
@@ -240,7 +240,7 @@ defmodule Beacon.Migrations.V001 do
 
       add :layout_id, references(:beacon_layouts, type: :binary_id)
 
-      timestamps(type: :utc_datetime_usec)
+      timestamps(inserted_at: :inserted_at, updated_at: :updated_at, type: :utc_datetime_usec)
     end
 
     create_if_not_exists unique_index(:beacon_error_pages, [:status, :site])

--- a/lib/beacon/migrations/v002.ex
+++ b/lib/beacon/migrations/v002.ex
@@ -11,7 +11,7 @@ defmodule Beacon.Migrations.V002 do
       add :code, :text, null: false
       add :site, :text, null: false
 
-      timestamps(type: :utc_datetime_usec)
+      timestamps(inserted_at: :inserted_at, updated_at: :updated_at, type: :utc_datetime_usec)
     end
 
     flush()
@@ -41,7 +41,7 @@ defmodule Beacon.Migrations.V002 do
       add :msg, :text, null: false
       add :code, :text, null: false
 
-      timestamps(type: :utc_datetime_usec)
+      timestamps(inserted_at: :inserted_at, updated_at: :updated_at, type: :utc_datetime_usec)
     end
   end
 
@@ -53,7 +53,7 @@ defmodule Beacon.Migrations.V002 do
 
       add :page_id, references(:beacon_pages, on_delete: :delete_all, type: :binary_id), null: false
 
-      timestamps(type: :utc_datetime_usec)
+      timestamps(inserted_at: :inserted_at, updated_at: :updated_at, type: :utc_datetime_usec)
     end
 
     # global event handlers can't be converted back into page event handlers

--- a/lib/beacon/migrations/v003.ex
+++ b/lib/beacon/migrations/v003.ex
@@ -9,7 +9,7 @@ defmodule Beacon.Migrations.V003 do
       add :name, :text, null: false
       add :code, :text, null: false
 
-      timestamps(type: :utc_datetime_usec)
+      timestamps(inserted_at: :inserted_at, updated_at: :updated_at, type: :utc_datetime_usec)
     end
   end
 

--- a/lib/beacon/schema.ex
+++ b/lib/beacon/schema.ex
@@ -10,7 +10,7 @@ defmodule Beacon.Schema do
       alias Ecto.Changeset
       @primary_key {:id, :binary_id, autogenerate: true}
       @foreign_key_type :binary_id
-      @timestamps_opts type: :utc_datetime_usec
+      @timestamps_opts [inserted_at: :inserted_at, updated_at: :updated_at, type: :utc_datetime_usec]
     end
   end
 


### PR DESCRIPTION
Resolves issue #776

Hardcode the "inserted_at" and "updated_at" names for timestamps options in Ecto migrations and schemas. As Beacon is configured to use a host application's Ecto Repo, querying for those columns by their default names may fail if the host application defines custom column names (e.g. "created_at" in place of "inserted_at").
