### PR TITLE
Fix:#821 Supports private phoenix_live_view session as tuple and map

### DIFF
--- a/lib/beacon/plug.ex
+++ b/lib/beacon/plug.ex
@@ -38,11 +38,19 @@ defmodule Beacon.Plug do
   defp put_roll(conn) do
     path_list = conn.path_params["path"]
 
-    with %{private: %{phoenix_live_view: {_, _, %{extra: %{session: %{"beacon_site" => site}}}}}} <- conn,
+    with %{private: %{phoenix_live_view: {_, _, %{extra: %{session: site_session}}}}} <- conn,
+         site <- fetch_session_site(site_session),
          {_, _} <- Beacon.RouterServer.lookup_path(site, path_list, 1) do
       Plug.Conn.put_session(conn, "beacon_variant_roll", Enum.random(1..100))
     else
       _ -> conn
+    end
+  end
+
+  defp fetch_session_site(site_session) do
+    case site_session do
+      {Beacon.Router, :session, [site, _]} -> site
+      %{"beacon_site" => site} -> site
     end
   end
 end

--- a/lib/beacon/router.ex
+++ b/lib/beacon/router.ex
@@ -323,6 +323,9 @@ defmodule Beacon.Router do
       %{phoenix_live_view: {Beacon.Web.PageLive, _, _, %{extra: %{session: %{"beacon_site" => ^site}}}}} ->
         {:ok, {endpoint, host}}
 
+      %{phoenix_live_view: {Beacon.Web.PageLive, _, _, %{extra: %{session: {Beacon.Router, :session, [^site, _sess]}}}}} ->
+        {:ok, {endpoint, host}}
+
       _ ->
         {:error, {endpoint, host}}
     end

--- a/lib/beacon/web/controllers/error_html.ex
+++ b/lib/beacon/web/controllers/error_html.ex
@@ -8,7 +8,7 @@ defmodule Beacon.Web.ErrorHTML do
 
   @doc false
   def render(<<status_code::binary-size(3), _rest::binary>> = template, %{conn: conn}) do
-    {_, _, %{extra: %{session: %{"beacon_site" => site}}}} = conn.private.phoenix_live_view
+    site = conn.private.phoenix_live_view |> fetch_session_site()
     error_module = Beacon.Loader.fetch_error_page_module(site)
     conn = Plug.Conn.assign(conn, :beacon, Beacon.Web.BeaconAssigns.new(site))
     Beacon.apply_mfa(site, error_module, :render, [conn, String.to_integer(status_code)])
@@ -28,5 +28,12 @@ defmodule Beacon.Web.ErrorHTML do
   def render(template, _assigns) do
     Logger.warning("could not find an error page for #{template}, fallbacking to default Phoenix error page")
     Phoenix.Controller.status_message_from_template(template)
+  end
+
+  defp fetch_session_site({_, _, %{extra: %{session: site_session}}}) do
+    case site_session do
+      %{"beacon_site" => site} -> site
+      {Beacon.Router, :session, [site, _]} -> site
+    end
   end
 end

--- a/lib/beacon/web/controllers/error_html.ex
+++ b/lib/beacon/web/controllers/error_html.ex
@@ -30,6 +30,11 @@ defmodule Beacon.Web.ErrorHTML do
     Phoenix.Controller.status_message_from_template(template)
   end
 
