### PR TITLE
Support gettext ~> 1.0 for Phoenix 1.8 compatibility

### DIFF
--- a/lib/beacon/private.ex
+++ b/lib/beacon/private.ex
@@ -52,18 +52,9 @@ defmodule Beacon.Private do
     Phoenix.LiveView.Route.live_link_info_without_checks(endpoint, router, url)
   end
 
-  def endpoint_config(otp_app, endpoint) do
-    Phoenix.Endpoint.Supervisor.config(otp_app, endpoint)
+  def endpoint_host(_otp_app, endpoint) do
+    endpoint.host()
   end
-
-  def endpoint_host(otp_app, endpoint) do
-    url_config = endpoint_config(otp_app, endpoint)[:url]
-    host_to_binary(url_config[:host] || "localhost")
-  end
-
-  # https://github.com/phoenixframework/phoenix/blob/4ebefb9d1f710c576f08c517f5852498dd9b935c/lib/phoenix/endpoint/supervisor.ex#L301-L302
-  defp host_to_binary({:system, env_var}), do: host_to_binary(System.get_env(env_var))
-  defp host_to_binary(host), do: host
 
   def router(%{private: %{phoenix_router: router}}), do: router
 

--- a/mix.exs
+++ b/mix.exs
@@ -69,7 +69,7 @@ defmodule Beacon.MixProject do
       {:ex_aws, "~> 2.4.0"},
       {:ex_aws_s3, "~> 2.4.0"},
       {:floki, ">= 0.30.0"},
-      {:gettext, "~> 0.26"},
+      {:gettext, "~> 0.26 or ~> 1.0"},
       {:hackney, "~> 1.16"},
       {:image, "~> 0.40"},
       {:vix, "<= 0.30.0 or >= 0.31.1"},


### PR DESCRIPTION
Make Beacon installable and functional on Phoenix 1.8.

  ### Changes

  **Widen gettext dependency** (`mix.exs`)

  `~> 0.26` → `~> 0.26 or ~> 1.0`

  Phoenix 1.8 ships with `{:gettext, "~> 1.0"}`, causing a Hex resolution failure. The codebase already uses the gettext 1.0-compatible API (`Gettext.Backend`, `backend:` option, direct `Gettext.dgettext/4` calls), so only
  the version constraint needed updating.

  **Replace removed private API** (`lib/beacon/private.ex`)

  `Phoenix.Endpoint.Supervisor.config/2` was removed in Phoenix 1.8, breaking `Beacon.Private.endpoint_host/2` at runtime:

   > (UndefinedFunctionError) function Phoenix.Endpoint.Supervisor.config/2 is undefined or private

  Replaced with `endpoint.host/0`, which is the public callback available on all Phoenix endpoints.

  Closes #859