### PR TITLE
fix: add unique constraint on component name per site

### DIFF
--- a/lib/beacon/content/component.ex
+++ b/lib/beacon/content/component.ex
@@ -47,6 +47,7 @@ defmodule Beacon.Content.Component do
     |> validate_required([:site, :name, :template, :example, :category])
     |> validate_format(:name, ~r/^[a-z0-9_!]+$/, message: "can only contain lowercase letters, numbers, and underscores")
     |> validate_exclusion(:name, reserved_names)
+    |> unique_constraint([:site, :name])
     |> validate_unique_attr_name(attrs)
     |> cast_assoc(:attrs, with: &ComponentAttr.changeset/2)
     |> cast_assoc(:slots, with: &ComponentSlot.changeset/2)

--- a/lib/beacon/migration.ex
+++ b/lib/beacon/migration.ex
@@ -52,7 +52,7 @@ defmodule Beacon.Migration do
   """
 
   @initial_version 1
-  @current_version 6
+  @current_version 7
 
   @doc """
   Upgrades Beacon database schemas.

--- a/lib/beacon/migrations/v007.ex
+++ b/lib/beacon/migrations/v007.ex
@@ -1,0 +1,12 @@
+defmodule Beacon.Migrations.V007 do
+  @moduledoc false
+  use Ecto.Migration
+
+  def up do
+    create_if_not_exists unique_index(:beacon_components, [:site, :name])
+  end
+
+  def down do
+    drop_if_exists unique_index(:beacon_components, [:site, :name])
+  end
+end


### PR DESCRIPTION
## Summary

Adds a unique constraint on `[:site, :name]` for components to prevent duplicate component names within a site. Duplicate names cause compilation issues since function overloading is not supported.

## Changes

- `lib/beacon/content/component.ex`: Added `unique_constraint([:site, :name])` to the changeset pipeline
- `lib/beacon/migrations/v007.ex`: New migration creating the unique index on `beacon_components` table
- `lib/beacon/migration.ex`: Bumped `@current_version` from 6 to 7

Follows the same pattern as existing unique constraints on pages (`:path, :site`) and error pages (`:status, :site`).

Fixes #650

This contribution was developed with AI assistance (Claude Code).