+  defp fetch_session_site(%{params: %{"site" => site}})
+    when is_binary(site) and byte_size(site) > 0 do
+    String.to_atom(site)
+  end
+
   defp fetch_session_site(%{
     private: %{
       phoenix_live_view: {_, _, %{extra: %{session: site_session}}}

--- a/lib/beacon/web/controllers/error_html.ex
+++ b/lib/beacon/web/controllers/error_html.ex
@@ -30,11 +30,6 @@ defmodule Beacon.Web.ErrorHTML do
     Phoenix.Controller.status_message_from_template(template)
   end
 
-  defp fetch_session_site(%{params: %{"site" => site}})
-    when is_binary(site) and byte_size(site) > 0 do
-    String.to_atom(site)
-  end
-
   defp fetch_session_site(%{
     private: %{
       phoenix_live_view: {_, _, %{extra: %{session: site_session}}}

--- a/lib/beacon/web/controllers/error_html.ex
+++ b/lib/beacon/web/controllers/error_html.ex
@@ -30,7 +30,9 @@ defmodule Beacon.Web.ErrorHTML do
     Phoenix.Controller.status_message_from_template(template)
   end
 
-  # To be able to render error templates beacon_live_admin when a site exists in the params
+  # To be able to render error templates beacon_live_admin
+  # Only works when editing existin sites. Going to admin will fallback
+  # to phoenix error
   defp fetch_session_site(%{params: %{"site" => site}})
     when is_binary(site) and byte_size(site) > 0 do
     String.to_atom(site)

--- a/lib/beacon/web/controllers/error_html.ex
+++ b/lib/beacon/web/controllers/error_html.ex
@@ -30,7 +30,6 @@ defmodule Beacon.Web.ErrorHTML do
     Phoenix.Controller.status_message_from_template(template)
   end
 
-  # handles erors from beacon_live_admin endpoints
   defp fetch_session_site(%{params: %{"site" => site}})
     when is_binary(site) and byte_size(site) > 0 do
     String.to_atom(site)

--- a/lib/beacon/web/controllers/error_html.ex
+++ b/lib/beacon/web/controllers/error_html.ex
@@ -32,7 +32,7 @@ defmodule Beacon.Web.ErrorHTML do
 
   # To be able to render error templates beacon_live_admin
   # Only works when editing existin sites. Going to admin will fallback
-  # to phoenix error
+  # to phoenix error. Any suggestions on how to handle this, will be nice.
   defp fetch_session_site(%{params: %{"site" => site}})
     when is_binary(site) and byte_size(site) > 0 do
     String.to_atom(site)

--- a/lib/beacon/web/controllers/error_html.ex
+++ b/lib/beacon/web/controllers/error_html.ex
@@ -30,6 +30,7 @@ defmodule Beacon.Web.ErrorHTML do
     Phoenix.Controller.status_message_from_template(template)
   end
 
+  # To be able to render error templates beacon_live_admin when a site exists in the params
   defp fetch_session_site(%{params: %{"site" => site}})
     when is_binary(site) and byte_size(site) > 0 do
     String.to_atom(site)

--- a/test/beacon/router_test.exs
+++ b/test/beacon/router_test.exs
@@ -67,6 +67,15 @@ defmodule Beacon.RouterTest do
       )
     end
 
+    test "phoenix live_view site map" do
+      config2 = Map.merge(
+        Beacon.Config.fetch!(:my_site),
+        %{host: "host_test", prefix: "/", router: Beacon.BeaconTest.Router}
+      )
+
+      assert Router.reachable?(config2, host: "host.com", prefix: "/host_test")
+    end
+
     test "match existing host" do
       config = config(:host_test)
       assert Router.reachable?(config, host: "host.com", prefix: "/host_test")

--- a/test/beacon_web/controllers/error_html_test.exs
+++ b/test/beacon_web/controllers/error_html_test.exs
@@ -1,15 +1,41 @@
 defmodule Beacon.Web.ErrorHTMLTest do
-  use ExUnit.Case, async: true
+  use Beacon.Web.ConnCase, async: false
+  use Beacon.Test, site: :my_site
 
   alias Beacon.Web.ErrorHTML
 
-  @tag capture_log: true
-  test "invalid status code" do
-    assert ErrorHTML.render("invalid", %{conn: nil}) == "Internal Server Error"
+  describe "render/2 unit test" do
+    @tag capture_log: true
+    test "invalid status code" do
+      assert ErrorHTML.render("invalid", %{conn: nil}) == "Internal Server Error"
+    end
+
+    @tag capture_log: true
+    test "invalid conn" do
+      assert ErrorHTML.render("404.html", %{conn: nil}) == "Not Found"
+    end
   end
 
-  @tag capture_log: true
-  test "invalid conn" do
-    assert ErrorHTML.render("404.html", %{conn: nil}) == "Not Found"
+  describe "render/2 integration with dynamic error pages" do
+    setup %{conn: conn} do
+      beacon_error_page_fixture(
+        status: 404,
+        template: "My Site Not Found Page"
+      )
+
+      conn =
+        conn
+        |> Plug.Conn.assign(:beacon, %{site: :my_site})
+        |> Plug.Conn.put_private(:phoenix_router, Beacon.BeaconTest.Router)
+
+      {:ok, conn: conn}
+    end
+
+    test "missing path", %{conn: conn} do
+      {404, _headers, body} =
+        assert_error_sent(404, fn -> get(conn, "/missing_path") end)
+
+      assert body =~ "My Site Not Found Page"
+    end
   end
 end


### PR DESCRIPTION
This is a proposal solution for https://github.com/BeaconCMS/beacon/issues/821

What Is aw in my dev environment is that `conn.private.phoenix_live_view` extra session value is set as 3 items tuple, instead of a map, as expected. Not sure if this changed some where in the past and is actually expected.
I can't figure it out clearly what was going on, and why the session is expected as a map, every test I did, returned as a tuple, not sure if this was a change on LiveView itself, I didn't research much from that side.

Hopefully you have time to review this and clarify if needed (I am using this branch for my working site as I need this custom error pages to work), If there is an alternative, I will appreciate it