### PR TITLE
fix: handle non-ASCII characters in page paths for Tailwind compilation

### DIFF
--- a/lib/beacon/tailwind_compiler.ex
+++ b/lib/beacon/tailwind_compiler.ex
@@ -257,7 +257,15 @@ defmodule Beacon.RuntimeCSS.TailwindCompiler do
     input_css_path
   end
 
-  defp remove_special_chars(name), do: String.replace(name, ~r/[^[:alnum:]_]+/, "_")
+  # The Tailwind CLI binary cannot handle UTF-8 filenames, so we hash
+  # any paths containing non-ASCII characters (Arabic, Chinese, etc.)
+  defp remove_special_chars(name) do
+    if String.match?(name, ~r/[^\x00-\x7F]/) do
+      "_hash_#{:erlang.phash2(name)}"
+    else
+      String.replace(name, ~r/[^a-zA-Z0-9_]+/, "_")
+    end
+  end
 
   # include paths for the following scenarios:
   # - regular app


### PR DESCRIPTION
## Problem

The `remove_special_chars/1` function in `TailwindCompiler` uses `[^[:alnum:]_]` regex which allows Unicode letters (Arabic, Chinese, etc.) through. The Tailwind CLI binary cannot handle UTF-8 filenames, causing ENOENT errors during boot when pages have non-Latin paths.

**Error example:**
```
Error: ENOENT: no such file or directory, open '/tmp/.../abc_page__blog_�_�_ت�_�_�_�_.template'
```

## Solution

Hash non-ASCII paths using `:erlang.phash2/1` to create safe ASCII-only filenames, while preserving the existing behavior for ASCII-only paths.

**Before:**
```elixir
defp remove_special_chars(name), do: String.replace(name, ~r/[^[:alnum:]_]+/, "_")
```

**After:**
```elixir
defp remove_special_chars(name) do
  if String.match?(name, ~r/[^\x00-\x7F]/) do
    "_hash_#{:erlang.phash2(name)}"
  else
    String.replace(name, ~r/[^a-zA-Z0-9_]+/, "_")
  end
end
```

## Testing

- Tested with Arabic page paths (e.g., `/مدونة`)
- Fixes boot crash on Fly.io deployment